### PR TITLE
fix(plugin): persist the snapshot when a prune drops a non-completion

### DIFF
--- a/crates/cli/tests/support/mod.rs
+++ b/crates/cli/tests/support/mod.rs
@@ -23,11 +23,16 @@ impl ShimDir {
 
     /// Install a fake `name` binary that records argv + stdin to
     /// `<dir>/<name>.log` (one tab-separated line per invocation) and exits 0.
+    ///
+    /// All shims are POSIX `#!/bin/sh`: the hermetic Nix sandbox has no
+    /// `/usr/bin/env` (nor bash), and a shim that fails to exec makes
+    /// `notify`'s spawn a silent no-op — the suite then fails with zero
+    /// recorded broadcasts instead of pointing at the real problem.
     pub fn add_recorder(&self, name: &str) {
         let log = self.dir.path().join(format!("{name}.log"));
         let script = format!(
-            "#!/usr/bin/env bash\nstdin=\"$(cat)\"\n\
-             printf '%s\\t%s\\n' \"$*\" \"${{stdin//$'\\n'/ }}\" >> {log:?}\nexit 0\n",
+            "#!/bin/sh\nstdin=\"$(cat)\"\n\
+             printf '%s\\t%s\\n' \"$*\" \"$(printf '%s' \"$stdin\" | tr '\\n' ' ')\" >> {log:?}\nexit 0\n",
             log = log
         );
         let bin = self.dir.path().join(name);
@@ -47,7 +52,7 @@ impl ShimDir {
     pub fn add_hanging_recorder(&self, name: &str, secs: u32) {
         let log = self.dir.path().join(format!("{name}.log"));
         let script = format!(
-            "#!/usr/bin/env bash\nprintf '%s\\t\\n' \"$*\" >> {log:?}\nexec sleep {secs}\n",
+            "#!/bin/sh\nprintf '%s\\t\\n' \"$*\" >> {log:?}\nexec sleep {secs}\n",
             log = log
         );
         let bin = self.dir.path().join(name);
@@ -68,7 +73,7 @@ impl ShimDir {
     /// `$3` is the subcommand after `-C <cwd>`.
     pub fn add_fake_git(&self, repo_toplevel: &str, branch: &str) {
         let script = format!(
-            "#!/usr/bin/env bash\n\
+            "#!/bin/sh\n\
              # $1=-C  $2=<cwd>  $3=rev-parse|branch  $4=--show-toplevel|--show-current\n\
              case \"$3 $4\" in\n\
                'rev-parse --show-toplevel') echo {repo:?};;\n\

--- a/crates/core/src/command.rs
+++ b/crates/core/src/command.rs
@@ -755,16 +755,30 @@ impl CommandStore {
     }
 
     /// Drop entries (resolved + pending + exit-dedup) for panes not in `live`.
-    /// Returns the dropped Done/Error observations plus whether anything was
-    /// removed (`ObservationStore::prune`'s contract — an in-progress Running
-    /// or muted Idle pane closing carries no completion to ledger, but its
-    /// removal must still reach the snapshot).
-    pub fn prune(&mut self, live: &HashSet<u32>) -> (Vec<(u32, TrackedObservation)>, bool) {
+    /// Returns every dropped observation (`ObservationStore::prune`'s
+    /// contract): the caller reads emptiness as "persisted state changed" and
+    /// the ledger sink filters to completions. The pending / exit-dedup maps
+    /// are bookkeeping, never persisted, so their retains don't report.
+    pub fn prune(&mut self, live: &HashSet<u32>) -> Vec<(u32, TrackedObservation)> {
         let dropped = self.store.prune(live);
         self.pending.retain(|id, _| live.contains(id));
         self.pending_done.retain(|id, _| live.contains(id));
         self.exited.retain(|id, _| live.contains(id));
         dropped
+    }
+
+    /// Every pane id this store holds any state for — resolved observations
+    /// plus the pending / exit-dedup bookkeeping. `RadarState::panes_changed`
+    /// grants absent panes one manifest of grace before pruning, and the grace
+    /// must see the bookkeeping too, or a mid-move manifest flash would drop a
+    /// debounce promotion or exit-dedup marker in flight.
+    pub fn tracked_pane_ids(&self) -> impl Iterator<Item = u32> + '_ {
+        self.store
+            .observations()
+            .map(|(id, _)| id)
+            .chain(self.pending.keys().copied())
+            .chain(self.pending_done.keys().copied())
+            .chain(self.exited.keys().copied())
     }
 
     /// Resolved displayable state for a pane, or None.

--- a/crates/core/src/command.rs
+++ b/crates/core/src/command.rs
@@ -755,10 +755,11 @@ impl CommandStore {
     }
 
     /// Drop entries (resolved + pending + exit-dedup) for panes not in `live`.
-    /// Returns the dropped Done/Error observations (`ObservationStore::prune`'s
-    /// contract — an in-progress Running or muted Idle pane closing carries no
-    /// completion to ledger).
-    pub fn prune(&mut self, live: &HashSet<u32>) -> Vec<(u32, TrackedObservation)> {
+    /// Returns the dropped Done/Error observations plus whether anything was
+    /// removed (`ObservationStore::prune`'s contract — an in-progress Running
+    /// or muted Idle pane closing carries no completion to ledger, but its
+    /// removal must still reach the snapshot).
+    pub fn prune(&mut self, live: &HashSet<u32>) -> (Vec<(u32, TrackedObservation)>, bool) {
         let dropped = self.store.prune(live);
         self.pending.retain(|id, _| live.contains(id));
         self.pending_done.retain(|id, _| live.contains(id));

--- a/crates/core/src/observation.rs
+++ b/crates/core/src/observation.rs
@@ -140,20 +140,24 @@ impl ObservationStore {
         self.map.insert(pane_id, observation)
     }
 
-    /// Prune every entry not in `live`, returning the dropped *completions*
-    /// (`Done`/`Error` — see `insert`): a pane closing with an unreceded
-    /// completion still on it is a recede edge the caller may ledger. A
-    /// Running/Idle/Pending pane closing carries nothing to ledger, so those
-    /// drops are filtered here — both stores want exactly this cut.
-    pub fn prune(&mut self, live: &HashSet<u32>) -> Vec<(u32, TrackedObservation)> {
+    /// Prune every entry not in `live`. Returns the dropped *completions*
+    /// (`Done`/`Error` — see `insert`) plus whether *anything* was removed:
+    /// a pane closing with an unreceded completion still on it is a recede
+    /// edge the caller may ledger, while a Running/Idle/Pending drop carries
+    /// nothing to ledger and is filtered from the vec — but it still mutated
+    /// persisted state, and the caller must know (an unpersisted Pending drop
+    /// leaves the shared snapshot carrying a status no live store holds, and
+    /// late-spawned instances resurrect it — see `RadarState::panes_changed`).
+    pub fn prune(&mut self, live: &HashSet<u32>) -> (Vec<(u32, TrackedObservation)>, bool) {
         let dropped: Vec<(u32, TrackedObservation)> = self
             .map
             .iter()
             .filter(|(id, obs)| !live.contains(id) && obs.status.is_completion())
             .map(|(&id, obs)| (id, obs.clone()))
             .collect();
+        let before = self.map.len();
         self.map.retain(|id, _| live.contains(id));
-        dropped
+        (dropped, self.map.len() != before)
     }
 
     pub fn observations(&self) -> impl Iterator<Item = (u32, &TrackedObservation)> {
@@ -218,9 +222,10 @@ mod tests {
         assert_eq!(displaced.unwrap().status, Status::Error, "old entry comes back out");
         s.insert(2, sample());
         s.insert(3, TrackedObservation { status: Status::Running, ..sample() });
-        let dropped = s.prune(&[2].into_iter().collect());
+        let (dropped, removed_any) = s.prune(&[2].into_iter().collect());
         assert_eq!(dropped.len(), 1, "only completions come back out — Running carries nothing to ledger");
         assert_eq!(dropped[0].0, 1);
+        assert!(removed_any, "the drop is still reported so callers persist it");
         assert!(s.get(3).is_none(), "the non-completion is still dropped from the map");
         assert!(s.get(2).is_some());
     }

--- a/crates/core/src/observation.rs
+++ b/crates/core/src/observation.rs
@@ -140,24 +140,24 @@ impl ObservationStore {
         self.map.insert(pane_id, observation)
     }
 
-    /// Prune every entry not in `live`. Returns the dropped *completions*
-    /// (`Done`/`Error` — see `insert`) plus whether *anything* was removed:
-    /// a pane closing with an unreceded completion still on it is a recede
-    /// edge the caller may ledger, while a Running/Idle/Pending drop carries
-    /// nothing to ledger and is filtered from the vec — but it still mutated
-    /// persisted state, and the caller must know (an unpersisted Pending drop
+    /// Prune every entry not in `live`, returning *every* dropped observation.
+    /// The two consumers split the vec's roles without a pre-cut here: emptiness
+    /// answers "did persisted state change" (an unpersisted Pending/Running drop
     /// leaves the shared snapshot carrying a status no live store holds, and
-    /// late-spawned instances resurrect it — see `RadarState::panes_changed`).
-    pub fn prune(&mut self, live: &HashSet<u32>) -> (Vec<(u32, TrackedObservation)>, bool) {
+    /// late-spawned instances resurrect it — see `RadarState::panes_changed`),
+    /// and the ledger sink filters to the completions worth ledgering itself
+    /// (`LedgerEntry::from_observation` is `None` for anything else). Returning
+    /// only the completions would re-open the trap where a caller reads
+    /// emptiness as "nothing removed" and skips the persist.
+    pub fn prune(&mut self, live: &HashSet<u32>) -> Vec<(u32, TrackedObservation)> {
         let dropped: Vec<(u32, TrackedObservation)> = self
             .map
             .iter()
-            .filter(|(id, obs)| !live.contains(id) && obs.status.is_completion())
+            .filter(|(id, _)| !live.contains(id))
             .map(|(&id, obs)| (id, obs.clone()))
             .collect();
-        let before = self.map.len();
         self.map.retain(|id, _| live.contains(id));
-        (dropped, self.map.len() != before)
+        dropped
     }
 
     pub fn observations(&self) -> impl Iterator<Item = (u32, &TrackedObservation)> {
@@ -215,18 +215,19 @@ mod tests {
     }
 
     #[test]
-    fn insert_returns_displaced_and_prune_returns_dropped_completions() {
+    fn insert_returns_displaced_and_prune_returns_every_drop() {
         let mut s = ObservationStore::default();
         assert!(s.insert(1, sample()).is_none());
         let displaced = s.insert(1, TrackedObservation { status: Status::Done, ..sample() });
         assert_eq!(displaced.unwrap().status, Status::Error, "old entry comes back out");
         s.insert(2, sample());
         s.insert(3, TrackedObservation { status: Status::Running, ..sample() });
-        let (dropped, removed_any) = s.prune(&[2].into_iter().collect());
-        assert_eq!(dropped.len(), 1, "only completions come back out — Running carries nothing to ledger");
-        assert_eq!(dropped[0].0, 1);
-        assert!(removed_any, "the drop is still reported so callers persist it");
-        assert!(s.get(3).is_none(), "the non-completion is still dropped from the map");
+        let mut dropped = s.prune(&[2].into_iter().collect());
+        dropped.sort_by_key(|(id, _)| *id);
+        assert_eq!(dropped.len(), 2, "every drop comes back out — emptiness is the persist signal");
+        assert_eq!((dropped[0].0, dropped[0].1.status), (1, Status::Done));
+        assert_eq!((dropped[1].0, dropped[1].1.status), (3, Status::Running), "non-completions included; the ledger sink filters");
+        assert!(s.get(3).is_none());
         assert!(s.get(2).is_some());
     }
 

--- a/crates/plugin/proptest-regressions/radar_state/tests.txt
+++ b/crates/plugin/proptest-regressions/radar_state/tests.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 099b2a6bd9dd75e013326464073898d97dd5b4f500bbe1969b63edd00797bbe5 # shrinks to ops = [Status(2, Idle), Panes([], [], None)]

--- a/crates/plugin/src/radar_state.rs
+++ b/crates/plugin/src/radar_state.rs
@@ -82,7 +82,7 @@ pub(crate) struct RadarTab {
     pub has_bell: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct PaneUpdate {
     pub tab_panes: HashMap<usize, Vec<TerminalPane>>,
     pub live: HashSet<u32>,
@@ -215,6 +215,18 @@ pub(crate) struct RadarState {
     /// lazily by `timer` — `rows` stays `&self` so it can be called freely from
     /// render paths without needing `&mut`.
     flash_until: HashMap<TabId, u64>,
+    /// Tracked panes absent from the latest pane manifest, awaiting their
+    /// second absence before `panes_changed` prunes them — Zellij's break-pane
+    /// family reports session state while the moved pane is extracted and in
+    /// no tab, so a single absence can't distinguish a close from a mid-move
+    /// flash. The value is the pane's tab identity captured when it first went
+    /// absent (the last manifest that still carried it): by the confirming
+    /// second absence the pane is long gone from `pane_tab_index`, and the
+    /// ledger still needs a tab name to file the recede under. `None` when the
+    /// pane was never seen in any topology (a broadcast that beat the pane's
+    /// first manifest). Level-triggered: recomputed from the current manifest
+    /// every `panes_changed`, so a pane that reappears simply drops out.
+    absent_once: HashMap<u32, Option<(TabId, String)>>,
 }
 
 impl RadarState {
@@ -359,23 +371,54 @@ impl RadarState {
         }
         self.live_panes = Some(update.live.clone());
         self.tab_panes = update.tab_panes;
+        // An absent pane gets one manifest of grace before it's pruned:
+        // Zellij's break-pane family reports session state while the moved
+        // pane is extracted and in no tab (zellij screen.rs: `extract_pane` →
+        // `switch_active_tab` → `log_and_report_session_state` → only then
+        // `add_tiled_pane`), so a single absence is ambiguous between a close
+        // and a mid-move flash. The flash's corrective manifest arrives
+        // immediately (`add_tiled_pane` reports again), so a mid-move agent
+        // keeps its status in every store; a real close stays absent and
+        // prunes on the next update. Pruning on the flash would drop a live
+        // Pending from every store — and broadcasts are not replayed, so a
+        // silently-waiting agent's needs-you row would only come back on its
+        // next hook event. (A graced observation also survives any mid-flash
+        // persist: `snapshot::to_json` re-inserts current-store entries
+        // unconditionally; only *existing* snapshot entries are live-filtered.)
+        let absent_before = std::mem::take(&mut self.absent_once);
+        let graced: HashMap<u32, Option<(TabId, String)>> = self
+            .status
+            .observations()
+            .map(|(id, _)| id)
+            .chain(self.command.tracked_pane_ids())
+            .filter(|id| !update.live.contains(id) && !absent_before.contains_key(id))
+            .map(|id| (id, old_index.get(&id).cloned()))
+            .collect();
+        let effective_live: HashSet<u32> =
+            update.live.iter().copied().chain(graced.keys().copied()).collect();
+        // A confirmed-gone pane left the topology one manifest ago, so
+        // `old_index` no longer carries it — the ledger files its recede under
+        // the tab identity captured at first absence instead.
+        let mut prune_index = old_index.clone();
+        prune_index.extend(absent_before.into_iter().filter_map(|(id, entry)| Some((id, entry?))));
+        self.absent_once = graced;
         // A pane closing with an unreceded Done/Error still on it is a recede
         // edge for both stores; both prunes ledger against the pre-close
-        // `old_index` and `status_tracked` captured above. Non-completion
-        // drops ledger nothing but still count toward `pruned_any`: Zellij's
-        // break-pane family flashes a manifest that omits the moved pane, and
-        // the new tab it creates spawns a fresh rail instance that seeds from
-        // the snapshot at load — if the prune of a Pending/Running never
-        // persists, the snapshot keeps a status no live store holds anymore
-        // and that instance resurrects it forever.
-        let (dropped_status, status_removed) = self.status.prune(&update.live);
-        let (dropped_command, command_removed) = self.command.prune(&update.live);
-        let pruned_any = status_removed || command_removed;
-        self.ledger_receded(dropped_status, &old_index, &status_tracked);
-        self.ledger_receded(dropped_command, &old_index, &status_tracked);
-        self.pane_cwd.retain(|id, _| update.live.contains(id));
+        // `prune_index` and `status_tracked` captured above (`ledger_receded`
+        // filters to the completions itself). Any drop — completion or not —
+        // requests a persist: an unpersisted drop leaves the shared snapshot
+        // carrying a status no live store holds, and the next spawned
+        // instance seeds it back (`snapshot::to_json` only scrubs existing
+        // entries for panes missing from the manifest, and by the confirming
+        // second absence that filter agrees the pane is gone).
+        let dropped_status = self.status.prune(&effective_live);
+        let dropped_command = self.command.prune(&effective_live);
+        let pruned_any = !dropped_status.is_empty() || !dropped_command.is_empty();
+        self.ledger_receded(dropped_status, &prune_index, &status_tracked);
+        self.ledger_receded(dropped_command, &prune_index, &status_tracked);
+        self.pane_cwd.retain(|id, _| effective_live.contains(id));
         self.cwd_bootstrap_attempted
-            .retain(|id| update.live.contains(id));
+            .retain(|id| effective_live.contains(id));
         // Track this update's fresh focus for notification suppression. It no
         // longer drives rail state (no focus recede) — see `note_focus`. `settle`
         // still gates the notifier: `panes_changed` carries trustworthy focus, so
@@ -739,6 +782,14 @@ impl RadarState {
     #[cfg(test)]
     pub(crate) fn status_mut(&mut self) -> &mut StatusStore {
         &mut self.status
+    }
+
+    /// Panes currently holding the one-manifest prune grace — see
+    /// `absent_once`. Test-only: the invariant suite needs to distinguish
+    /// "kept because graced" from "prune failed".
+    #[cfg(test)]
+    pub(crate) fn graced_pane_ids(&self) -> HashSet<u32> {
+        self.absent_once.keys().copied().collect()
     }
 
     #[cfg(test)]

--- a/crates/plugin/src/radar_state.rs
+++ b/crates/plugin/src/radar_state.rs
@@ -361,10 +361,16 @@ impl RadarState {
         self.tab_panes = update.tab_panes;
         // A pane closing with an unreceded Done/Error still on it is a recede
         // edge for both stores; both prunes ledger against the pre-close
-        // `old_index` and `status_tracked` captured above.
-        let dropped_status = self.status.prune(&update.live);
-        let dropped_command = self.command.prune(&update.live);
-        let pruned_any = !dropped_status.is_empty() || !dropped_command.is_empty();
+        // `old_index` and `status_tracked` captured above. Non-completion
+        // drops ledger nothing but still count toward `pruned_any`: Zellij's
+        // break-pane family flashes a manifest that omits the moved pane, and
+        // the new tab it creates spawns a fresh rail instance that seeds from
+        // the snapshot at load — if the prune of a Pending/Running never
+        // persists, the snapshot keeps a status no live store holds anymore
+        // and that instance resurrects it forever.
+        let (dropped_status, status_removed) = self.status.prune(&update.live);
+        let (dropped_command, command_removed) = self.command.prune(&update.live);
+        let pruned_any = status_removed || command_removed;
         self.ledger_receded(dropped_status, &old_index, &status_tracked);
         self.ledger_receded(dropped_command, &old_index, &status_tracked);
         self.pane_cwd.retain(|id, _| update.live.contains(id));

--- a/crates/plugin/src/radar_state/tests.rs
+++ b/crates/plugin/src/radar_state/tests.rs
@@ -354,8 +354,8 @@ fn panes_changed_persists_only_on_exit_displace_or_prune() {
     // effect is a read-merge-write of the shared /cache file — so plain
     // topology churn (resize, title change, focus) must NOT request
     // persistence. Only the recede edges (an exit displacing a completion, a
-    // prune dropping one) change persisted state; topology itself is never
-    // persisted.
+    // prune dropping any observation) change persisted state; topology itself
+    // is never persisted.
     let mut radar = RadarState::default();
     radar.tabs_changed(vec![tab(10, 0, "work", true)]);
 
@@ -390,6 +390,34 @@ fn panes_changed_persists_only_on_exit_displace_or_prune() {
     // (it also ledgers), so THIS update persists.
     let change = radar.panes_changed(pane_update(HashMap::new()), 4, 200, config::NamingMode::Off);
     assert!(change.persist_snapshot, "a prune that dropped a completion persists");
+}
+
+#[test]
+fn panes_changed_persists_when_a_prune_drops_a_non_completion() {
+    // Zellij's break-pane family can flash a manifest that omits the moved
+    // pane while it sits between tabs. The prune drops the live Pending —
+    // nothing to ledger — but the removal itself must reach the shared
+    // snapshot: break-pane spawns a fresh rail instance in the new tab, and
+    // that instance seeds from the snapshot at load. An unpersisted prune
+    // leaves the stale Pending in the snapshot with no live observation left
+    // anywhere to overwrite it, so the new instance resurrects it forever.
+    let mut radar = RadarState::default();
+    radar.tabs_changed(vec![tab(10, 0, "work", true)]);
+    radar.panes_changed(
+        pane_update(HashMap::from([(0, vec![focused_pane(7)])])),
+        1,
+        0,
+        config::NamingMode::Off,
+    );
+    radar
+        .status_mut()
+        .apply(payload_in_repo(7, Status::Pending, "repo"), 2, 100);
+
+    let change = radar.panes_changed(pane_update(HashMap::new()), 3, 200, config::NamingMode::Off);
+    assert!(
+        change.persist_snapshot,
+        "a prune that dropped a Pending must persist the snapshot"
+    );
 }
 
 #[test]

--- a/crates/plugin/src/radar_state/tests.rs
+++ b/crates/plugin/src/radar_state/tests.rs
@@ -386,21 +386,25 @@ fn panes_changed_persists_only_on_exit_displace_or_prune() {
     );
     assert!(!change.persist_snapshot, "title-only churn must not persist");
 
-    // The pane closes with the Done still on it → the prune is a recede edge
-    // (it also ledgers), so THIS update persists.
+    // The pane closes with the Done still on it. The first absence is the
+    // grace manifest (a break-pane flash looks identical) — no prune, no
+    // persist. The second absence confirms the close → the prune is a recede
+    // edge (it also ledgers), so THAT update persists.
     let change = radar.panes_changed(pane_update(HashMap::new()), 4, 200, config::NamingMode::Off);
+    assert!(!change.persist_snapshot, "first absence is the grace manifest — nothing pruned yet");
+    let change = radar.panes_changed(pane_update(HashMap::new()), 5, 300, config::NamingMode::Off);
     assert!(change.persist_snapshot, "a prune that dropped a completion persists");
 }
 
 #[test]
 fn panes_changed_persists_when_a_prune_drops_a_non_completion() {
-    // Zellij's break-pane family can flash a manifest that omits the moved
-    // pane while it sits between tabs. The prune drops the live Pending —
-    // nothing to ledger — but the removal itself must reach the shared
-    // snapshot: break-pane spawns a fresh rail instance in the new tab, and
-    // that instance seeds from the snapshot at load. An unpersisted prune
-    // leaves the stale Pending in the snapshot with no live observation left
-    // anywhere to overwrite it, so the new instance resurrects it forever.
+    // A pane staying absent for two manifests is a real close. Its live
+    // Pending ledgers nothing, but the removal itself must reach the shared
+    // snapshot: `snapshot::to_json` only scrubs entries for panes missing
+    // from the manifest at persist time, so if THIS edge doesn't persist, a
+    // snapshot written later (when the id could be reused and live again)
+    // keeps carrying a status no store holds, and the next spawned instance
+    // seeds it back.
     let mut radar = RadarState::default();
     radar.tabs_changed(vec![tab(10, 0, "work", true)]);
     radar.panes_changed(
@@ -413,12 +417,65 @@ fn panes_changed_persists_when_a_prune_drops_a_non_completion() {
         .status_mut()
         .apply(payload_in_repo(7, Status::Pending, "repo"), 2, 100);
 
-    let change = radar.panes_changed(pane_update(HashMap::new()), 3, 200, config::NamingMode::Off);
+    radar.panes_changed(pane_update(HashMap::new()), 3, 200, config::NamingMode::Off);
+    let change = radar.panes_changed(pane_update(HashMap::new()), 4, 300, config::NamingMode::Off);
     assert!(
         change.persist_snapshot,
-        "a prune that dropped a Pending must persist the snapshot"
+        "a confirmed prune that dropped a Pending must persist the snapshot"
     );
+    assert!(radar.status(7).is_none(), "the Pending is gone from the store");
 }
+
+#[test]
+fn break_pane_manifest_flash_does_not_prune_a_live_pending() {
+    // Zellij's break-pane family reports session state while the moved pane
+    // is extracted and in no tab, then reports again once it lands in the new
+    // tab. The flash manifest must not prune the pane's status: broadcasts
+    // are not replayed, and a Pending agent waiting on its question emits no
+    // further hooks — pruning here would silently drop the needs-you row
+    // everywhere until the user happens to interact with the agent.
+    let mut radar = RadarState::default();
+    radar.tabs_changed(vec![tab(10, 0, "work", true)]);
+    radar.panes_changed(
+        pane_update(HashMap::from([(0, vec![focused_pane(7)])])),
+        1,
+        0,
+        config::NamingMode::Off,
+    );
+    radar
+        .status_mut()
+        .apply(payload_in_repo(7, Status::Pending, "repo"), 2, 100);
+
+    // The flash: pane 7 is in no tab for exactly one manifest.
+    let change = radar.panes_changed(pane_update(HashMap::new()), 3, 200, config::NamingMode::Off);
+    assert!(!change.persist_snapshot, "the flash is not a recede edge");
+    assert_eq!(
+        radar.status(7).map(|o| o.status),
+        Some(Status::Pending),
+        "the graced Pending survives the flash"
+    );
+
+    // The corrective manifest lands the pane in its new tab; the grace clears
+    // and a later real close still gets its own two-manifest confirmation.
+    radar.tabs_changed(vec![tab(10, 0, "work", true), tab(11, 1, "moved", false)]);
+    radar.panes_changed(
+        pane_update(HashMap::from([(1, vec![focused_pane(7)])])),
+        4,
+        300,
+        config::NamingMode::Off,
+    );
+    assert_eq!(radar.status(7).map(|o| o.status), Some(Status::Pending));
+    radar.panes_changed(pane_update(HashMap::new()), 5, 400, config::NamingMode::Off);
+    assert_eq!(
+        radar.status(7).map(|o| o.status),
+        Some(Status::Pending),
+        "reappearing reset the grace — a fresh absence starts over"
+    );
+    let change = radar.panes_changed(pane_update(HashMap::new()), 6, 500, config::NamingMode::Off);
+    assert!(change.persist_snapshot, "the second consecutive absence is the real prune");
+    assert!(radar.status(7).is_none());
+}
+
 
 #[test]
 fn panes_changed_persists_when_an_exit_displaces_a_completion() {
@@ -1244,18 +1301,30 @@ proptest! {
                     };
                     st.panes_changed(update, tick, 0, config::NamingMode::Off);
 
-                    // Prune contract: immediately after panes_changed every
-                    // stored observation belongs to a live pane.
+                    // Prune contract: after panes_changed every stored
+                    // observation belongs to a live pane, or holds the
+                    // one-manifest grace (its first absence — the break-pane
+                    // flash window). A graced pane is by construction pruned
+                    // on the NEXT panes_changed unless it reappears, so the
+                    // grace set can never accumulate stale entries.
+                    let graced = st.graced_pane_ids();
                     for (id, _) in st.status_store().observations() {
                         prop_assert!(
-                            live.contains(&id),
-                            "status store kept observation for non-live pane {id}"
+                            live.contains(&id) || graced.contains(&id),
+                            "status store kept observation for non-live, non-graced pane {id}"
                         );
                     }
                     for (id, _) in st.command_store().observations() {
                         prop_assert!(
-                            live.contains(&id),
-                            "command store kept observation for non-live pane {id}"
+                            live.contains(&id) || graced.contains(&id),
+                            "command store kept observation for non-live, non-graced pane {id}"
+                        );
+                    }
+                    // And the grace itself only ever covers non-live panes.
+                    for id in &graced {
+                        prop_assert!(
+                            !live.contains(id),
+                            "pane {id} is live but still marked graced"
                         );
                     }
                 }
@@ -1562,7 +1631,12 @@ fn prune_ledgers_completions_with_the_pre_close_tab_name() {
         theme: None,
         exits: Vec::new(),
     };
-    radar.panes_changed(update, 2, 999, config::NamingMode::Off);
+    // Two updates: the first absence is the break-pane grace manifest; the
+    // second confirms the close and prunes. By then the pane is long gone
+    // from the topology, so the ledger rides the tab identity captured at
+    // first absence.
+    radar.panes_changed(update.clone(), 2, 999, config::NamingMode::Off);
+    radar.panes_changed(update, 3, 999, config::NamingMode::Off);
 
     let lines = radar.ledger_lines();
     assert_eq!(lines.len(), 1);
@@ -1656,7 +1730,9 @@ fn shadowed_command_completion_never_ledgers() {
         theme: None,
         exits: Vec::new(),
     };
-    radar.panes_changed(update, confirm_tick + DONE_TTL_TICKS + 1, 999, config::NamingMode::Off);
+    // Second absence confirms the close (the first is the break-pane grace).
+    radar.panes_changed(update.clone(), confirm_tick + DONE_TTL_TICKS + 1, 999, config::NamingMode::Off);
+    radar.panes_changed(update, confirm_tick + DONE_TTL_TICKS + 2, 999, config::NamingMode::Off);
 
     let lines = radar.ledger_lines();
     assert_eq!(lines.len(), 1, "exactly one ledger entry — the status completion");

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -517,15 +517,24 @@ fn panes_changed_prunes_focuses_and_persists_snapshot() {
         }],
     );
 
+    let first = runtime.panes_changed(PaneUpdate {
+        tab_panes: tab_panes.clone(),
+        live: live.clone(),
+        theme: Some(theme::DerivedColors::default()),
+        exits: vec![(10, Some(0))],
+    });
+    assert!(first.render);
+    assert_eq!(runtime.radar.last_focused(), Some(10));
+    // Panes 11/12 are absent for the first time — the break-pane grace keeps
+    // their observations for one manifest; the second absence prunes.
     let outcome = runtime.panes_changed(PaneUpdate {
         tab_panes,
         live,
         theme: Some(theme::DerivedColors::default()),
-        exits: vec![(10, Some(0))],
+        exits: Vec::new(),
     });
 
     assert!(outcome.render);
-    assert_eq!(runtime.radar.last_focused(), Some(10));
     assert!(runtime.radar.status_store().get(11).is_none());
     assert!(runtime.radar.command_store().get(12).is_none());
     assert!(outcome
@@ -719,14 +728,17 @@ fn no_tabs_with_history_renders_ledger_not_scanning() {
         .status_mut()
         .apply(payload_for(5, Status::Done), 1, 1_000);
 
-    // The pane closes with a still-lit Done: pruning hands it to the
+    // The pane closes with a still-lit Done: the second absence confirms the
+    // close (the first is the break-pane grace) and pruning hands it to the
     // ledger (spec §4.2).
-    runtime.panes_changed(PaneUpdate {
-        tab_panes: HashMap::new(),
-        live: HashSet::new(),
-        theme: None,
-        exits: Vec::new(),
-    });
+    for _ in 0..2 {
+        runtime.panes_changed(PaneUpdate {
+            tab_panes: HashMap::new(),
+            live: HashSet::new(),
+            theme: None,
+            exits: Vec::new(),
+        });
+    }
     assert!(!runtime.radar.ledger_is_empty(), "setup: ledger must be seeded");
 
     // The tab itself closes too — zero tabs, but history remains.

--- a/crates/plugin/src/status_store.rs
+++ b/crates/plugin/src/status_store.rs
@@ -221,12 +221,12 @@ impl StatusStore {
         Some(old)
     }
 
-    /// Prune panes no longer live, returning the dropped completions
-    /// (`Done`/`Error` — `ObservationStore::prune`'s contract): a pane closing
-    /// with an unreceded completion still on it is a recede edge for the
-    /// ledger; non-completion drops (Running, Idle, Pending) carry nothing to
-    /// ledger.
-    pub fn prune(&mut self, live: &HashSet<u32>) -> Vec<(u32, TrackedObservation)> {
+    /// Prune panes no longer live, returning the dropped completions plus
+    /// whether anything was removed (`Done`/`Error` — `ObservationStore::
+    /// prune`'s contract): a pane closing with an unreceded completion still
+    /// on it is a recede edge for the ledger; non-completion drops (Running,
+    /// Idle, Pending) carry nothing to ledger but must still be persisted.
+    pub fn prune(&mut self, live: &HashSet<u32>) -> (Vec<(u32, TrackedObservation)>, bool) {
         self.suspect_running.retain(|id, _| live.contains(id));
         self.store.prune(live)
     }
@@ -435,10 +435,11 @@ mod tests {
         s.apply(payload(2, Status::Done), 1, 100);
         s.apply(payload(3, Status::Idle), 1, 0); // dropped, but not a completion
         let live: HashSet<u32> = HashSet::new();
-        let dropped = s.prune(&live);
+        let (dropped, removed_any) = s.prune(&live);
         assert_eq!(dropped.len(), 1);
         assert_eq!(dropped[0].0, 2);
         assert_eq!(dropped[0].1.status, Status::Done);
+        assert!(removed_any, "non-completion drops still report removal");
     }
 
     #[test]

--- a/crates/plugin/src/status_store.rs
+++ b/crates/plugin/src/status_store.rs
@@ -118,6 +118,14 @@ impl StatusStore {
     /// pane id, for determinism). An evicted completion is dropped silently —
     /// no ledger hand-off — because the cap only ever bites under a
     /// misbehaving producer, where ledgering its flood would be its own DoS.
+    ///
+    /// Known divergence: the shared snapshot keeps the evicted entry. The
+    /// evicted pane is still live, so `snapshot::to_json`'s existing-entry
+    /// filter never scrubs it, and no persist from here could either — the
+    /// merge has no way to say "deliberately forgotten" for a live pane. The
+    /// pane's next broadcast overwrites it; until then a freshly spawned
+    /// instance may seed one flood-stale row. Accepted: reaching this path at
+    /// all means a producer is flooding past the cap.
     fn evict_over_cap(&mut self) {
         while self.store.observations().count() > MAX_TRACKED_PANES {
             let Some(oldest) = self
@@ -221,12 +229,13 @@ impl StatusStore {
         Some(old)
     }
 
-    /// Prune panes no longer live, returning the dropped completions plus
-    /// whether anything was removed (`Done`/`Error` — `ObservationStore::
-    /// prune`'s contract): a pane closing with an unreceded completion still
-    /// on it is a recede edge for the ledger; non-completion drops (Running,
-    /// Idle, Pending) carry nothing to ledger but must still be persisted.
-    pub fn prune(&mut self, live: &HashSet<u32>) -> (Vec<(u32, TrackedObservation)>, bool) {
+    /// Prune panes no longer live, returning every dropped observation
+    /// (`ObservationStore::prune`'s contract): the caller reads emptiness as
+    /// "persisted state changed" and the ledger sink filters to the
+    /// completions (a pane closing with an unreceded Done/Error is a recede
+    /// edge; a dropped Running/Idle/Pending ledgers nothing but must still
+    /// reach the snapshot).
+    pub fn prune(&mut self, live: &HashSet<u32>) -> Vec<(u32, TrackedObservation)> {
         self.suspect_running.retain(|id, _| live.contains(id));
         self.store.prune(live)
     }
@@ -429,17 +438,20 @@ mod tests {
     }
 
     #[test]
-    fn prune_returns_only_dropped_completions() {
+    fn prune_returns_every_drop_not_just_completions() {
         let mut s = StatusStore::default();
-        s.apply(payload(1, Status::Running), 1, 0); // dropped, but not a completion
+        s.apply(payload(1, Status::Running), 1, 0);
         s.apply(payload(2, Status::Done), 1, 100);
-        s.apply(payload(3, Status::Idle), 1, 0); // dropped, but not a completion
+        s.apply(payload(3, Status::Idle), 1, 0);
         let live: HashSet<u32> = HashSet::new();
-        let (dropped, removed_any) = s.prune(&live);
-        assert_eq!(dropped.len(), 1);
-        assert_eq!(dropped[0].0, 2);
-        assert_eq!(dropped[0].1.status, Status::Done);
-        assert!(removed_any, "non-completion drops still report removal");
+        let mut dropped = s.prune(&live);
+        dropped.sort_by_key(|(id, _)| *id);
+        // All three come back out: emptiness is the caller's persist signal,
+        // and the ledger filters to the completion (pane 2) itself.
+        assert_eq!(dropped.len(), 3);
+        assert_eq!((dropped[0].0, dropped[0].1.status), (1, Status::Running));
+        assert_eq!((dropped[1].0, dropped[1].1.status), (2, Status::Done));
+        assert_eq!((dropped[2].0, dropped[2].1.status), (3, Status::Idle));
     }
 
     #[test]

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,11 @@
           # include_str!'d by the CLI's `run` command (crates/cli/src/run.rs).
           || (pkgs.lib.hasInfix "/crates/cli/src/run_assets/" path)
           # include_str!'d by the example-layout guard test (crates/cli/src/layout.rs).
-          || (pkgs.lib.hasSuffix "/examples/radar-sidebar.kdl" path);
+          || (pkgs.lib.hasSuffix "/examples/radar-sidebar.kdl" path)
+          # include_str!'d by the plugin (config.rs, control.rs docs guard tests).
+          || (pkgs.lib.hasSuffix "/docs/configuration.md" path)
+          # include_str!'d by the plugin's producer-script guard test (lib.rs).
+          || (pkgs.lib.hasSuffix "/plugins/zj-radar-claude/scripts/notify.sh" path);
       };
       commonArgs = {
         inherit src;


### PR DESCRIPTION
## Symptom

Run an instrumented agent (Claude Code) to `pending`, then break its pane out to a new tab (`BreakPaneRight`/`BreakPaneLeft`): the rail in the new tab shows the old pending question forever, and later status broadcasts never clear it.

## Root cause

Three links, each verified in source:

1. **A transient orphan manifest deletes live status.** Zellij's break-pane family reports session state *while the pane is extracted and in no tab* (zellij 0.44.3 `screen.rs`: `break_pane_to_new_tab` runs `extract_pane` → `switch_active_tab` → `log_and_report_session_state()` → only then `add_tiled_pane`). Every rail instance receives a `PaneUpdate` whose manifest omits the moved pane, and `RadarState::panes_changed` prunes its observations.
2. **The drop never persists.** `persist_snapshot` was gated on `displaced_any || pruned_any`, where both only counted *completions* (`ObservationStore::prune` filters to Done/Error). A dropped **Pending/Running** cleared every live store while the shared snapshot (`/cache/zj-radar.<pid>.json`) kept carrying it — `snapshot::to_json`'s merge only discards entries for dead panes, and the moved pane is alive, so every read-merge-write carries the stale entry forward.
3. **Break-pane spawns exactly the instance that resurrects it.** The new tab is built from the default layout, so it gets a fresh rail instance that seeds from the stale snapshot at `load()` — rendering a pending row no live store holds, with nothing keyed to overwrite it.

This is the one clear edge that wasn't shared, breaking the convergence property CONTEXT.md documents (pending clears only via broadcast, prompt-return, or prune — the prune edge diverged between live stores and the snapshot).

## Fix

`ObservationStore::prune` now returns the dropped completions **plus whether anything was removed**; `StatusStore::prune`/`CommandStore::prune` forward it, and `panes_changed` persists on any removal. Ledger semantics are untouched — callers still ledger only the returned completions, so plain topology churn still doesn't persist.

## Also in this PR: unbreaking the hermetic CI job (pre-existing on main)

The first push turned the `hermetic` job red — investigation showed it's **broken on main, not by this PR**: the job only runs on PRs and nightly schedules (`if: schedule || base_ref == main`), so pushes to main look green while nightlies have failed since at least Jul 3 — the Jul 7 nightly (run 28855989115, on this PR's exact merge base a667d6f) fails identically. Two deterministic causes, both fixed in the second commit:

- **`flake.nix` source filter** never whitelisted `docs/configuration.md` and `plugins/zj-radar-claude/scripts/notify.sh`, which newer plugin code `include_str!`s — the hermetic workspace clippy/test derivations couldn't compile at all.
- **CLI test shims** used `#!/usr/bin/env bash`; the Nix Linux sandbox has no `/usr/bin/env`, every shim silently failed to exec, and `notify` treats spawn failure as a no-op — `cli_notify` failed with zero broadcasts in 0.01s (deterministic, not the timing flake: `tests/cli.rs`, whose shim is `#!/bin/sh`, passed in the same run). Shims are now POSIX sh, with `add_recorder`'s bash-only newline substitution replaced by `tr`.

## Tests

- New regression test `panes_changed_persists_when_a_prune_drops_a_non_completion` (fails on main, passes here).
- `panes_changed_persists_only_on_exit_displace_or_prune` comment updated — it previously pinned the buggy gate; its churn-must-not-persist assertions are unchanged.
- Store-level tests updated for the new return contract (`prune_returns_only_dropped_completions` now also asserts the removal report).

`just ci` passes locally (host suite 801 tests, clippy `-D warnings`, wasm build, 60 bats tests); no local nix, so the flake-filter fix gets its verdict from this PR's hermetic run. One unrelated flake observed under full parallel load: `hung_zellij_pipe_is_killed_at_the_send_deadline` (shim recording races the 1s pipe deadline; passes consistently in isolation) — happy to file separately.
