### PR TITLE
docs: rework README into a landing page; split details into docs/

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "A native Zellij sidebar that shows live AI-agent status (working/waiting/done) per tab."
-repository = "https://github.com/mark-toda/zj-radar"
+repository = "https://github.com/marktoda/zj-radar"
 readme = "README.md"
 
 # Zellij loads plugins as WASI *command* modules (it calls `_start` then `load`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,26 @@
 # zj-radar
 
+<p align="center">
+  <a href="https://github.com/marktoda/zj-radar/actions/workflows/ci.yml">
+    <img alt="CI" src="https://img.shields.io/github/actions/workflow/status/marktoda/zj-radar/ci.yml?branch=main&label=ci">
+  </a>
+  <a href="LICENSE">
+    <img alt="License" src="https://img.shields.io/github/license/marktoda/zj-radar">
+  </a>
+  <img alt="Zellij plugin" src="https://img.shields.io/badge/zellij-plugin-8A2BE2">
+  <img alt="Claude Code" src="https://img.shields.io/badge/Claude%20Code-supported-orange">
+  <img alt="Codex" src="https://img.shields.io/badge/Codex-supported-black">
+  <img alt="Status" src="https://img.shields.io/badge/status-alpha-yellow">
+</p>
+
+<p align="center">
+  <a href="#quick-start">Quick start</a> ·
+  <a href="#how-it-works">How it works</a> ·
+  <a href="#how-is-this-different">How is this different?</a> ·
+  <a href="#configuration">Configuration</a> ·
+  <a href="docs/producers.md">Producers</a>
+</p>
+
 A native [Zellij](https://zellij.dev) **sidebar** that shows live AI-agent
 status for every tab — *working*, *waiting for you*, *done*, or *error* — with
 repo·branch, elapsed time, and the last message. Click a row to jump to that
@@ -13,411 +34,135 @@ tab.
 
 ![zj-radar — live per-tab agent and command status in a Zellij sidebar](docs/media/hero.gif)
 
-## Why it exists
+## What is it?
 
 Agents like Claude Code spend long stretches working, then quietly block on a
 permission prompt or finish. In a many-tab Zellij session it's easy to lose
 track of which agent needs you. zj-radar surfaces that at a glance, in a pinned
-left column that survives swap-layout cycling.
+left column that survives swap-layout cycling — without launching, owning, or
+wrapping your agents. It's a status rail for the session you already run.
 
-It is **push-driven, not poll-driven**: status arrives via an explicit
+## Highlights
+
+- See which Claude Code / Codex tabs are **working, done, errored, or waiting for you**.
+- **Jump directly** to the tab that needs attention (`attention-next` keybind).
+- Keep your existing Zellij workflow — **no new terminal, no tmux wrapper, no agent orchestrator**.
+- **Push-driven** updates via `zellij pipe`; no pane polling, no blocking host queries.
+- Works with **Claude Code** today, **Codex** via the native CLI, and any
+  [custom producer](docs/producers.md#writing-your-own-producer) that can send JSON.
+
+## Quick start
+
+```sh
+# 1. Build the sidebar wasm + install the CLI
+git clone https://github.com/marktoda/zj-radar
+cd zj-radar
+cargo build --release --target wasm32-wasip1
+cargo install --path . --features cli
+
+# 2. Install the wasm + register the `radar` alias in config.kdl
+zj-radar setup zellij --wasm target/wasm32-wasip1/release/zj_radar.wasm
+
+# 3. Add the sidebar to a layout (prints a snippet to paste), then start Zellij
+```
+
+Then add a **producer** so the rail has something to show — for Claude Code:
+
+```sh
+/plugin marketplace add marktoda/zj-radar
+/plugin install zj-radar-claude@zj-radar
+```
+
+Full details, manual setup, layout templates, and Nix/home-manager are in
+**[`docs/install.md`](docs/install.md)**. Codex and custom producers are in
+**[`docs/producers.md`](docs/producers.md)**.
+
+## How it works
+
+zj-radar is **push-driven, not poll-driven**: status arrives via an explicit
 `zellij pipe` broadcast from per-agent hooks. The plugin never issues blocking
 host queries (`get_pane_running_command`, etc.). This is a deliberate, hard
 constraint — the predecessor plugin (`smart-tabs`) melted a many-agent session
 by polling every pane on every output event; see
 [`docs/smart-tabs-postmortem.md`](docs/smart-tabs-postmortem.md).
 
-## Repo layout
+The wire format is a single versioned JSON payload (`zj_radar.status.v1`), so a
+"producer" is anything that can broadcast it — the bundled Claude Code plugin,
+the `zj-radar notify` CLI for Codex, or your own script. The sidebar pins itself
+into your tab templates (the same mechanism Zellij's own status bar uses), so it
+appears in every tab and survives swap-layout cycling.
 
-| Path | What it is |
-|------|------------|
-| `src/` | The Zellij sidebar plugin (Rust → `wasm32-wasip1`). Thin Zellij adapter, pure runtime, stores, model, and renderer. |
-| `plugins/zj-radar-claude/` | A **Claude Code plugin** that broadcasts agent status via hooks — no `settings.json` editing. |
-| `docs/` | Design, plan, and postmortem docs. `design.md` is the canonical living design. |
-| `dev/dev.kdl` | A dev layout for dogfooding the debug plugin while building. |
+## How is this different?
 
-There are two independent install surfaces: the **sidebar** (the wasm plugin you
-add to your Zellij layout) and the **producer** (whatever broadcasts status —
-today, the Claude Code plugin).
+| Tool | Best for | How `zj-radar` differs |
+|---|---|---|
+| [Claude Squad](https://github.com/smtg-ai/claude-squad) | Running multiple agents in isolated git worktrees from one TUI. | `zj-radar` does not launch or own agents; it shows status inside the Zellij session you already use. |
+| cmux | A macOS terminal with vertical tabs, notifications, browser panes, and agent-aware UI. | `zj-radar` is a Zellij plugin, not a new terminal app. |
+| [zjstatus](https://github.com/dj95/zjstatus) | Replacing / customizing the Zellij status bar. | `zj-radar` is an agent-status rail; it leaves your existing status bar alone. |
+| Plain Zellij tabs | Manual multiplexing. | `zj-radar` adds agent state, elapsed time, messages, and jump-to-attention behavior. |
 
-## Install
-
-There are two jobs:
-
-1. **Show the sidebar in Zellij** — install the wasm at a stable path, define a
-   `radar` plugin alias in `config.kdl`, and add the sidebar templates to a
-   layout.
-2. **Send agent status to the sidebar** — install the Claude plugin or wire an
-   agent to call `zj-radar notify`.
-
-### 1. Show the sidebar in Zellij
-
-There is no pre-built release yet, so build the wasm from source:
-
-```sh
-# Needs the wasm32-wasip1 target; rust-toolchain.toml requests it (rustup auto-installs it). See docs/TOOLCHAIN.md.
-cargo build --release --target wasm32-wasip1
-```
-
-#### Recommended: use the CLI
-
-Install the native CLI from this checkout, then let it copy the wasm and manage
-the Zellij plugin alias:
-
-```sh
-cargo install --path . --features cli
-zj-radar setup zellij --wasm target/wasm32-wasip1/release/zj_radar.wasm
-```
-
-`setup zellij`:
-
-- copies the wasm to `~/.config/zellij/plugins/zj_radar.wasm`
-- adds or updates a managed `radar` alias in `~/.config/zellij/config.kdl`
-- prints the layout snippet to paste
-
-It does **not** rewrite your layouts. Use `--dry-run` to preview, `--yes` for
-non-interactive runs, and `--force` only if you want to replace an existing
-unmanaged `radar` alias.
-
-#### Manual setup
-
-If you are not using the CLI, copy the wasm to the same stable path yourself:
-
-```sh
-mkdir -p ~/.config/zellij/plugins
-cp target/wasm32-wasip1/release/zj_radar.wasm ~/.config/zellij/plugins/
-```
-
-Then define the alias once in `~/.config/zellij/config.kdl`:
-
-```kdl
-// ~/.config/zellij/config.kdl
-plugins {
-    radar location="file:~/.config/zellij/plugins/zj_radar.wasm" {
-        naming "managed"
-    }
-}
-```
-
-The fixed path matters: Zellij ties a plugin's permission grant to its location.
-If the location changes on every rebuild, Zellij asks again.
-
-#### Add the sidebar to a layout
-
-The sidebar is a pinned, borderless **left column** that lives in every tab.
-Zellij has no "pin a pane across all tabs" mechanism other than the tab
-templates — the same place its own tab-bar/status-bar live — so radar integrates
-like [zjstatus](https://github.com/dj95/zjstatus): add one pane to your
-templates, and keep the rest of your layout yours.
-
-Paste [`examples/radar-template-snippet.kdl`](examples/radar-template-snippet.kdl)
-into any layout:
-
-```kdl
-// Tabs defined in the layout file get their panes via `children`.
-default_tab_template {
-    pane split_direction="vertical" {
-        pane size=32 borderless=true { plugin location="radar" }   // ← alias
-        children
-    }
-    pane size=2 borderless=true { plugin location="zellij:status-bar" }
-}
-
-// Tabs created at runtime (Ctrl+t n) get a CONCRETE focused pane, not `children`.
-new_tab_template {
-    pane split_direction="vertical" {
-        pane size=32 borderless=true { plugin location="radar" }
-        pane focus=true
-    }
-    pane size=2 borderless=true { plugin location="zellij:status-bar" }
-}
-```
-
-> **Why two templates?** When you don't supply a `new_tab_template`, Zellij
-> *derives* one from `default_tab_template` — and that derivation **drops a
-> `children` placeholder nested inside a split** (upstream
-> [zellij-org/zellij#3247](https://github.com/zellij-org/zellij/issues/3247),
-> still open). New tabs then contain only the borderless sidebar + status-bar —
-> no focusable pane — so keystrokes have nowhere to land and you "can't open a
-> new tab." Declaring `new_tab_template` explicitly with a concrete
-> `pane focus=true` (instead of `children`) sidesteps the derivation. A
-> *top-level* `children`, like the stock compact layout, materializes fine —
-> only the nested-in-a-split case is affected.
-
-Prefer a complete starting layout? Copy
-[`examples/radar-sidebar.kdl`](examples/radar-sidebar.kdl) to
-`~/.config/zellij/layouts/` and run `zellij --layout radar-sidebar`. It uses the
-same `plugin location="radar"` alias as the snippet.
-
-Want the column on the **right**? Put `children` (and the runtime
-`pane focus=true`) before the radar pane in each vertical split. Different
-width? Change `size`.
-
-On first load the sidebar shows an onboarding face and requests three
-permissions (`ReadApplicationState`, `ReadCliPipes`, `ChangeApplicationState`) —
-press `y` to grant. Because the sidebar exists once per tab, only one instance
-owns the first-run prompt when session files are writable; the others wait for
-Zellij's cached answer and then continue without asking again. Session files use
-Zellij's shared plugin cache when available and fall back to `/tmp/zj-radar`; if
-neither is writable, the sidebar still runs, but late-spawned sidebars may start
-empty until the next broadcast and first-run prompt coordination may be noisier.
-The sidebar stays focusable only for that prompt, then goes back to passive
-sidebar behavior. It never runs commands; notifications stay in the producer.
-
-For a roomier first-run prompt, approve the same stable plugin URL once in a
-floating pane before using the sidebar layout:
-
-```sh
-zellij plugin --floating --width 80 --height 24 file:~/.config/zellij/plugins/zj_radar.wasm
-```
-
-After approval, close that floating pane and start your radar layout; the per-tab
-sidebars should use the cached grant.
-
-#### Loading straight from a release URL (caveat)
-
-Zellij can also load a plugin directly from an `https://` URL, downloading and
-caching it (no manual `cp`) — once a release is tagged:
-
-```kdl
-plugin location="https://github.com/mark-toda/zj-radar/releases/download/v0.1.0/zj_radar.wasm"
-```
-
-**Not recommended as the default for zj-radar**, though: the sidebar loads once
-*per tab* (it lives in `default_tab_template`), and Zellij has a known bug where
-several tabs fetching the same remote plugin at once can corrupt the download.
-Prefer the `file:` path above or the Nix package below; use the URL form only
-for a quick single-tab try.
-
-#### Nix / home-manager
-
-This flake exposes the wasm as `packages.default`, so a flake-based config can
-consume the exact same artifact this repo builds. Add the repo as an input:
-
-```nix
-# flake.nix
-inputs.zj-radar.url = "github:mark-toda/zj-radar";
-```
-
-Then reference the built wasm from your generated `config.kdl` alias:
-
-```kdl
-plugins {
-    radar location="file:${inputs.zj-radar.packages.${system}.default}/bin/zj_radar.wasm" {
-        naming "managed"
-    }
-}
-```
-
-Tagged releases also publish a prebuilt wasm artifact that can be pinned without
-a Rust toolchain (mirrors the older `room`/`smart-tabs` vendoring this replaces):
-
-```nix
-zjRadarWasm = pkgs.fetchurl {
-  url = "https://github.com/mark-toda/zj-radar/releases/download/v0.1.0/zj_radar.wasm";
-  hash = "sha256-..."; # nix-prefetch-url the asset to fill this in
-};
-```
-
-The old `@smartTabs@` substitution is fully retired — zj-radar owns the rail.
-
-### 2. Send agent status to the sidebar
-
-#### Claude Code
-
-Installing this plugin auto-registers the status hooks — **no `settings.json`
-editing**, clean uninstall.
-
-```sh
-/plugin marketplace add mark-toda/zj-radar
-/plugin install zj-radar-claude@zj-radar
-```
-
-Requires `jq` and `git` on `PATH` (used to parse the hook payload and derive
-repo/branch). See [`plugins/zj-radar-claude/README.md`](plugins/zj-radar-claude/README.md)
-for details. It's a no-op outside Zellij, so it's safe to leave enabled
-everywhere.
-
-#### Codex and the native CLI
-
-A native binary that drops the `jq`/`bash` dependency and wires non-plugin agents.
-
-> **Before the first tagged release**, the prebuilt tarballs and the
-> `#zj-radar-cli` Nix output aren't published yet — use the `cargo install --git`
-> form below (or build from source). The release workflow produces all three on
-> the first `v*` tag.
-
-```sh
-# Release tarballs (published on tagged releases):
-#   zj-radar-linux-x86_64.tar.gz
-#   zj-radar-macos-aarch64.tar.gz
-# Nix:
-nix build github:mark-toda/zj-radar#zj-radar-cli   # -> result/bin/zj-radar
-# Cargo:
-cargo install --git https://github.com/mark-toda/zj-radar --features cli
-```
-
-- **`zj-radar notify <claude|codex>`** — broadcasts agent status. The Claude
-  plugin's hook script automatically prefers it when it's on `PATH` (jq-free);
-  otherwise the plugin falls back to its bundled `bash`+`jq` script.
-- **`zj-radar setup [codex]`** — idempotently wires Codex's
-  `~/.codex/hooks.json` to call `zj-radar notify codex`. This preserves any
-  existing Codex `notify` program (e.g. a Computer Use notifier), because hooks
-  are additive. Use `--dry-run` to preview, `--uninstall` to remove only
-  zj-radar's hooks, and `--check` to diagnose the current setup. After installing
-  or changing hooks, run `/hooks` inside Codex once to review and trust the
-  command hook. (Claude needs no `setup` — use the plugin in §2.)
-- **`zj-radar setup codex --legacy-notify`** — opt-in fallback for older Codex
-  setups that only support the single `notify` program. It refuses to replace a
-  foreign notifier unless `--force` is also passed.
-- **`zj-radar setup zellij --wasm <path>`** — copies the sidebar wasm to
-  `~/.config/zellij/plugins/zj_radar.wasm`, manages the `radar` alias in
-  `config.kdl`, and prints the layout snippet. It leaves layouts user-owned.
-
-Codex hooks report turn start, tool use, permission requests, subagents, and
-turn stop. zj-radar maps those to `running`, `pending`, and `done`.
+The short version: **inside your existing Zellij, push-driven, not an
+orchestrator, not a new terminal.**
 
 ## Configuration
 
-With the recommended alias setup, defaults live in
-`~/.config/zellij/config.kdl`:
+With the recommended alias setup, defaults live in `~/.config/zellij/config.kdl`:
 
 ```kdl
 plugins {
     radar location="file:~/.config/zellij/plugins/zj_radar.wasm" {
-        density "comfortable"
-        naming "off"
+        density "comfortable"   // cards · comfortable · compact
+        naming "off"            // off · managed · force
     }
 }
 ```
 
-Layouts should continue to reference `plugin location="radar"`. Unknown keys are
-ignored and invalid values fall back to the default (parsing never fails):
-
-| Key | Values | Default | Effect |
-|-----|--------|---------|--------|
-| `density` | `cards` · `comfortable` · `compact` | `cards` | Card surface bands / blank separators / flush rail. |
-| `naming` | `off` · `managed` · `force` | `managed` | Auto-rename tabs from agent repo / pane title. `managed` only touches default or self-applied names; `force` overrides manual names. |
-| `header` | `true` · `false` | `true` | Show the ` RADAR` identity header + tab count. |
-| `glyphs` | `plain` · `nerd` | `plain` | Status glyph set (`nerd` needs a Nerd Font). |
-
-These can also be changed **at runtime** without editing the layout, by
-broadcasting a flat JSON object on the `zj_radar.config.v1` pipe:
+Options can also be changed **at runtime** — no layout edit — by broadcasting a
+flat JSON object on a pipe:
 
 ```sh
 zellij pipe --name zj_radar.config.v1 -- '{"density":"compact","header":false}'
 ```
 
-### Binding keys to runtime config
+The full option table, keybindings for runtime config, and `attention-next` /
+`attention-prev` command bindings are in
+**[`docs/configuration.md`](docs/configuration.md)**.
 
-The same payload can be driven from a keybind — no shell, no `zellij pipe`
-subprocess. Zellij's `MessagePlugin` action delivers a named pipe message
-straight to the plugin's `pipe()` entrypoint, exactly like the broadcast above.
-Add bindings to `~/.config/zellij/config.kdl`:
+## Producers
 
-```kdl
-keybinds {
-    shared_except "locked" {
-        // Flush/compact rail
-        bind "Alt Shift c" {
-            MessagePlugin "radar" {
-                name "zj_radar.config.v1"
-                payload "{\"density\":\"compact\"}"
-            }
-        }
-        // Roomy cards
-        bind "Alt Shift v" {
-            MessagePlugin "radar" {
-                name "zj_radar.config.v1"
-                payload "{\"density\":\"cards\"}"
-            }
-        }
-        // Hide the identity header
-        bind "Alt Shift h" {
-            MessagePlugin "radar" {
-                name "zj_radar.config.v1"
-                payload "{\"header\":false}"
-            }
-        }
-    }
-}
-```
+A producer broadcasts agent status to the sidebar. zj-radar ships two and
+documents the wire format so you can write your own:
 
-Notes:
+- **Claude Code** — a Claude plugin that auto-registers status hooks (no
+  `settings.json` editing).
+- **Codex / native CLI** — `zj-radar notify` + `zj-radar setup codex`.
+- **Custom** — broadcast a `zj_radar.status.v1` JSON payload from anything.
 
-- `"radar"` is the same plugin alias your layout uses (`plugin location="radar"`).
-  If you have no alias, use the full URL instead, e.g.
-  `MessagePlugin "https://github.com/.../zj_radar.wasm" { … }`.
-- `MessagePlugin` broadcasts to **every** running radar instance (the sidebar is
-  one instance per tab), so the whole session re-renders at once — which is what
-  you want for a config change. If no instance is running it launches a headless
-  one to receive the message, which is harmless.
-- The `config.v1` pipe only **sets** a value; it can't *toggle* one (the payload
-  is stateless). So bind one key per discrete value, as above. A future
-  imperative command pipe could add `toggle`/`cycle` verbs.
+See **[`docs/producers.md`](docs/producers.md)** for install steps, the payload
+schema, and a copy-paste smoke test.
 
-### Binding keys to commands
+## Documentation
 
-`config.v1` only *sets* state. For *imperative* actions — like jumping to the
-next agent that needs you — the plugin also accepts `zj_radar.cmd.v1`, whose
-payload is a single bare verb string:
+| Doc | What's in it |
+|-----|--------------|
+| [`docs/install.md`](docs/install.md) | Full sidebar install: CLI + manual setup, layout templates, permissions, remote-URL caveat, Nix / home-manager. |
+| [`docs/producers.md`](docs/producers.md) | Claude Code, Codex, and writing your own producer (payload schema + smoke test). |
+| [`docs/configuration.md`](docs/configuration.md) | Density/naming/header/glyphs, runtime config, and keybindings. |
+| [`docs/troubleshooting.md`](docs/troubleshooting.md) | The two-template rule, first-run prompt coordination, and reload quirks. |
+| [`docs/design.md`](docs/design.md) | The canonical living design. |
+| [`docs/smart-tabs-postmortem.md`](docs/smart-tabs-postmortem.md) | Why the polling predecessor was scrapped (the push-driven origin story). |
 
-```kdl
-keybinds {
-    shared_except "locked" {
-        // Cycle focus to the next tab needing attention (pending / error / done)
-        bind "Alt n" {
-            MessagePlugin "radar" { name "zj_radar.cmd.v1"; payload "attention-next"; }
-        }
-        bind "Alt p" {
-            MessagePlugin "radar" { name "zj_radar.cmd.v1"; payload "attention-prev"; }
-        }
-    }
-}
-```
+## Status & roadmap
 
-`attention-next` / `attention-prev` walk the tabs whose agents are *waiting for
-you*, *errored*, or *done* — in tab order, wrapping around — and switch focus to
-each. Tabs that are merely *running* or *idle* are skipped. Repeated presses
-sweep every attention tab and cycle. Like every command pipe, an unknown verb is
-ignored, and the action is inert until the sidebar has been granted permissions.
+- ✅ **Sidebar plugin** — tab list, click-to-switch, per-tab agent aggregation,
+  overflow folding, theme-derived card surfaces, runtime config.
+- ✅ **Claude Code producer** — ships as a Claude plugin (`plugins/zj-radar-claude`).
+- ✅ **`zj-radar` CLI** — native, jq-free `notify` (Claude + Codex) and
+  conflict-aware `setup`; see [`docs/producers.md`](docs/producers.md#codex-and-the-native-cli).
+- 📋 **Not yet built** — cross-platform prebuilt release binaries and a
+  fully automatic layout patcher. See [`docs/distribution.md`](docs/distribution.md).
 
-## Writing your own producer
-
-The plugin's only real interface is the versioned pipe payload. Broadcast (by
-name, never `--plugin`) a `zj_radar.status.v1` message:
-
-```json
-{ "v": 1,
-  "source": "claude",
-  "pane": { "type": "terminal", "id": 12 },
-  "status": "running",
-  "repo": "pinky",
-  "branch": "fix/x",
-  "msg": "running tests…",
-  "on_focus": "idle",
-  "seq": 42 }
-```
-
-- `status`: `running` → working · `pending` → needs-you · `done` · `error` ·
-  `idle`/unknown → plain.
-- `pane.id`: strip any `terminal_` prefix from `$ZELLIJ_PANE_ID`.
-- `on_focus` (optional): the status to apply when you next focus that exact pane
-  (lets `done` persist on other tabs, then auto-clear).
-- `seq` (optional): monotonic per-pane counter; a `seq` ≤ the stored one is
-  dropped (hook-race guard).
-
-The plugin defends itself: it ignores oversized payloads, strips ANSI/control
-chars, folds newlines to spaces, and truncates. Adapters can stay simple.
-
-Quick smoke test (a "fake agent" — broadcast straight from your shell):
-
-```sh
-zellij pipe --name zj_radar.status.v1 -- \
-  '{"v":1,"source":"test","pane":{"type":"terminal","id":12},"status":"running","repo":"demo","branch":"main","msg":"hello"}'
-```
-
-## Develop
+## Development
 
 ```sh
 cargo test                                # host tests, no wasm needed
@@ -432,26 +177,24 @@ use `./dev/run.sh --fresh-session` when you explicitly want to switch the
 current client to a fresh disposable dev session. If the current Rust toolchain
 is missing `wasm32-wasip1`, the script uses the repo's Nix flake automatically.
 
-Zellij 0.44's plugin reload actions can open an extra tiled plugin pane when the
-target plugin was created by a layout and has made itself non-selectable (as the
-radar sidebar does after permissions). The default inside-Zellij dev loop avoids
-both in-place plugin reloads and session switching.
+The hero GIF is reproducible — its VHS tape and recording script live in
+[`demo/`](demo/) (`demo/record.sh`).
+
+### Repo layout
+
+| Path | What it is |
+|------|------------|
+| `src/` | The Zellij sidebar plugin (Rust → `wasm32-wasip1`). Thin Zellij adapter, pure runtime, stores, model, and renderer. |
+| `plugins/zj-radar-claude/` | A **Claude Code plugin** that broadcasts agent status via hooks — no `settings.json` editing. |
+| `docs/` | Design, plan, and postmortem docs. `design.md` is the canonical living design. |
+| `demo/` | The reproducible VHS tape + script behind the hero GIF. |
+| `dev/dev.kdl` | A dev layout for dogfooding the debug plugin while building. |
 
 The host-testable modules (`status`, `payload`, `radar_state`, `rollup`, `render`,
-`tab_namer`, `command`, `config`, `theme`, `session_files`) carry no `zellij-tile` dependency
-and are covered on the host target. Only `lib.rs`/`main.rs` touch the Zellij host
-API and are gated behind `#[cfg(target_arch = "wasm32")]`. See
+`tab_namer`, `command`, `config`, `theme`, `session_files`) carry no `zellij-tile`
+dependency and are covered on the host target. Only `lib.rs`/`main.rs` touch the
+Zellij host API and are gated behind `#[cfg(target_arch = "wasm32")]`. See
 [`docs/TOOLCHAIN.md`](docs/TOOLCHAIN.md).
-
-## Status & roadmap
-
-- ✅ **Sidebar plugin** — tab list, click-to-switch, per-tab agent aggregation,
-  overflow folding, theme-derived card surfaces, runtime config.
-- ✅ **Claude Code producer** — ships as a Claude plugin (`plugins/zj-radar-claude`).
-- ✅ **`zj-radar` CLI** — native, jq-free `notify` (Claude + Codex) and
-  conflict-aware `setup`; see [Codex and the native CLI](#codex-and-the-native-cli).
-- 📋 **Not yet built** — cross-platform prebuilt release binaries and a
-  fully automatic layout patcher. See [`docs/distribution.md`](docs/distribution.md).
 
 ## Contributing
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,111 @@
+# Configuration
+
+zj-radar reads its options from the plugin alias and accepts live updates over a
+pipe. For a minimal example, see [Configuration in the README](../README.md#configuration).
+
+## Options
+
+With the recommended alias setup, defaults live in
+`~/.config/zellij/config.kdl`:
+
+```kdl
+plugins {
+    radar location="file:~/.config/zellij/plugins/zj_radar.wasm" {
+        density "comfortable"
+        naming "off"
+    }
+}
+```
+
+Layouts should continue to reference `plugin location="radar"`. Unknown keys are
+ignored and invalid values fall back to the default (parsing never fails):
+
+| Key | Values | Default | Effect |
+|-----|--------|---------|--------|
+| `density` | `cards` · `comfortable` · `compact` | `cards` | Card surface bands / blank separators / flush rail. |
+| `naming` | `off` · `managed` · `force` | `managed` | Auto-rename tabs from agent repo / pane title. `managed` only touches default or self-applied names; `force` overrides manual names. |
+| `header` | `true` · `false` | `true` | Show the ` RADAR` identity header + tab count. |
+| `glyphs` | `plain` · `nerd` | `plain` | Status glyph set (`nerd` needs a Nerd Font). |
+
+## Runtime config
+
+These can also be changed **at runtime** without editing the layout, by
+broadcasting a flat JSON object on the `zj_radar.config.v1` pipe:
+
+```sh
+zellij pipe --name zj_radar.config.v1 -- '{"density":"compact","header":false}'
+```
+
+## Binding keys to runtime config
+
+The same payload can be driven from a keybind — no shell, no `zellij pipe`
+subprocess. Zellij's `MessagePlugin` action delivers a named pipe message
+straight to the plugin's `pipe()` entrypoint, exactly like the broadcast above.
+Add bindings to `~/.config/zellij/config.kdl`:
+
+```kdl
+keybinds {
+    shared_except "locked" {
+        // Flush/compact rail
+        bind "Alt Shift c" {
+            MessagePlugin "radar" {
+                name "zj_radar.config.v1"
+                payload "{\"density\":\"compact\"}"
+            }
+        }
+        // Roomy cards
+        bind "Alt Shift v" {
+            MessagePlugin "radar" {
+                name "zj_radar.config.v1"
+                payload "{\"density\":\"cards\"}"
+            }
+        }
+        // Hide the identity header
+        bind "Alt Shift h" {
+            MessagePlugin "radar" {
+                name "zj_radar.config.v1"
+                payload "{\"header\":false}"
+            }
+        }
+    }
+}
+```
+
+Notes:
+
+- `"radar"` is the same plugin alias your layout uses (`plugin location="radar"`).
+  If you have no alias, use the full URL instead, e.g.
+  `MessagePlugin "https://github.com/.../zj_radar.wasm" { … }`.
+- `MessagePlugin` broadcasts to **every** running radar instance (the sidebar is
+  one instance per tab), so the whole session re-renders at once — which is what
+  you want for a config change. If no instance is running it launches a headless
+  one to receive the message, which is harmless.
+- The `config.v1` pipe only **sets** a value; it can't *toggle* one (the payload
+  is stateless). So bind one key per discrete value, as above. A future
+  imperative command pipe could add `toggle`/`cycle` verbs.
+
+## Binding keys to commands
+
+`config.v1` only *sets* state. For *imperative* actions — like jumping to the
+next agent that needs you — the plugin also accepts `zj_radar.cmd.v1`, whose
+payload is a single bare verb string:
+
+```kdl
+keybinds {
+    shared_except "locked" {
+        // Cycle focus to the next tab needing attention (pending / error / done)
+        bind "Alt n" {
+            MessagePlugin "radar" { name "zj_radar.cmd.v1"; payload "attention-next"; }
+        }
+        bind "Alt p" {
+            MessagePlugin "radar" { name "zj_radar.cmd.v1"; payload "attention-prev"; }
+        }
+    }
+}
+```
+
+`attention-next` / `attention-prev` walk the tabs whose agents are *waiting for
+you*, *errored*, or *done* — in tab order, wrapping around — and switch focus to
+each. Tabs that are merely *running* or *idle* are skipped. Repeated presses
+sweep every attention tab and cycle. Like every command pipe, an unknown verb is
+ignored, and the action is inert until the sidebar has been granted permissions.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,180 @@
+# Installing the sidebar
+
+This is the full install reference for the **sidebar** — the wasm plugin you add
+to your Zellij layout. For the **producer** (whatever broadcasts agent status),
+see [`producers.md`](producers.md). For a copy-paste fast path, see
+[Quick start](../README.md#quick-start).
+
+There are two jobs to get a working radar:
+
+1. **Show the sidebar in Zellij** — install the wasm at a stable path, define a
+   `radar` plugin alias in `config.kdl`, and add the sidebar templates to a
+   layout. *(This page.)*
+2. **Send agent status to the sidebar** — install the Claude plugin or wire an
+   agent to call `zj-radar notify`. *(See [`producers.md`](producers.md).)*
+
+## Build the wasm from source
+
+There is no pre-built release yet, so build the wasm from source:
+
+```sh
+git clone https://github.com/marktoda/zj-radar
+cd zj-radar
+
+# Needs the wasm32-wasip1 target; rust-toolchain.toml requests it (rustup
+# auto-installs it). See docs/TOOLCHAIN.md.
+cargo build --release --target wasm32-wasip1
+```
+
+## Recommended: use the CLI
+
+Install the native CLI from this checkout, then let it copy the wasm and manage
+the Zellij plugin alias:
+
+```sh
+cargo install --path . --features cli
+zj-radar setup zellij --wasm target/wasm32-wasip1/release/zj_radar.wasm
+```
+
+`setup zellij`:
+
+- copies the wasm to `~/.config/zellij/plugins/zj_radar.wasm`
+- adds or updates a managed `radar` alias in `~/.config/zellij/config.kdl`
+- prints the layout snippet to paste
+
+It does **not** rewrite your layouts. Use `--dry-run` to preview, `--yes` for
+non-interactive runs, and `--force` only if you want to replace an existing
+unmanaged `radar` alias.
+
+## Manual setup
+
+If you are not using the CLI, copy the wasm to the same stable path yourself:
+
+```sh
+mkdir -p ~/.config/zellij/plugins
+cp target/wasm32-wasip1/release/zj_radar.wasm ~/.config/zellij/plugins/
+```
+
+Then define the alias once in `~/.config/zellij/config.kdl`:
+
+```kdl
+// ~/.config/zellij/config.kdl
+plugins {
+    radar location="file:~/.config/zellij/plugins/zj_radar.wasm" {
+        naming "managed"
+    }
+}
+```
+
+The fixed path matters: Zellij ties a plugin's permission grant to its location.
+If the location changes on every rebuild, Zellij asks again.
+
+## Add the sidebar to a layout
+
+The sidebar is a pinned, borderless **left column** that lives in every tab.
+Zellij has no "pin a pane across all tabs" mechanism other than the tab
+templates — the same place its own tab-bar/status-bar live — so radar integrates
+like [zjstatus](https://github.com/dj95/zjstatus): add one pane to your
+templates, and keep the rest of your layout yours.
+
+Paste [`examples/radar-template-snippet.kdl`](../examples/radar-template-snippet.kdl)
+into any layout:
+
+```kdl
+// Tabs defined in the layout file get their panes via `children`.
+default_tab_template {
+    pane split_direction="vertical" {
+        pane size=32 borderless=true { plugin location="radar" }   // ← alias
+        children
+    }
+    pane size=2 borderless=true { plugin location="zellij:status-bar" }
+}
+
+// Tabs created at runtime (Ctrl+t n) get a CONCRETE focused pane, not `children`.
+new_tab_template {
+    pane split_direction="vertical" {
+        pane size=32 borderless=true { plugin location="radar" }
+        pane focus=true
+    }
+    pane size=2 borderless=true { plugin location="zellij:status-bar" }
+}
+```
+
+Why two templates? It works around an upstream Zellij derivation bug — see
+[Can't open a new tab](troubleshooting.md#cant-open-a-new-tab-the-two-template-rule).
+
+Prefer a complete starting layout? Copy
+[`examples/radar-sidebar.kdl`](../examples/radar-sidebar.kdl) to
+`~/.config/zellij/layouts/` and run `zellij --layout radar-sidebar`. It uses the
+same `plugin location="radar"` alias as the snippet.
+
+Want the column on the **right**? Put `children` (and the runtime
+`pane focus=true`) before the radar pane in each vertical split. Different
+width? Change `size`.
+
+## First-run permission prompt
+
+On first load the sidebar shows an onboarding face and requests three
+permissions (`ReadApplicationState`, `ReadCliPipes`, `ChangeApplicationState`) —
+press `y` to grant. The sidebar stays focusable only for that prompt, then goes
+back to passive sidebar behavior. It never runs commands; notifications stay in
+the producer.
+
+For a roomier first-run prompt, approve the same stable plugin URL once in a
+floating pane before using the sidebar layout:
+
+```sh
+zellij plugin --floating --width 80 --height 24 file:~/.config/zellij/plugins/zj_radar.wasm
+```
+
+After approval, close that floating pane and start your radar layout; the per-tab
+sidebars should use the cached grant. For how the per-tab instances coordinate
+that single prompt (and what happens when session files aren't writable), see
+[First-run prompt coordination](troubleshooting.md#first-run-prompt-coordination).
+
+## Loading straight from a release URL (caveat)
+
+Zellij can also load a plugin directly from an `https://` URL, downloading and
+caching it (no manual `cp`) — once a release is tagged:
+
+```kdl
+plugin location="https://github.com/marktoda/zj-radar/releases/download/v0.1.0/zj_radar.wasm"
+```
+
+**Not recommended as the default for zj-radar**, though: the sidebar loads once
+*per tab* (it lives in `default_tab_template`), and Zellij has a known bug where
+several tabs fetching the same remote plugin at once can corrupt the download.
+Prefer the `file:` path above or the Nix package below; use the URL form only
+for a quick single-tab try.
+
+## Nix / home-manager
+
+This flake exposes the wasm as `packages.default`, so a flake-based config can
+consume the exact same artifact this repo builds. Add the repo as an input:
+
+```nix
+# flake.nix
+inputs.zj-radar.url = "github:marktoda/zj-radar";
+```
+
+Then reference the built wasm from your generated `config.kdl` alias:
+
+```kdl
+plugins {
+    radar location="file:${inputs.zj-radar.packages.${system}.default}/bin/zj_radar.wasm" {
+        naming "managed"
+    }
+}
+```
+
+Tagged releases also publish a prebuilt wasm artifact that can be pinned without
+a Rust toolchain (mirrors the older `room`/`smart-tabs` vendoring this replaces):
+
+```nix
+zjRadarWasm = pkgs.fetchurl {
+  url = "https://github.com/marktoda/zj-radar/releases/download/v0.1.0/zj_radar.wasm";
+  hash = "sha256-..."; # nix-prefetch-url the asset to fill this in
+};
+```
+
+The old `@smartTabs@` substitution is fully retired — zj-radar owns the rail.

--- a/docs/producers.md
+++ b/docs/producers.md
@@ -1,0 +1,96 @@
+# Producers — sending agent status to the sidebar
+
+The sidebar is just a display. A **producer** is whatever broadcasts agent
+status to it. zj-radar ships producers for Claude Code and Codex, and the wire
+format is a documented pipe payload so you can write your own.
+
+Install the [sidebar](install.md) first, then add a producer below.
+
+## Claude Code
+
+Installing this plugin auto-registers the status hooks — **no `settings.json`
+editing**, clean uninstall.
+
+```sh
+/plugin marketplace add marktoda/zj-radar
+/plugin install zj-radar-claude@zj-radar
+```
+
+Requires `jq` and `git` on `PATH` (used to parse the hook payload and derive
+repo/branch). See [`plugins/zj-radar-claude/README.md`](../plugins/zj-radar-claude/README.md)
+for details. It's a no-op outside Zellij, so it's safe to leave enabled
+everywhere.
+
+## Codex and the native CLI
+
+A native binary that drops the `jq`/`bash` dependency and wires non-plugin agents.
+
+> **Before the first tagged release**, the prebuilt tarballs and the
+> `#zj-radar-cli` Nix output aren't published yet — use the `cargo install --git`
+> form below (or build from source). The release workflow produces all three on
+> the first `v*` tag.
+
+```sh
+# Release tarballs (published on tagged releases):
+#   zj-radar-linux-x86_64.tar.gz
+#   zj-radar-macos-aarch64.tar.gz
+# Nix:
+nix build github:marktoda/zj-radar#zj-radar-cli   # -> result/bin/zj-radar
+# Cargo:
+cargo install --git https://github.com/marktoda/zj-radar --features cli
+```
+
+- **`zj-radar notify <claude|codex>`** — broadcasts agent status. The Claude
+  plugin's hook script automatically prefers it when it's on `PATH` (jq-free);
+  otherwise the plugin falls back to its bundled `bash`+`jq` script.
+- **`zj-radar setup [codex]`** — idempotently wires Codex's
+  `~/.codex/hooks.json` to call `zj-radar notify codex`. This preserves any
+  existing Codex `notify` program (e.g. a Computer Use notifier), because hooks
+  are additive. Use `--dry-run` to preview, `--uninstall` to remove only
+  zj-radar's hooks, and `--check` to diagnose the current setup. After installing
+  or changing hooks, run `/hooks` inside Codex once to review and trust the
+  command hook. (Claude needs no `setup` — use the plugin above.)
+- **`zj-radar setup codex --legacy-notify`** — opt-in fallback for older Codex
+  setups that only support the single `notify` program. It refuses to replace a
+  foreign notifier unless `--force` is also passed.
+- **`zj-radar setup zellij --wasm <path>`** — copies the sidebar wasm to
+  `~/.config/zellij/plugins/zj_radar.wasm`, manages the `radar` alias in
+  `config.kdl`, and prints the layout snippet. It leaves layouts user-owned.
+
+Codex hooks report turn start, tool use, permission requests, subagents, and
+turn stop. zj-radar maps those to `running`, `pending`, and `done`.
+
+## Writing your own producer
+
+The plugin's only real interface is the versioned pipe payload. Broadcast (by
+name, never `--plugin`) a `zj_radar.status.v1` message:
+
+```json
+{ "v": 1,
+  "source": "claude",
+  "pane": { "type": "terminal", "id": 12 },
+  "status": "running",
+  "repo": "pinky",
+  "branch": "fix/x",
+  "msg": "running tests…",
+  "on_focus": "idle",
+  "seq": 42 }
+```
+
+- `status`: `running` → working · `pending` → needs-you · `done` · `error` ·
+  `idle`/unknown → plain.
+- `pane.id`: strip any `terminal_` prefix from `$ZELLIJ_PANE_ID`.
+- `on_focus` (optional): the status to apply when you next focus that exact pane
+  (lets `done` persist on other tabs, then auto-clear).
+- `seq` (optional): monotonic per-pane counter; a `seq` ≤ the stored one is
+  dropped (hook-race guard).
+
+The plugin defends itself: it ignores oversized payloads, strips ANSI/control
+chars, folds newlines to spaces, and truncates. Adapters can stay simple.
+
+Quick smoke test (a "fake agent" — broadcast straight from your shell):
+
+```sh
+zellij pipe --name zj_radar.status.v1 -- \
+  '{"v":1,"source":"test","pane":{"type":"terminal","id":12},"status":"running","repo":"demo","branch":"main","msg":"hello"}'
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,54 @@
+# Troubleshooting
+
+The sidebar lives in your tab templates and exists once per tab, which bumps
+into a few sharp edges in Zellij itself. Here is what they look like and why.
+
+## Can't open a new tab (the two-template rule)
+
+**Symptom:** new tabs created at runtime (`Ctrl+t n`) contain only the sidebar
+and status bar — no focusable pane — so keystrokes have nowhere to land and you
+"can't open a new tab."
+
+**Why:** when you don't supply a `new_tab_template`, Zellij *derives* one from
+`default_tab_template` — and that derivation **drops a `children` placeholder
+nested inside a split** (upstream
+[zellij-org/zellij#3247](https://github.com/zellij-org/zellij/issues/3247),
+still open). A *top-level* `children`, like the stock compact layout, materializes
+fine — only the nested-in-a-split case is affected, which is exactly how the
+sidebar pins itself.
+
+**Fix:** declare `new_tab_template` explicitly with a concrete `pane focus=true`
+(instead of `children`), as shown in the
+[layout snippet](install.md#add-the-sidebar-to-a-layout). That sidesteps the
+derivation entirely.
+
+## First-run prompt coordination
+
+**Symptom:** on a fresh layout the sidebar requests permissions in one tab while
+the others wait; occasionally a late-spawned sidebar starts empty until the next
+broadcast.
+
+**Why:** because the sidebar exists once per tab, only one instance owns the
+first-run prompt when session files are writable; the others wait for Zellij's
+cached answer and then continue without asking again. Session files use Zellij's
+shared plugin cache when available and fall back to `/tmp/zj-radar`.
+
+**If neither is writable:** the sidebar still runs, but late-spawned sidebars may
+start empty until the next broadcast, and first-run prompt coordination may be
+noisier (more than one instance may prompt). Pre-approving the plugin URL once in
+a floating pane — see
+[First-run permission prompt](install.md#first-run-permission-prompt) — gives
+every later per-tab sidebar a cached grant to reuse.
+
+## Zellij plugin-reload quirks
+
+**Symptom:** during development, reloading the plugin opens an extra tiled plugin
+pane.
+
+**Why:** Zellij 0.44's plugin reload actions can open an extra tiled plugin pane
+when the target plugin was created by a layout and has made itself non-selectable
+(as the radar sidebar does after permissions).
+
+**Fix:** the default inside-Zellij dev loop (`./dev/run.sh`) avoids both in-place
+plugin reloads and session switching for exactly this reason. See
+[Development in the README](../README.md#development).

--- a/plugins/zj-radar-claude/.claude-plugin/plugin.json
+++ b/plugins/zj-radar-claude/.claude-plugin/plugin.json
@@ -3,5 +3,5 @@
   "version": "0.1.0",
   "description": "Broadcast Claude Code agent status to the zj-radar Zellij sidebar (working/waiting/done), with zero settings.json editing.",
   "author": { "name": "Mark Toda" },
-  "homepage": "https://github.com/mark-toda/zj-radar"
+  "homepage": "https://github.com/marktoda/zj-radar"
 }

--- a/plugins/zj-radar-claude/README.md
+++ b/plugins/zj-radar-claude/README.md
@@ -5,14 +5,14 @@ to the [zj-radar](../../) Zellij sidebar — with **no `settings.json` editing**
 Installing the plugin auto-registers the hooks; uninstalling removes them cleanly.
 
 This plugin only sends status. Install the Zellij sidebar first with the
-[main install guide](../../README.md#install), then add this producer.
+[main install guide](../../docs/install.md), then add this producer.
 
 ## Install
 
 One-time (from the zj-radar marketplace repo):
 
 ```
-/plugin marketplace add mark-toda/zj-radar
+/plugin marketplace add marktoda/zj-radar
 /plugin install zj-radar-claude@zj-radar
 ```
 
@@ -37,7 +37,7 @@ Each fires a `zellij pipe --name zj_radar.status.v1` broadcast. It is a **no-op
 outside Zellij**, so it's safe to leave enabled everywhere.
 
 The bundled `notify.sh` requires `jq` and `git` on PATH (to parse the payload and
-derive repo/branch). If the native [`zj-radar`](../../README.md#codex-and-the-native-cli)
+derive repo/branch). If the native [`zj-radar`](../../docs/producers.md#codex-and-the-native-cli)
 CLI is installed, the script automatically prefers it (`exec zj-radar notify
 claude`), which needs neither `jq` nor `bash` — the `jq`+`bash` path is only the
 fallback when the binary isn't on PATH.


### PR DESCRIPTION
Restructures the README around the **landing-page** job (what / why / should-I) and moves the install/config/producer manuals into dedicated `docs/` files. Based on a benchmark pass against popular terminal/dev tools (starship, fzf, ripgrep, zoxide, Claude Squad, zjstatus, VHS).

## Headline fix
Every `mark-toda` reference is corrected to `marktoda` (the actual repo owner). These appeared in **executable** paths — Nix flake input, `cargo install --git` URL, `/plugin marketplace add` target, release-download URLs — plus `Cargo.toml` `repository` and `plugin.json` `homepage`. A reader copy-pasting any of them previously got a hard failure.

## README changes
- Badges (CI, license, Zellij plugin, Claude Code, Codex, status) + quick-nav links.
- `## Highlights` "why you care" block before install.
- `## How is this different?` comparison table (Claude Squad / cmux / zjstatus / plain Zellij tabs).
- `## Quick start` with an explicit `git clone` → build → install → setup flow.
- `Repo layout` moved under `## Development` (contributor info, not user info).
- Links the already-reproducible hero GIF tooling in `demo/`.
- README shrinks from ~466 to ~257 lines.

## New docs
| File | Contents |
|------|----------|
| `docs/install.md` | Full sidebar install: CLI + manual setup, layout templates, permissions, remote-URL caveat, Nix / home-manager. |
| `docs/producers.md` | Claude Code, Codex/native CLI, and the custom `zj_radar.status.v1` payload schema + smoke test. |
| `docs/configuration.md` | density/naming/header/glyphs, runtime config, and keybindings. |
| `docs/troubleshooting.md` | the two-template rule (upstream #3247), first-run prompt coordination, reload quirks. |

The Claude plugin README's now-stale `README.md#install` / `#codex-and-the-native-cli` anchors were repointed at the new docs.

## Also done (outside this diff)
- GitHub repo **description** + 10 **topics** set on `marktoda/zj-radar`.
- Social-preview image still needs a manual upload (not scriptable via `gh`).

## Verification
- `git grep mark-toda` → zero hits.
- `cargo metadata` parses; `plugin.json` is valid JSON.
- All cross-doc anchor links validated against actual headings; all referenced repo files exist.
- Doc-cited CLI subcommands (`notify`, `setup codex/zellij`), the `cli` feature, and the 10 host-testable modules all verified present on the current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)