### PR TITLE
feat: cross-session radar — per-session badge + session cycling (#4)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -278,3 +278,44 @@ low-level primitive detectors (`notify_is_ours`, `has_unmanaged_radar_alias`,
 `crates/cli/src/setup/detect.rs`, a neutral module that both `analyze` and `edit`
 depend on. The legacy-notify vs hooks choice is a flag the consumer projects on,
 never a fact.
+
+## Cross-session presence
+
+How one session's rail learns another session's counts, without ever asking
+Zellij "what sessions exist." Each session's plugin writes its own tiny
+`zj-radar.presence.<zellij_pid>.json` (`{session_name, running, attention,
+attention_tab_position, updated_epoch_s}`) into the same plugin-URL-scoped
+`/cache` root snapshots already use (`session_files.rs`); peers read that
+directory back on Fast-cadence timer fires only (see `Cadence`, above) and
+feed the parsed rows into `Sessions` (`sessions.rs`) — pure state, no
+`zellij-tile`, that derives the cross-session badge on demand from
+`peers`/`own`, exactly like `RadarState` never caches a derived value.
+
+**Liveness is the mtime, not a roster.** An earlier iteration subscribed to
+`Event::SessionUpdate` and cross-checked a peer list against presence files.
+E2E against real Zellij 0.44.3 showed `SessionUpdate` only delivers peers
+after some plugin has called the blocking `get_session_list()` host
+function — which nothing in this stack does, and which would violate the
+push-driven doctrine (`CONTRIBUTING.md`; `smart-tabs-postmortem.md`) if it
+did. `SessionUpdate` was dropped entirely (task-8b): liveness is now judged
+purely by a presence file's mtime (`PRESENCE_LIVE_TTL`, 180s) at read time —
+a stale file's row is skipped, never deleted by the reader; a separate 6h
+sweep at plugin `load()` deletes genuine debris. A session with nothing new
+to report still heartbeats — an unconditional `PersistPresence` on every
+Slow (60s) tick, bypassing the normal content-edge gate — so an idle-but-alive
+session's file never ages past the TTL and vanishes from peers' badges. The
+session's own name arrives the same push-style way its liveness does:
+`Event::ModeUpdate`'s `ModeInfo.session_name`, not a session-list lookup.
+
+**Badge and cycling share one order.** `Sessions::badge()` (what the rail
+shows) and `Sessions::cycle()`/`tick()` (what `session-next`/`session-prev`
+step through and idle-commit) both derive from the same `ordered()`:
+current session first, then attention-bearing peers by name, then the rest
+by name — so "what's shown" and "what Alt+[/] steps through" can never
+disagree. The pending cycle selection is tracked by session *name*, never a
+list position, so peers joining or leaving mid-cycle can't silently retarget
+it (the same identity-over-position lesson `RailTarget` already applies to
+clicks). The badge renders zero lines with only one session known — the
+feature is invisible until there's genuinely something cross-session to
+show — and degrades the same way persistence does: no writable shared
+`/cache` root means no presence file and no badge, nothing else affected.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -291,31 +291,46 @@ feed the parsed rows into `Sessions` (`sessions.rs`) — pure state, no
 `zellij-tile`, that derives the cross-session badge on demand from
 `peers`/`own`, exactly like `RadarState` never caches a derived value.
 
-**Liveness is the mtime, not a roster.** An earlier iteration subscribed to
+**Liveness is the mtime, not a roster — and a remembered session never
+vanishes (task-14).** An earlier iteration subscribed to
 `Event::SessionUpdate` and cross-checked a peer list against presence files.
 E2E against real Zellij 0.44.3 showed `SessionUpdate` only delivers peers
 after some plugin has called the blocking `get_session_list()` host
 function — which nothing in this stack does, and which would violate the
 push-driven doctrine (`CONTRIBUTING.md`; `smart-tabs-postmortem.md`) if it
-did. `SessionUpdate` was dropped entirely (task-8b): liveness is now judged
-purely by a presence file's mtime (`PRESENCE_LIVE_TTL`, 180s) at read time —
-a stale file's row is skipped, never deleted by the reader; a separate 6h
-sweep at plugin `load()` deletes genuine debris. A session with nothing new
-to report still heartbeats — an unconditional `PersistPresence` on every
-Slow (60s) tick, bypassing the normal content-edge gate — so an idle-but-alive
-session's file never ages past the TTL and vanishes from peers' badges. The
-session's own name arrives the same push-style way its liveness does:
-`Event::ModeUpdate`'s `ModeInfo.session_name`, not a session-list lookup.
+did. `SessionUpdate` was dropped entirely (task-8b): liveness is judged from
+a presence file's mtime. Task-8b had the READ path (`read_peer_presences`)
+drop a peer once its mtime passed a TTL; task-14 changed that on user
+request — a session the badge has ever shown must never silently disappear
+from it. `read_peer_presences` now returns every peer file it finds,
+unconditionally, paired with that file's mtime age; only a much longer 6h
+open-time sweep at plugin `load()` ever actually deletes one (genuine
+debris). `Sessions` (`sessions.rs`) turns that age into a per-entry
+fresh/stale state (`STALE_AFTER_SECS`, 90s — 50% margin over the 60s
+heartbeat): stale entries dim on the badge and are unreachable via
+`session-next`/`session-prev` (switching onto a likely-dead session would
+have Zellij resurrect it as an empty zombie), but stay on screen. A session
+with nothing new to report still heartbeats — an unconditional
+`PersistPresence` on every Slow (60s) tick, bypassing the normal
+content-edge gate — so an idle-but-alive session's file rarely even crosses
+into stale. The session's own name arrives the same push-style way its
+liveness does: `Event::ModeUpdate`'s `ModeInfo.session_name`, not a
+session-list lookup.
 
 **Badge and cycling share one order.** `Sessions::badge()` (what the rail
 shows) and `Sessions::cycle()`/`tick()` (what `session-next`/`session-prev`
 step through and idle-commit) both derive from the same `ordered()`:
-current session first, then attention-bearing peers by name, then the rest
-by name — so "what's shown" and "what Alt+[/] steps through" can never
-disagree. The pending cycle selection is tracked by session *name*, never a
-list position, so peers joining or leaving mid-cycle can't silently retarget
-it (the same identity-over-position lesson `RailTarget` already applies to
-clicks). The badge renders zero lines with only one session known — the
-feature is invisible until there's genuinely something cross-session to
-show — and degrades the same way persistence does: no writable shared
-`/cache` root means no presence file and no badge, nothing else affected.
+current session first, then fresh attention-bearing peers by name, then the
+rest of the fresh peers by name, then every stale peer by name — a stale
+peer's attention count isn't actionable, so staleness outranks attention for
+ordering. `cycle()` filters stale entries out of its target set entirely.
+The pending cycle selection is tracked by session *name*, never a list
+position, so peers joining or leaving mid-cycle can't silently retarget it
+(the same identity-over-position lesson `RailTarget` already applies to
+clicks) — and a selection that goes stale between the tap and the
+idle-commit is dropped the same way a vanished one is. The badge renders
+zero lines with only one session known — the feature is invisible until
+there's genuinely something cross-session to show, and a lone fresh own
+entry plus only stale peers still counts as "something" — and degrades the
+same way persistence does: no writable shared `/cache` root means no
+presence file and no badge, nothing else affected.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ tab.
 <p align="center">
   <a href="#quick-start">Quick start</a> ·
   <a href="#how-it-works">How it works</a> ·
+  <a href="#cross-session-badge">Cross-session badge</a> ·
   <a href="#how-is-this-different">How is this different?</a> ·
   <a href="#configuration">Configuration</a> ·
   <a href="#producers">Producers</a>
@@ -51,6 +52,9 @@ wrapping your agents. It's a status rail for the session you already run.
 - **Push-driven** updates via `zellij pipe`; no pane polling, no blocking host queries.
 - Works with **Claude Code** today, **Codex** via the native CLI, and any
   [custom producer](https://github.com/marktoda/zj-radar/blob/main/docs/producers.md#writing-your-own-producer) that can send JSON.
+- Running more than one Zellij session? A **cross-session badge** shows every
+  other session's running/attention counts, with click-to-switch and a
+  `session-next`/`session-prev` cycle — see below.
 
 ## Quick start
 
@@ -112,6 +116,28 @@ The wire format is a single versioned JSON payload (`zj_radar.status.v1`), so a
 the `zj-radar notify` CLI for Codex, or your own script. The sidebar pins itself
 into your tab templates (the same mechanism Zellij's own status bar uses), so it
 appears in every tab and survives swap-layout cycling.
+
+## Cross-session badge
+
+Run zj-radar in more than one Zellij session on the same machine (e.g. one
+per project) and each session's rail quietly publishes its own counts for
+the others to see — no setup needed. Once a second session is live, every
+rail grows a line per session: current session first, then any session that
+needs your attention, then the rest — name plus running/attention counts.
+With just one session running, the badge renders nothing; the feature stays
+invisible until there's genuinely something cross-session to show.
+
+Click a peer's line to switch straight to that session (landing on its
+attention tab, if it has one). Or cycle the highlight with `session-next` /
+`session-prev` on the `zj_radar.cmd.v1` pipe (unbound by default — see
+[binding keys to commands](https://github.com/marktoda/zj-radar/blob/main/docs/configuration.md#binding-keys-to-commands)):
+each tap moves the highlight, wrapping, and the selection commits about a
+second after your last tap — or cancels if you land back on your own
+session.
+
+This rides the same shared `/cache` mount the sidebar already uses for
+snapshot persistence; if no writable shared root is found, the badge simply
+never appears and nothing else about the sidebar is affected.
 
 ## How is this different?
 
@@ -183,6 +209,8 @@ schema, and a copy-paste smoke test.
 
 - ✅ **Sidebar plugin** — tab list, click-to-switch, per-tab agent aggregation,
   overflow folding, theme-derived card surfaces, runtime config.
+- ✅ **Cross-session badge** — see [Cross-session badge](#cross-session-badge)
+  above; click-to-switch and `session-next`/`session-prev` cycling.
 - ✅ **Claude Code producer** — ships as a Claude plugin (`plugins/zj-radar-claude`).
 - ✅ **`zj-radar` CLI** — native, jq-free `notify` (Claude + Codex) and
   conflict-aware `setup`; see [`docs/producers.md`](https://github.com/marktoda/zj-radar/blob/main/docs/producers.md#codex-and-the-native-cli).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 A native [Zellij](https://zellij.dev) **sidebar** that shows live AI-agent
 status for every tab — *working*, *waiting for you*, *done*, or *error* — with
 repo·branch, elapsed time, and the last message. Click a row to jump to that
-tab.
+tab; right-click to acknowledge — a pane still flagged "needs you" after
+you've already seen it, or a dead peer session (details below).
 
 <p align="center">
   <a href="https://github.com/marktoda/zj-radar/actions/workflows/ci.yml">
@@ -145,6 +146,27 @@ next heartbeat simply brings it back, fresh.
 This rides the same shared `/cache` mount the sidebar already uses for
 snapshot persistence; if no writable shared root is found, the badge simply
 never appears and nothing else about the sidebar is affected.
+
+### Mouse gestures
+
+The rail follows one rule everywhere: **left-click navigates, right-click
+acknowledges.** Left-click always just switches — to a tab, a pane, or (as
+above) a peer session, landing on its attention tab. Right-click means "I've
+seen this, stop flagging it" and does one of two things depending on the row:
+
+- **A dimmed peer session** (above) — dismiss it from the badge; alive-but-quiet
+  sessions simply reappear on their next heartbeat.
+- **A pane or tab row still flagged `◆ needs you`** — acknowledge it. The row
+  downgrades to `done` for every tab's copy of the rail, not just this one:
+  the click never mutates state locally, it re-broadcasts a `done` update over
+  `zj_radar.status.v1` the same way a real agent hook would, so every
+  instance converges through the normal status pipe. This is the fix for an
+  agent that ends an otherwise-finished turn with a courtesy question ("want
+  me to also...?") — a genuinely blocking question still clears the usual way,
+  by you typing a reply.
+
+Right-clicking anything else — a fresh peer, your own session's line, a row
+with nothing pending — is a no-op.
 
 ## How is this different?
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ each tap moves the highlight, wrapping, and the selection commits about a
 second after your last tap — or cancels if you land back on your own
 session.
 
+A session that stops heartbeating dims rather than disappearing, so a
+crashed machine or killed server never silently drops off your radar.
+Right-click a dimmed entry to dismiss it immediately — the manual
+complement to the automatic sweep, for a session you already know is dead.
+Dismissing is never destructive: if the session turns out to be alive, its
+next heartbeat simply brings it back, fresh.
+
 This rides the same shared `/cache` mount the sidebar already uses for
 snapshot persistence; if no writable shared root is found, the badge simply
 never appears and nothing else about the sidebar is affected.

--- a/crates/cli/src/notify.rs
+++ b/crates/cli/src/notify.rs
@@ -255,6 +255,7 @@ fn broadcast(pane_id: u32, update: AgentUpdate, source: &str, dry_run: bool) {
         msg,
         task,
         source: source.to_string(),
+        ack: false,
     });
 
     if dry_run {

--- a/crates/core/src/observation.rs
+++ b/crates/core/src/observation.rs
@@ -67,6 +67,14 @@ pub struct TrackedObservation {
     /// wait tag; rides the snapshot so rehydrated rows keep the true wait.
     #[serde(default)]
     pub pending_epoch_s: Option<u64>,
+    /// The user has already seen this status (the payload rode in with
+    /// `ack: true` — the rail's right-click acknowledge). The notifier skips
+    /// acknowledged observations outright; everything else treats them like
+    /// any other status. Overwritten fresh on every intake, so the exemption
+    /// lasts exactly as long as the acknowledged status itself. Serde-defaulted
+    /// so pre-ack snapshots still load.
+    #[serde(default)]
+    pub acknowledged: bool,
 }
 
 impl TrackedObservation {
@@ -88,6 +96,7 @@ impl TrackedObservation {
             exit_code: None,
             completed_epoch_s: None,
             pending_epoch_s: None,
+            acknowledged: false,
         }
     }
 
@@ -199,6 +208,7 @@ mod tests {
             exit_code: Some(1),
             completed_epoch_s: None,
             pending_epoch_s: None,
+            acknowledged: false,
         }
     }
 

--- a/crates/core/src/payload.rs
+++ b/crates/core/src/payload.rs
@@ -115,6 +115,12 @@ pub struct StatusPayload {
     /// through `Kind::from_source`, so unknown sources still render (as
     /// `Other`). Optional; sanitized and capped at [`MAX_SOURCE_CHARS`].
     pub source: String,
+    /// The user has already seen this status: converge state as usual, but the
+    /// notifier must stay silent for it. Set by the rail's right-click
+    /// acknowledge (whose whole point is "stop flagging this" — its synthetic
+    /// `done` echo must not itself pop a notification); producers reporting
+    /// real events leave it absent. Optional; absent on the wire when `false`.
+    pub ack: bool,
 }
 
 #[derive(Deserialize)]
@@ -141,6 +147,8 @@ struct Raw {
     task: String,
     #[serde(default)]
     source: String,
+    #[serde(default)]
+    ack: bool,
 }
 // Note: the retired clear-on-focus hint key is silently ignored (serde drops
 // unknown fields) — no longer consumed, kept tolerated on the wire for back-compat
@@ -305,6 +313,7 @@ pub fn parse(raw: &str) -> Option<StatusPayload> {
         msg: sanitize(&r.msg, MAX_MSG_CHARS),
         task: sanitize(&r.task, MAX_TASK_CHARS),
         source: sanitize(&r.source, MAX_SOURCE_CHARS),
+        ack: r.ack,
     })
 }
 
@@ -321,6 +330,14 @@ struct Wire<'a> {
     branch: &'a str,
     msg: &'a str,
     task: &'a str,
+    // Absent when false — the overwhelmingly common case (every real producer
+    // event) — so the pinned wire bytes and existing consumers see no change.
+    #[serde(skip_serializing_if = "is_false")]
+    ack: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !b
 }
 
 #[derive(serde::Serialize)]
@@ -365,6 +382,7 @@ pub fn to_wire(p: &StatusPayload) -> String {
         branch: cap_chars(&p.branch, MAX_WIRE_FIELD_CHARS),
         msg: cap_chars(&p.msg, MAX_WIRE_FIELD_CHARS),
         task: cap_chars(&p.task, MAX_WIRE_FIELD_CHARS),
+        ack: p.ack,
     })
     .expect("status payload of plain fields always serializes")
 }
@@ -591,6 +609,7 @@ mod tests {
             msg: "editing x.rs".into(),
             task: "fix flaky e2e".into(),
             source: "claude".into(),
+            ack: false,
         });
         let got = parse(&json).expect("to_wire output must parse");
         assert_eq!(got.task, "fix flaky e2e");
@@ -619,6 +638,7 @@ mod tests {
             msg: "running tests".into(),
             task: "".into(),
             source: "claude".into(),
+            ack: false,
         });
         let got = parse(&json).expect("to_wire output must parse");
         assert_eq!(got.pane_id, 12);
@@ -644,11 +664,24 @@ mod tests {
             msg: "running tests".into(),
             task: "fix flaky e2e".into(),
             source: "claude".into(),
+            ack: false,
         });
         assert_eq!(
             json,
             r#"{"v":1,"source":"claude","pane":{"type":"terminal","id":12},"status":"running","repo":"pinky","branch":"fix/x","msg":"running tests","task":"fix flaky e2e"}"#
         );
+    }
+
+    #[test]
+    fn ack_is_absent_on_the_wire_unless_true_and_round_trips() {
+        // False (every real producer event) emits no key at all — the pinned
+        // bytes above prove existing payloads are unchanged. True rides the
+        // wire and survives parse; absent defaults false (old producers).
+        let acked = to_wire(&StatusPayload { pane_id: 3, status: Status::Done, ack: true, ..Default::default() });
+        assert!(acked.ends_with(r#""ack":true}"#), "ack rides the wire when set: {acked}");
+        assert!(parse(&acked).unwrap().ack);
+        let got = p(r#"{"pane":{"type":"terminal","id":3},"status":"done"}"#).unwrap();
+        assert!(!got.ack, "absent ack defaults false");
     }
 
     #[test]
@@ -696,6 +729,7 @@ mod tests {
             msg in "[a-zA-Z0-9 ]{0,40}",
             task in "[a-zA-Z0-9 ]{0,40}",
             source in "[a-z]{0,12}",
+            ack in proptest::bool::ANY,
         ) {
             // to_wire and parse must be inverses: a round-trip through the wire
             // format must preserve EVERY field parse surfaces — across all statuses,
@@ -703,7 +737,7 @@ mod tests {
             // silently dropped). Only printable ASCII within each field's cap is
             // generated, so sanitize does not alter any field and whole-struct
             // equality is the exact inverse law.
-            let p = StatusPayload { pane_id: pane, status, repo, branch, msg, task, source };
+            let p = StatusPayload { pane_id: pane, status, repo, branch, msg, task, source, ack };
             let got = parse(&to_wire(&p)).expect("our own wire output must parse");
             prop_assert_eq!(got, p);
         }

--- a/crates/plugin/src/control.rs
+++ b/crates/plugin/src/control.rs
@@ -14,6 +14,8 @@ pub(crate) const CMD_PIPE: &str = "zj_radar.cmd.v1";
 pub(crate) enum Verb {
     AttentionNext,
     AttentionPrev,
+    SessionNext,
+    SessionPrev,
 }
 
 /// Parse a bare verb string. Trims surrounding whitespace; case-sensitive
@@ -22,6 +24,8 @@ pub(crate) fn parse(s: &str) -> Option<Verb> {
     match s.trim() {
         "attention-next" => Some(Verb::AttentionNext),
         "attention-prev" => Some(Verb::AttentionPrev),
+        "session-next"   => Some(Verb::SessionNext),
+        "session-prev"   => Some(Verb::SessionPrev),
         _ => None,
     }
 }
@@ -41,6 +45,12 @@ mod tests {
         assert_eq!(parse(""), None);
         assert_eq!(parse("attention-top"), None);
         assert_eq!(parse("ATTENTION-NEXT"), None);
+    }
+
+    #[test]
+    fn session_cycle_verbs_parse() {
+        assert_eq!(parse("session-next"), Some(Verb::SessionNext));
+        assert_eq!(parse("session-prev"), Some(Verb::SessionPrev));
     }
 
     /// docs/configuration.md is where users copy their `MessagePlugin`

--- a/crates/plugin/src/ledger.rs
+++ b/crates/plugin/src/ledger.rs
@@ -218,6 +218,7 @@ mod tests {
             exit_code: None,
             completed_epoch_s,
             pending_epoch_s: None,
+            acknowledged: false,
         }
     }
 

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -249,6 +249,30 @@ impl State {
                             .is_some_and(|p| p.session_name == name)
                     });
                 }
+                Effect::BroadcastStatus { payload } => {
+                    // Same delivery every CLI producer already uses
+                    // (`crates/cli/src/notify.rs`'s `broadcast`): `zellij
+                    // pipe --name zj_radar.status.v1 -- <payload>`, spawned
+                    // via `run_command` (the `RunCommands` grant this plugin
+                    // already requests). The alternative considered —
+                    // zellij-tile's `pipe_message_to_plugin` — was rejected:
+                    // its `MessageToPlugin` addresses ONE destination plugin
+                    // (`destination_plugin_id`/`plugin_url`; see
+                    // zellij-utils 0.44.3's `data.rs`), not every instance
+                    // subscribed to a named pipe, so it can't fan out to
+                    // every tab's rail the way this gesture's convergence
+                    // requires. `zellij pipe` already does exactly that —
+                    // it's the same host route every producer's broadcast
+                    // takes, proven in production — and reaches THIS
+                    // instance too, which is the whole point: the click
+                    // itself mutates nothing (`Effect::BroadcastStatus`'s
+                    // doc), so this instance's own convergence rides the
+                    // echo like everyone else's.
+                    run_command(
+                        &["zellij", "pipe", "--name", PIPE_NAME, "--", &payload],
+                        std::collections::BTreeMap::new(),
+                    );
+                }
             }
         }
         render

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -268,6 +268,16 @@ impl State {
                     // itself mutates nothing (`Effect::BroadcastStatus`'s
                     // doc), so this instance's own convergence rides the
                     // echo like everyone else's.
+                    //
+                    // ACCEPTED RISK: The spawned `zellij pipe` blocks until
+                    // every rail instance consumes the message; unlike the
+                    // CLI producer's broadcast (`crates/cli/src/notify.rs`),
+                    // the plugin's `run_command` returns no handle, so no
+                    // deadline/kill is possible — a wedged receiver (e.g.
+                    // stuck at a permission prompt) would orphan the process.
+                    // Accepted: the trigger is a human-paced right-click,
+                    // orders of magnitude rarer than producer hooks, and
+                    // fan-out is bounded by one tab's pending panes.
                     run_command(
                         &["zellij", "pipe", "--name", PIPE_NAME, "--", &payload],
                         std::collections::BTreeMap::new(),

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -64,8 +64,6 @@ use runtime::Effect;
 #[cfg(target_arch = "wasm32")]
 use session_files::SessionFileIds;
 #[cfg(target_arch = "wasm32")]
-use sessions::SessionLite;
-#[cfg(target_arch = "wasm32")]
 use std::collections::BTreeMap;
 #[cfg(target_arch = "wasm32")]
 use zellij_tile::prelude::*;
@@ -274,7 +272,21 @@ impl ZellijPlugin for State {
             EventType::Timer,
             EventType::Mouse,
             EventType::PermissionRequestResult,
-            EventType::SessionUpdate,
+            // Replaces `SessionUpdate`: stock zj-radar never calls the
+            // blocking `get_session_list()` host fn that's the ONLY thing
+            // that repopulates `SessionUpdate`'s peer list in zellij 0.44.3
+            // (task-8-report.md's root-cause dive) — only Zellij's own
+            // session-manager plugin does, so a user without it open would
+            // see an empty cross-session badge forever. `ModeUpdate` fires
+            // automatically right after this plugin loads (Zellij's
+            // `RequestStateUpdateForPlugins` → `Tab::update_input_modes`,
+            // unconditional on every successful plugin load — no polling,
+            // no other plugin required) and carries `ModeInfo.session_name`,
+            // which is all this plugin ever needed from `SessionUpdate` in
+            // the first place; liveness itself now comes from the presence
+            // files' own mtimes (`session_files::PRESENCE_LIVE_TTL`), not
+            // from a Zellij-reported peer list at all.
+            EventType::ModeUpdate,
         ]);
         // Seed from the shared snapshot so a tab opened after agents were already
         // running shows their real status instead of a blank (all-idle) rail.
@@ -365,12 +377,8 @@ impl ZellijPlugin for State {
                 let outcome = self.runtime.permission_result(granted);
                 self.handle_outcome(outcome)
             }
-            Event::SessionUpdate(sessions, _resurrectable) => {
-                let live = sessions
-                    .into_iter()
-                    .map(|s| SessionLite { name: s.name, is_current: s.is_current_session })
-                    .collect();
-                let outcome = self.runtime.session_update(live);
+            Event::ModeUpdate(mode_info) => {
+                let outcome = self.runtime.session_name_changed(mode_info.session_name);
                 self.handle_outcome(outcome)
             }
             Event::CwdChanged(pane_id, path, _clients) => {

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -238,6 +238,17 @@ impl State {
                     Some(pos) => switch_session_with_focus(&name, Some(pos), None),
                     None => switch_session(Some(&name)),
                 },
+                Effect::DismissPresence { name } => {
+                    // The predicate parses each candidate file the same way
+                    // the read path does (`Presence::parse`), so a dismiss
+                    // matches names exactly as leniently as the badge that
+                    // showed them — while `remove_presences_matching` itself
+                    // stays parse-agnostic (see its doc for the layering).
+                    self.session_files.remove_presences_matching(|json| {
+                        crate::presence::Presence::parse(json)
+                            .is_some_and(|p| p.session_name == name)
+                    });
+                }
             }
         }
         render
@@ -377,6 +388,10 @@ impl ZellijPlugin for State {
             }
             Event::Mouse(Mouse::LeftClick(line, _col)) => {
                 let outcome = self.runtime.mouse_click(line);
+                self.handle_outcome(outcome)
+            }
+            Event::Mouse(Mouse::RightClick(line, _col)) => {
+                let outcome = self.runtime.mouse_right_click(line);
                 self.handle_outcome(outcome)
             }
             Event::PermissionRequestResult(status) => {

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -33,6 +33,7 @@ mod config;
 mod control;
 mod ledger;
 mod notify_rules;
+mod presence;
 mod permission;
 mod radar_state;
 #[cfg(test)]

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -225,7 +225,12 @@ impl State {
                     self.session_files.persist_presence(&self.runtime.presence_json())
                 }
                 Effect::ReadPresences => {
-                    let raw = self.session_files.read_peer_presences();
+                    let raw = self
+                        .session_files
+                        .read_peer_presences()
+                        .into_iter()
+                        .map(|p| (p.json, p.age_secs))
+                        .collect();
                     let outcome = self.runtime.presences_changed(raw);
                     render |= self.handle_outcome(outcome);
                 }
@@ -284,8 +289,10 @@ impl ZellijPlugin for State {
             // no other plugin required) and carries `ModeInfo.session_name`,
             // which is all this plugin ever needed from `SessionUpdate` in
             // the first place; liveness itself now comes from the presence
-            // files' own mtimes (`session_files::PRESENCE_LIVE_TTL`), not
-            // from a Zellij-reported peer list at all.
+            // files' own mtimes, turned into a per-entry stale/fresh state
+            // (`sessions::STALE_AFTER_SECS`) rather than a Zellij-reported
+            // peer list — and, per task-14, a peer past that age dims
+            // rather than vanishing.
             EventType::ModeUpdate,
         ]);
         // Seed from the shared snapshot so a tab opened after agents were already

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -33,8 +33,8 @@ mod config;
 mod control;
 mod ledger;
 mod notify_rules;
-mod presence;
 mod permission;
+mod presence;
 mod radar_state;
 #[cfg(test)]
 mod reference_tests;

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -64,6 +64,8 @@ use runtime::Effect;
 #[cfg(target_arch = "wasm32")]
 use session_files::SessionFileIds;
 #[cfg(target_arch = "wasm32")]
+use sessions::SessionLite;
+#[cfg(target_arch = "wasm32")]
 use std::collections::BTreeMap;
 #[cfg(target_arch = "wasm32")]
 use zellij_tile::prelude::*;
@@ -169,11 +171,16 @@ impl State {
 impl State {
     fn handle_outcome(&mut self, outcome: runtime::Outcome) -> bool {
         let render = outcome.render;
-        self.handle_effects(outcome.effects);
-        render
+        self.handle_effects(outcome.effects) || render
     }
 
-    fn handle_effects(&mut self, effects: Vec<Effect>) {
+    /// Returns whether any *re-entrant* outcome handled along the way (see
+    /// `Effect::ReadPresences`) wants a repaint. Most effects are
+    /// fire-and-forget host calls with nothing to report; `ResolveCwd`
+    /// deliberately drops its nested render flag (see `resolve_cwd`'s doc
+    /// comment) rather than folding it in here.
+    fn handle_effects(&mut self, effects: Vec<Effect>) -> bool {
+        let mut render = false;
         for effect in effects {
             match effect {
                 // Keep in lockstep with REQUIRED_PLUGIN_PERMISSIONS in
@@ -216,8 +223,21 @@ impl State {
                         run_command(&args, std::collections::BTreeMap::new());
                     }
                 }
+                Effect::PersistPresence => {
+                    self.session_files.persist_presence(&self.runtime.presence_json())
+                }
+                Effect::ReadPresences => {
+                    let raw = self.session_files.read_peer_presences();
+                    let outcome = self.runtime.presences_changed(raw);
+                    render |= self.handle_outcome(outcome);
+                }
+                Effect::SwitchSession { name, tab_position } => match tab_position {
+                    Some(pos) => switch_session_with_focus(&name, Some(pos), None),
+                    None => switch_session(Some(&name)),
+                },
             }
         }
+        render
     }
 
     /// Bootstrap tab names for freshly-opened panes by reading each pane's cwd
@@ -254,6 +274,7 @@ impl ZellijPlugin for State {
             EventType::Timer,
             EventType::Mouse,
             EventType::PermissionRequestResult,
+            EventType::SessionUpdate,
         ]);
         // Seed from the shared snapshot so a tab opened after agents were already
         // running shows their real status instead of a blank (all-idle) rail.
@@ -342,6 +363,14 @@ impl ZellijPlugin for State {
             Event::PermissionRequestResult(status) => {
                 let granted = status == PermissionStatus::Granted;
                 let outcome = self.runtime.permission_result(granted);
+                self.handle_outcome(outcome)
+            }
+            Event::SessionUpdate(sessions, _resurrectable) => {
+                let live = sessions
+                    .into_iter()
+                    .map(|s| SessionLite { name: s.name, is_current: s.is_current_session })
+                    .collect();
+                let outcome = self.runtime.session_update(live);
                 self.handle_outcome(outcome)
             }
             Event::CwdChanged(pane_id, path, _clients) => {

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -42,6 +42,7 @@ mod render;
 mod rollup;
 mod runtime;
 mod session_files;
+mod sessions;
 mod status_store;
 mod tab_namer;
 #[cfg(test)]

--- a/crates/plugin/src/notify_rules.rs
+++ b/crates/plugin/src/notify_rules.rs
@@ -86,6 +86,14 @@ pub fn diff(
 ) -> Vec<Notification> {
     let mut out = Vec::new();
     for (&pane_id, &o) in current {
+        // An acknowledged status arrived with the payload's `ack` flag — the
+        // user has already seen it (the rail's right-click "stop flagging
+        // this"), so its edge must never notify. Carried by the payload, NOT
+        // inferred from the edge shape: a real Pending → Done edge (answer a
+        // question, tab away, a short no-tool turn finishes) still notifies.
+        if o.acknowledged {
+            continue;
+        }
         let new = o.status;
         let was = prev.get(&pane_id).copied().unwrap_or(Status::Idle);
         if !new.needs_attention() || new == was {
@@ -241,6 +249,19 @@ mod tests {
         let pairs = [(7, &r), (8, &i)];
         let cur = current(&pairs);
         let prev = BTreeMap::from([(7, Status::Idle), (8, Status::Done)]);
+        assert!(diff(&prev, &cur, None, &Config::default()).is_empty());
+    }
+
+    #[test]
+    fn acknowledged_observation_never_notifies() {
+        // The rail's right-click acknowledge converges Pending → Done via a
+        // broadcast stamped `ack: true` — a background edge that would
+        // otherwise notify. The whole gesture means "stop flagging this".
+        let mut o = obs(Status::Done, "pinky", "main", "working");
+        o.acknowledged = true;
+        let pairs = [(7, &o)];
+        let cur = current(&pairs);
+        let prev = BTreeMap::from([(7, Status::Pending)]);
         assert!(diff(&prev, &cur, None, &Config::default()).is_empty());
     }
 

--- a/crates/plugin/src/presence.rs
+++ b/crates/plugin/src/presence.rs
@@ -5,8 +5,10 @@
 use serde::{Deserialize, Serialize};
 
 /// Ceiling on an inbound session name — presence files are peer input, and
-/// a corrupt or hostile file must not bloat the rail (mirrors payload's
-/// sanitize discipline).
+/// a corrupt or hostile file must not bloat the rail. Enforced through the
+/// sanitize round-trip in `parse` (`payload::sanitize` truncates past the
+/// ceiling, so an oversized name fails the equality check like any other
+/// unclean one).
 const MAX_SESSION_NAME_CHARS: usize = 128;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -27,9 +29,17 @@ impl Presence {
 
     /// Lenient: any malformation (bad JSON, missing name, oversized name)
     /// yields `None` — a corrupt peer file skips its badge, never crashes.
+    /// The name must also survive `payload::sanitize` unchanged: the badge
+    /// writes it into emitted ANSI, so control/escape/bidi content is the
+    /// same hostile-input class every other rail-bound string is scrubbed
+    /// for. Rejected rather than cleaned in place, because the name is also
+    /// the `SwitchSession` identity — a display-cleaned variant would
+    /// silently diverge from the session it claims to switch to.
     pub(crate) fn parse(s: &str) -> Option<Presence> {
         let p: Presence = serde_json::from_str(s).ok()?;
-        if p.session_name.is_empty() || p.session_name.chars().count() > MAX_SESSION_NAME_CHARS {
+        if p.session_name.is_empty()
+            || p.session_name != crate::payload::sanitize(&p.session_name, MAX_SESSION_NAME_CHARS)
+        {
             return None;
         }
         Some(p)
@@ -63,6 +73,20 @@ mod tests {
         .unwrap();
         assert_eq!(p.attention_tab_position, None);
         assert_eq!(p.updated_epoch_s, 0);
+    }
+
+    #[test]
+    fn hostile_session_name_with_control_or_bidi_content_is_rejected() {
+        // The badge writes the name into emitted ANSI, so a name carrying an
+        // OSC sequence (title/clipboard injection), a CSI color splice, or a
+        // bidi override is hostile-or-corrupt — and per this module's
+        // contract a corrupt peer file skips its badge entirely. Rejected,
+        // never cleaned in place: the name is also the `SwitchSession`
+        // identity, and a display-cleaned variant would diverge from it.
+        for name in ["\\u001b]0;pwned\\u0007work", "a\\u001b[31mred", "safe\\u202Eevil", "two\\nlines"] {
+            let json = format!(r#"{{"session_name":"{name}","running":0,"attention":0}}"#);
+            assert_eq!(Presence::parse(&json), None, "must reject {name}");
+        }
     }
 
     #[test]

--- a/crates/plugin/src/presence.rs
+++ b/crates/plugin/src/presence.rs
@@ -1,0 +1,74 @@
+//! Cross-session presence: the tiny JSON one session's rail publishes so
+//! peer sessions can render its badge. Pure data + lenient parse — file IO
+//! lives in `session_files`, state in `sessions`.
+
+use serde::{Deserialize, Serialize};
+
+/// Ceiling on an inbound session name — presence files are peer input, and
+/// a corrupt or hostile file must not bloat the rail (mirrors payload's
+/// sanitize discipline).
+const MAX_SESSION_NAME_CHARS: usize = 128;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct Presence {
+    pub session_name: String,
+    pub running: usize,
+    pub attention: usize,
+    #[serde(default)]
+    pub attention_tab_position: Option<usize>,
+    #[serde(default)]
+    pub updated_epoch_s: u64,
+}
+
+impl Presence {
+    pub(crate) fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap_or_default()
+    }
+
+    /// Lenient: any malformation (bad JSON, missing name, oversized name)
+    /// yields `None` — a corrupt peer file skips its badge, never crashes.
+    pub(crate) fn parse(s: &str) -> Option<Presence> {
+        let p: Presence = serde_json::from_str(s).ok()?;
+        if p.session_name.is_empty() || p.session_name.chars().count() > MAX_SESSION_NAME_CHARS {
+            return None;
+        }
+        Some(p)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_through_json() {
+        let p = Presence {
+            session_name: "work".into(),
+            running: 3,
+            attention: 1,
+            attention_tab_position: Some(2),
+            updated_epoch_s: 1000,
+        };
+        assert_eq!(Presence::parse(&p.to_json()), Some(p));
+    }
+
+    #[test]
+    fn parse_is_lenient_on_garbage_and_missing_fields() {
+        assert_eq!(Presence::parse("not json"), None);
+        assert_eq!(Presence::parse("{}"), None); // session_name is required
+        // Unknown fields are ignored; absent optionals default.
+        let p = Presence::parse(
+            r#"{"session_name":"a","running":1,"attention":0,"future_field":true}"#,
+        )
+        .unwrap();
+        assert_eq!(p.attention_tab_position, None);
+        assert_eq!(p.updated_epoch_s, 0);
+    }
+
+    #[test]
+    fn oversized_session_name_is_rejected() {
+        let long = "x".repeat(10_000);
+        let json = format!(r#"{{"session_name":"{long}","running":0,"attention":0}}"#);
+        assert_eq!(Presence::parse(&json), None);
+    }
+}

--- a/crates/plugin/src/radar_state.rs
+++ b/crates/plugin/src/radar_state.rs
@@ -712,6 +712,29 @@ impl RadarState {
         index
     }
 
+    /// Pane ids currently seated in tab `position`, in `self.tab_panes`'s
+    /// stored order — `PluginRuntime::mouse_right_click` reads this to
+    /// resolve a tab-row acknowledge (no `pane_id` on the click target) into
+    /// the set of panes it should check for a dismissible `Pending`. Empty
+    /// for an unknown position, same as every other `tab_panes` lookup here.
+    pub(crate) fn pane_ids_for_tab(&self, position: usize) -> Vec<u32> {
+        self.tab_panes
+            .get(&position)
+            .map(|panes| panes.iter().map(|p| p.id).collect())
+            .unwrap_or_default()
+    }
+
+    /// The STATUS-PIPE observation for `pane_id`, or `None` if the status
+    /// store isn't tracking it. Deliberately narrower than `resolve` (which
+    /// also falls back to the command store): the pending-pane acknowledge
+    /// gesture is status-pipe-only by design — a command-origin `Pending`
+    /// doesn't exist (`CommandStore` never produces one), so this is really
+    /// "is there anything here to acknowledge at all", read through the one
+    /// store that can say `Pending`.
+    pub(crate) fn status_observation(&self, pane_id: u32) -> Option<&TrackedObservation> {
+        self.status.get(pane_id)
+    }
+
     /// Pane ids the status store currently holds an observation for,
     /// regardless of its status value — mirrors `resolve`'s precedence check
     /// (`status.get(...).or_else(command.get(...))`: mere PRESENCE in the

--- a/crates/plugin/src/radar_state/snapshot.rs
+++ b/crates/plugin/src/radar_state/snapshot.rs
@@ -182,6 +182,7 @@ fn load_legacy_status(value: serde_json::Value) -> Option<LoadedSnapshot> {
                     exit_code: None,
                     completed_epoch_s: None,
                     pending_epoch_s: None,
+                    acknowledged: false,
                 }
                 .sanitized(),
             )

--- a/crates/plugin/src/reference_tests.rs
+++ b/crates/plugin/src/reference_tests.rs
@@ -583,6 +583,10 @@ fn build(input: &str) -> (Vec<TabRow>, Vec<crate::rollup::LedgerLine>, RenderOpt
         theme,
         now_epoch_s: LEDGER_NOW_EPOCH_S,
         jump_hint,
+        // The reference doc's scenarios are all single-session — the badge
+        // stays invisible (`render_session_badge`'s `len() <= 1` gate), same
+        // as every rail-reference.md fixture predates this field.
+        badge: vec![],
     };
     // Scenarios that don't declare an explicit `height` used the old
     // "unboundedly large" sentinel to mean "enough to fit, no overflow, no

--- a/crates/plugin/src/reference_tests.rs
+++ b/crates/plugin/src/reference_tests.rs
@@ -485,6 +485,7 @@ fn build(input: &str) -> (Vec<TabRow>, Vec<crate::rollup::LedgerLine>, RenderOpt
                     msg: pane.msg.clone(),
                     task: pane.task.clone(),
                     source: source.to_string(),
+                    ack: false,
                 });
                 radar.status_pipe(&wire_running, 0, 0, NamingMode::Off);
 
@@ -496,6 +497,7 @@ fn build(input: &str) -> (Vec<TabRow>, Vec<crate::rollup::LedgerLine>, RenderOpt
                     msg: pane.msg.clone(),
                     task: "".into(),
                     source: source.to_string(),
+                    ack: false,
                 });
                 radar.status_pipe(&wire_idle, 1, 0, NamingMode::Off);
             } else {
@@ -507,6 +509,7 @@ fn build(input: &str) -> (Vec<TabRow>, Vec<crate::rollup::LedgerLine>, RenderOpt
                     msg: pane.msg.clone(),
                     task: pane.task.clone(),
                     source: source.to_string(),
+                    ack: false,
                 });
                 // Applied "now" relative to the render epoch, backdated by the
                 // `waiting <N>m` trailer — how the doc's pending scenarios earn

--- a/crates/plugin/src/render.rs
+++ b/crates/plugin/src/render.rs
@@ -9,11 +9,13 @@
 //!    producing `Line`s through `prefixed_line`'s narrow-width guard.
 //! 3. **Layout planning** — delegated to `layout.rs` (pure, no ANSI, no
 //!    targets): overflow folding, card spacing, per-row line budgets.
-//! 4. **Assembly & paint** — body assembly, `paint_card_line`/`LineBg` tinting.
+//! 4. **Assembly & paint** — body assembly (header, cross-session badge,
+//!    cards), `paint_card_line`/`LineBg` tinting.
 //! 5. **Bottom region** — ledger lines, footer (rule + tally + hint), filler.
 
 use crate::config::Density;
 use crate::rollup::{LedgerLine, Outcome, PaneDisplay, TabDisplay, TabRow};
+use crate::sessions::BadgeEntry;
 pub use crate::status::GlyphSet;
 use crate::status::{Role, Status};
 use crate::theme::{DerivedColors, Rgb};
@@ -129,6 +131,13 @@ pub struct RenderOpts {
     /// truly delivers the chord may claim it; everything else omits the hint
     /// line rather than promising a chord that does nothing.
     pub jump_hint: bool,
+    /// The cross-session badge, current-first (`Sessions::badge()`'s
+    /// contract) — rendered by [`render_session_badge`] as zero lines
+    /// whenever `len() <= 1` (only this session, or the `SessionUpdate` event
+    /// hasn't landed yet), so every caller that never populates this (every
+    /// pre-existing test, and any host that hasn't wired Task 5/6's session
+    /// plumbing) renders byte-identical to before this field existed.
+    pub badge: Vec<BadgeEntry>,
 }
 
 /// Presentation for the roll-up's `Outcome` tag. The enum itself lives in
@@ -200,10 +209,66 @@ fn truncate(s: &str, max: usize) -> String {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// A click target. `session: None` (the vast majority — tabs and panes in
+/// THIS session) behaves exactly as before this field existed: `pane_id`
+/// present ⇒ `ShowPane`, else `SwitchTab { position: tab_position }` (see
+/// `mouse_click`). `session: Some(name)` marks a cross-session badge line
+/// (peer, never the current session — see `render_session_badge`) and routes
+/// to `Effect::SwitchSession` instead; its `tab_position` is then read
+/// through `session_tab_position`, not directly, because a session target
+/// needs to carry "no attention tab" (`Option::None`) losslessly through a
+/// field that stays a plain `usize` for every other target — see that
+/// method's doc. `session: Option<String>` (owned: a peer's name, read off
+/// its live `SessionLite`, isn't a value this module can borrow from) is why
+/// the struct can no longer derive `Copy`; every call site that used to rely
+/// on implicit-copy semantics now clones explicitly at its last use.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RailTarget {
     pub tab_position: usize,
     pub pane_id: Option<u32>,
+    pub session: Option<String>,
+}
+
+impl RailTarget {
+    /// Sentinel `tab_position` for a session target (`session: Some(_)`)
+    /// whose peer has nothing needing attention. Never a legitimate tab
+    /// index in practice (`RadarTab` positions come from real tab counts,
+    /// nowhere near `usize::MAX`), so it can share the plain `usize` field
+    /// every other target already uses instead of growing a 4th field just
+    /// for this one case.
+    const NO_ATTENTION: usize = usize::MAX;
+
+    /// Build a peer-session click target. `tab_position` is baked in NOW, at
+    /// line-build time, from the badge entry's `attention_tab_position` — by
+    /// the time a click lands the badge may have moved on, so the target
+    /// must carry everything `mouse_click` needs rather than re-deriving it.
+    /// Encodes `None` (no attention tab) as [`Self::NO_ATTENTION`] rather
+    /// than `unwrap_or(0)`: the latter would collide with a peer whose
+    /// attention IS at tab 0, and `mouse_click` would then force-focus that
+    /// tab for a peer that has nothing to focus — a silent behavior bug the
+    /// plain-`usize` field shape could otherwise hide. See
+    /// [`Self::session_tab_position`] for the inverse.
+    fn for_session(name: String, attention_tab_position: Option<usize>) -> Self {
+        RailTarget {
+            tab_position: attention_tab_position.unwrap_or(Self::NO_ATTENTION),
+            pane_id: None,
+            session: Some(name),
+        }
+    }
+
+    /// The inverse of [`Self::for_session`]'s sentinel encoding —
+    /// `mouse_click` calls this once it has confirmed `session.is_some()`,
+    /// to get the `Option<usize>` `Effect::SwitchSession` actually needs.
+    /// `None` ⇒ switch session, keep its own last-focused tab (`lib.rs`'s
+    /// plain `switch_session`); `Some(pos)` ⇒ switch AND focus
+    /// (`switch_session_with_focus`) — mirrors `Sessions::tick`'s
+    /// idle-commit `CommitTarget.attention_tab_position` exactly, so
+    /// Alt+[/] cycling and a badge click land identically for the same
+    /// peer state. Meaningless (and never called) on a target whose
+    /// `session` is `None` — those read `tab_position` directly.
+    pub(crate) fn session_tab_position(&self) -> Option<usize> {
+        (self.tab_position != Self::NO_ATTENTION).then_some(self.tab_position)
+    }
 }
 
 /// Surface class a line sits on (Cards density only); resolved to a concrete
@@ -324,7 +389,7 @@ impl RenderedRail {
         if line < 0 {
             return None;
         }
-        self.targets.get(line as usize).copied().flatten()
+        self.targets.get(line as usize).cloned().flatten()
     }
 
     #[cfg_attr(all(target_arch = "wasm32", not(test)), allow(dead_code))]
@@ -493,7 +558,7 @@ fn with_wait_tag(identity: &str, status: Status, pending_epoch_s: Option<u64>, n
 /// budget clamped so the emitted line never exceeds `width`. This is the
 /// densest width-math in the file, self-contained here so `render_row` reads
 /// as pane-roster logic.
-fn tab_header_line(row: &TabRow, opts: &RenderOpts, tab_target: RailTarget) -> Line {
+fn tab_header_line(row: &TabRow, opts: &RenderOpts, tab_target: &RailTarget) -> Line {
     let width = opts.width;
     let now_tick = opts.now_tick;
     let st = row.display.status;
@@ -583,7 +648,7 @@ fn tab_header_line(row: &TabRow, opts: &RenderOpts, tab_target: RailTarget) -> L
     };
     Line::new(
         format!("{}{}{}{}{}\n", bar, pad, label, " ".repeat(gap), bell),
-        Some(tab_target),
+        Some(tab_target.clone()),
         LineBg::Card,
     )
 }
@@ -600,7 +665,7 @@ fn render_row(row: &TabRow, opts: &RenderOpts) -> Vec<Line> {
     let st = row.display.status;
     let tab_target = target_for_row(row);
 
-    lines.push(tab_header_line(row, opts, tab_target));
+    lines.push(tab_header_line(row, opts, &tab_target));
 
     // Theme-derived detail text colors: dim_strong for activity text on non-pending rows,
     // idle_text for the muted tree chars and identity mark glyph (neutral/vendor color).
@@ -634,9 +699,12 @@ fn render_row(row: &TabRow, opts: &RenderOpts) -> Vec<Line> {
         }
         let identity =
             with_wait_tag(identity, pane_status, pane.pending_epoch_s(), opts.now_epoch_s);
-        let pane_target = RailTarget { tab_position: tab_target.tab_position, pane_id: Some(pane.pane_id()) };
+        let pane_target = RailTarget { tab_position: tab_target.tab_position, pane_id: Some(pane.pane_id()), session: None };
         let text = emit_pane_line(pane, &identity, detail.is_some(), opts, row.active, st, &dim_strong, &idle_color, branch);
-        let mut out = vec![Line::new(text, Some(pane_target), child_bg)];
+        // `pane_target` is cloned here because a Pending/Error pane also emits
+        // the subordinate `↳ question` line below, targeting the SAME pane —
+        // `RailTarget` dropped `Copy` when `session` (a `String`) joined it.
+        let mut out = vec![Line::new(text, Some(pane_target.clone()), child_bg)];
         if let Some(q) = detail {
             let text = emit_pane_detail_line(
                 q, row.active, st, pane_status, branch, &idle_color, width,
@@ -1014,6 +1082,7 @@ fn target_for_row(row: &TabRow) -> RailTarget {
     RailTarget {
         tab_position: row.number.saturating_sub(1) as usize,
         pane_id: None,
+        session: None,
     }
 }
 
@@ -1135,6 +1204,77 @@ fn header_rule(width: usize, now_tick: u64, working: bool, accent: &str) -> Stri
     )
 }
 
+/// The cross-session badge: one line per session `Sessions::badge()` tracks
+/// (current-first, per its ordering contract — this function trusts that
+/// order and does not re-sort), inserted between the header and the first
+/// card. Renders ZERO lines when `entries.len() <= 1` — only the current
+/// session, or the `SessionUpdate` event hasn't landed yet — so the feature
+/// is invisible until there's genuinely something cross-session to show, and
+/// every existing single-session snapshot/test stays byte-identical (the
+/// badge is additive, never a subtraction from the render surface).
+///
+/// The current session's own line carries NO click target at all — you
+/// can't "switch to" the session you're already in, and unlike a peer line
+/// there is no `attention_tab_position` to jump to either — so its `Line`
+/// gets `None`, exactly like a header line. Every peer line targets that
+/// peer via [`RailTarget::for_session`], which bakes in `tab_position` NOW
+/// (at line-build time, from the entry's `attention_tab_position`) rather
+/// than leaving `mouse_click` to re-derive it later against a badge that may
+/// have moved on by the time the click lands.
+///
+/// Text is `name` plus, only when nonzero, a running count and an attention
+/// count — each paired with the SAME glyph the per-tab rows already use for
+/// that status (`Status::Running`/`Status::Pending`, run through
+/// `opts.glyphs`) rather than inventing a parallel icon vocabulary the nerd/
+/// plain config wouldn't know about. `selected` (the pending Alt+[/] cycle
+/// target) renders bold+accent; everything else — including the current
+/// line — renders in the muted `idle_text`, so the badge reads as a status
+/// strip, not a second row of cards.
+fn render_session_badge(entries: &[BadgeEntry], opts: &RenderOpts) -> Vec<Line> {
+    if entries.len() <= 1 {
+        return vec![];
+    }
+    let width = opts.width;
+    let idle = tc_fg(opts.theme.idle_text);
+    let accent = Role::Accent.ansi();
+    let running_glyph = Status::Running.glyph_for(opts.glyphs);
+    let attention_glyph = Status::Pending.glyph_for(opts.glyphs);
+    entries
+        .iter()
+        .map(|entry| {
+            let mut label = entry.name.clone();
+            if entry.running > 0 {
+                label.push_str(&format!(" {}{}", entry.running, running_glyph));
+            }
+            if entry.attention > 0 {
+                label.push_str(&format!(" {}{}", entry.attention, attention_glyph));
+            }
+            // A dim `•` marks "you are here" on the current line, independent
+            // of `selected` — a plain space keeps every other line's label
+            // aligned under it.
+            let marker = if entry.is_current { "•" } else { " " };
+            const PREFIX_VIS: usize = 2; // marker + its separating space
+            let text = prefixed_line(
+                width,
+                PREFIX_VIS,
+                || format!("{marker} {label}"),
+                |avail| {
+                    let clamped = truncate(&label, avail);
+                    let label_seg = if entry.selected {
+                        Seg::bold(accent, clamped)
+                    } else {
+                        Seg::new(&idle, clamped)
+                    };
+                    format!("{} {}", Seg::new(&idle, marker), label_seg)
+                },
+            );
+            let target = (!entry.is_current)
+                .then(|| RailTarget::for_session(entry.name.clone(), entry.attention_tab_position));
+            Line::new(text, target, LineBg::Rail)
+        })
+        .collect()
+}
+
 /// Produce the idle-strip line as a raw (unpainted) `Line` value.
 /// Returns 0 lines if `strip_folded == 0`; else 1 line tagged `LineBg::Rail`.
 fn render_strip(strip_folded: usize, opts: &RenderOpts) -> Vec<Line> {
@@ -1168,13 +1308,22 @@ fn render_body(rows: &[TabRow], ledger: &[LedgerLine], opts: &RenderOpts) -> Vec
     // just because `rows` is empty.
     let has_content = !rows.is_empty() || !ledger.is_empty();
 
+    // Built (and its line count reserved out of `body_budget`) BEFORE
+    // `plan_layout` runs, exactly like `header_lines` above it — otherwise
+    // overflow folding would plan against a taller budget than the rows
+    // actually get once the badge lines land above them, and the final
+    // `flat.truncate(opts.height)` in `render_rail` would silently eat into
+    // the footer/last row rather than the folding math accounting for it.
+    let badge_lines = render_session_badge(&opts.badge, opts);
+
     let blocks: Vec<Vec<Line>> = rows.iter().map(|r| render_row(r, opts)).collect();
     let metas: Vec<RowMeta> = rows.iter().zip(&blocks)
         .map(|(r, b)| RowMeta { status: r.display.status, full_lines: b.len() })
         .collect();
     let body_budget = opts
         .height
-        .saturating_sub(header_lines(opts.header, opts.density, has_content));
+        .saturating_sub(header_lines(opts.header, opts.density, has_content))
+        .saturating_sub(badge_lines.len());
     let (plan, strip_folded, spacing) = plan_layout(&metas, body_budget, opts.density);
     let overflow = plan.len() < rows.len();
     // Drives the header-rule heartbeat — a plain `any()`, not a
@@ -1189,6 +1338,12 @@ fn render_body(rows: &[TabRow], ledger: &[LedgerLine], opts: &RenderOpts) -> Vec
 
     // Header.
     for line in render_header(rows, opts, overflow, has_content, working) {
+        flat.push(if cards { line.painted(width, &rail) } else { line });
+    }
+
+    // Cross-session badge (zero lines with ≤1 session — see
+    // `render_session_badge`), between the header and the first card.
+    for line in badge_lines {
         flat.push(if cards { line.painted(width, &rail) } else { line });
     }
 
@@ -1209,13 +1364,16 @@ fn render_body(rows: &[TabRow], ledger: &[LedgerLine], opts: &RenderOpts) -> Vec
         };
 
         // pad_y internal top padding — belongs to this card's click span.
+        // Cloned each iteration (`RailTarget` isn't `Copy`; `session` is a
+        // `String`) — `pad_y` can be >1, so a plain move would only survive
+        // the first pass.
         for _ in 0..spacing.pad_y {
-            flat.push(finalize(LineBg::Card, "\n".to_string(), Some(row_target)));
+            flat.push(finalize(LineBg::Card, "\n".to_string(), Some(row_target.clone())));
         }
 
         // content (truncated to the planned budget == today's compression).
         for line in blocks[i].iter().take(budget) {
-            flat.push(finalize(line.bg, line.text.clone(), line.target));
+            flat.push(finalize(line.bg, line.text.clone(), line.target.clone()));
         }
 
         // gap external separation (dark panel base in Cards).
@@ -1369,7 +1527,7 @@ fn ledger_entry_line(line: &LedgerLine, opts: &RenderOpts) -> Line {
     );
     Line::new(
         text,
-        line.tab_position.map(|p| RailTarget { tab_position: p, pane_id: None }),
+        line.tab_position.map(|p| RailTarget { tab_position: p, pane_id: None, session: None }),
         LineBg::Rail,
     )
 }

--- a/crates/plugin/src/render.rs
+++ b/crates/plugin/src/render.rs
@@ -1213,7 +1213,10 @@ fn header_rule(width: usize, now_tick: u64, working: bool, accent: &str) -> Stri
 /// so the feature is invisible until there's genuinely something
 /// cross-session to show, and
 /// every existing single-session snapshot/test stays byte-identical (the
-/// badge is additive, never a subtraction from the render surface).
+/// badge is additive, never a subtraction from the render surface). A lone
+/// fresh own-entry plus only STALE peers still clears this threshold and
+/// renders (task-14: the roster's whole point is remembering) — the count
+/// is over `entries`, not over fresh entries.
 ///
 /// The current session's own line carries NO click target at all — you
 /// can't "switch to" the session you're already in, and unlike a peer line
@@ -1222,16 +1225,19 @@ fn header_rule(width: usize, now_tick: u64, working: bool, accent: &str) -> Stri
 /// peer via [`RailTarget::for_session`], which bakes in `tab_position` NOW
 /// (at line-build time, from the entry's `attention_tab_position`) rather
 /// than leaving `mouse_click` to re-derive it later against a badge that may
-/// have moved on by the time the click lands.
+/// have moved on by the time the click lands. This applies uniformly to
+/// stale peers too — a click on one is a deliberate act (`entry.stale` only
+/// affects color, never the target).
 ///
 /// Text is `name` plus, only when nonzero, a running count and an attention
 /// count — each paired with the SAME glyph the per-tab rows already use for
 /// that status (`Status::Running`/`Status::Pending`, run through
 /// `opts.glyphs`) rather than inventing a parallel icon vocabulary the nerd/
 /// plain config wouldn't know about. `selected` (the pending Alt+[/] cycle
-/// target) renders bold+accent; everything else — including the current
-/// line — renders in the muted `idle_text`, so the badge reads as a status
-/// strip, not a second row of cards.
+/// target) renders bold+accent; a `stale` entry recedes past the ordinary
+/// muted `idle_text` (see the color derivation below); everything else —
+/// including the current line — renders in `idle_text`, so the badge reads
+/// as a status strip, not a second row of cards.
 ///
 /// A trailing blank separator line closes the block (live-use feedback: the
 /// badge read as glued to the first card below it without one) — appended
@@ -1250,6 +1256,14 @@ fn render_session_badge(entries: &[BadgeEntry], opts: &RenderOpts) -> Vec<Line> 
     }
     let width = opts.width;
     let idle = tc_fg(opts.theme.idle_text);
+    // A stale entry (task-14: dimmed, never dropped from the badge) recedes
+    // one step further than the ordinary muted `idle_text` every other line
+    // uses — blended halfway toward the panel background, the same "recede
+    // toward bg" idiom `DerivedColors::from_bg_fg` already uses for its own
+    // surface ladder, rather than inventing a parallel dim vocabulary. It
+    // stays fully clickable (`target` below doesn't distinguish stale from
+    // fresh) — a click on it is a deliberate act.
+    let stale = tc_fg(crate::theme::blend(opts.theme.idle_text, opts.theme.rail_bg, 0.5));
     let accent = Role::Accent.ansi();
     let running_glyph = Status::Running.glyph_for(opts.glyphs);
     let attention_glyph = Status::Pending.glyph_for(opts.glyphs);
@@ -1276,6 +1290,8 @@ fn render_session_badge(entries: &[BadgeEntry], opts: &RenderOpts) -> Vec<Line> 
                     let clamped = truncate(&label, avail);
                     let label_seg = if entry.selected {
                         Seg::bold(accent, clamped)
+                    } else if entry.stale {
+                        Seg::new(&stale, clamped)
                     } else {
                         Seg::new(&idle, clamped)
                     };

--- a/crates/plugin/src/render.rs
+++ b/crates/plugin/src/render.rs
@@ -1232,6 +1232,18 @@ fn header_rule(width: usize, now_tick: u64, working: bool, accent: &str) -> Stri
 /// target) renders bold+accent; everything else — including the current
 /// line — renders in the muted `idle_text`, so the badge reads as a status
 /// strip, not a second row of cards.
+///
+/// A trailing blank separator line closes the block (live-use feedback: the
+/// badge read as glued to the first card below it without one) — appended
+/// HERE, inside the same early-return guard, rather than by the `render_body`
+/// caller: entries.len() <= 1 already returns zero lines above, so tying the
+/// spacer to that same guard is how "spacer only when the badge itself
+/// emitted lines" stays a single fact instead of two functions agreeing on
+/// it. It rides through the same `Vec<Line>` as every other badge line (empty
+/// text via `Line::new`, no click target, `LineBg::Rail` — the same class the
+/// per-entry lines use), so `render_body`'s `badge_lines.len()` subtraction
+/// from the body budget and the `for line in badge_lines` paint loop pick it
+/// up for free, exactly as they do the entry lines above it.
 fn render_session_badge(entries: &[BadgeEntry], opts: &RenderOpts) -> Vec<Line> {
     if entries.len() <= 1 {
         return vec![];
@@ -1241,7 +1253,7 @@ fn render_session_badge(entries: &[BadgeEntry], opts: &RenderOpts) -> Vec<Line> 
     let accent = Role::Accent.ansi();
     let running_glyph = Status::Running.glyph_for(opts.glyphs);
     let attention_glyph = Status::Pending.glyph_for(opts.glyphs);
-    entries
+    let mut lines: Vec<Line> = entries
         .iter()
         .map(|entry| {
             let mut label = entry.name.clone();
@@ -1274,7 +1286,9 @@ fn render_session_badge(entries: &[BadgeEntry], opts: &RenderOpts) -> Vec<Line> 
                 .then(|| RailTarget::for_session(entry.name.clone(), entry.attention_tab_position));
             Line::new(text, target, LineBg::Rail)
         })
-        .collect()
+        .collect();
+    lines.push(Line::new("\n".to_string(), None, LineBg::Rail));
+    lines
 }
 
 /// Produce the idle-strip line as a raw (unpainted) `Line` value.

--- a/crates/plugin/src/render.rs
+++ b/crates/plugin/src/render.rs
@@ -133,8 +133,9 @@ pub struct RenderOpts {
     pub jump_hint: bool,
     /// The cross-session badge, current-first (`Sessions::badge()`'s
     /// contract) — rendered by [`render_session_badge`] as zero lines
-    /// whenever `len() <= 1` (only this session, or the `SessionUpdate` event
-    /// hasn't landed yet), so every caller that never populates this (every
+    /// whenever `len() <= 1` (only this session, or no peer presence has
+    /// crossed the shared `/cache` root yet), so every caller that never
+    /// populates this (every
     /// pre-existing test, and any host that hasn't wired Task 5/6's session
     /// plumbing) renders byte-identical to before this field existed.
     pub badge: Vec<BadgeEntry>,
@@ -219,7 +220,7 @@ fn truncate(s: &str, max: usize) -> String {
 /// needs to carry "no attention tab" (`Option::None`) losslessly through a
 /// field that stays a plain `usize` for every other target — see that
 /// method's doc. `session: Option<String>` (owned: a peer's name, read off
-/// its live `SessionLite`, isn't a value this module can borrow from) is why
+/// its `Presence`, isn't a value this module can borrow from) is why
 /// the struct can no longer derive `Copy`; every call site that used to rely
 /// on implicit-copy semantics now clones explicitly at its last use.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1208,8 +1209,9 @@ fn header_rule(width: usize, now_tick: u64, working: bool, accent: &str) -> Stri
 /// (current-first, per its ordering contract — this function trusts that
 /// order and does not re-sort), inserted between the header and the first
 /// card. Renders ZERO lines when `entries.len() <= 1` — only the current
-/// session, or the `SessionUpdate` event hasn't landed yet — so the feature
-/// is invisible until there's genuinely something cross-session to show, and
+/// session, or no peer presence has crossed the shared `/cache` root yet —
+/// so the feature is invisible until there's genuinely something
+/// cross-session to show, and
 /// every existing single-session snapshot/test stays byte-identical (the
 /// badge is additive, never a subtraction from the render surface).
 ///

--- a/crates/plugin/src/render/tests.rs
+++ b/crates/plugin/src/render/tests.rs
@@ -3777,7 +3777,7 @@ fn running_row_eases_to_slow_blink_after_long_runner_threshold() {
 /// Local test helper: field order matches `BadgeEntry`'s declaration EXCEPT
 /// `is_current` moves up next to `name` — the shape most test call sites
 /// read naturally ("work, current, 3 running, 0 attention, no attention tab,
-/// not selected").
+/// not selected, not stale").
 fn badge_entry(
     name: &str,
     is_current: bool,
@@ -3786,6 +3786,19 @@ fn badge_entry(
     attention_tab_position: Option<usize>,
     selected: bool,
 ) -> BadgeEntry {
+    stale_badge_entry(name, is_current, running, attention, attention_tab_position, selected, false)
+}
+/// As `badge_entry`, with an explicit trailing `stale` flag — for the
+/// dimmed/clickable/skip-cycle pins.
+fn stale_badge_entry(
+    name: &str,
+    is_current: bool,
+    running: usize,
+    attention: usize,
+    attention_tab_position: Option<usize>,
+    selected: bool,
+    stale: bool,
+) -> BadgeEntry {
     BadgeEntry {
         name: name.to_string(),
         running,
@@ -3793,6 +3806,7 @@ fn badge_entry(
         attention_tab_position,
         is_current,
         selected,
+        stale,
     }
 }
 
@@ -3846,5 +3860,85 @@ fn badge_encodes_missing_attention_as_a_sentinel_not_tab_zero() {
     assert_eq!(
         t.session_tab_position(), Some(0),
         "attention genuinely at tab 0 must still resolve to Some(0)"
+    );
+}
+
+// -- Pinning: stale badge entries (task-14) ---------------------------------
+// A remembered session must never silently vanish from the badge; it dims
+// to stale instead. The renderer's job is narrow: paint it in a receded
+// color and keep its click target — `Sessions::cycle` (sessions.rs's own
+// tests) is what actually keeps Alt+[/] from landing on it.
+
+#[test]
+fn stale_badge_entry_renders_dimmed_but_stays_clickable() {
+    let opts = ro(24, 0);
+    let idle_color = tc_fg(opts.theme.idle_text);
+    let stale_color = tc_fg(crate::theme::blend(opts.theme.idle_text, opts.theme.rail_bg, 0.5));
+
+    let entries = vec![
+        badge_entry("work", true, 0, 0, None, false),
+        stale_badge_entry("alpha", false, 0, 0, None, false, true),
+    ];
+    let lines = render_session_badge(&entries, &opts);
+
+    // Still fully clickable — a click on a stale entry is a deliberate act;
+    // `entry.stale` only ever affects color, never the target.
+    let t = lines[1].target.clone().expect("a stale peer line must still be clickable");
+    assert_eq!(t.session.as_deref(), Some("alpha"));
+
+    // Its label paints in the receded stale color, not the ordinary muted
+    // idle_text every fresh line uses.
+    assert!(
+        lines[1].text.contains(&format!("{stale_color}alpha")),
+        "stale label must render in the receded stale color, got {:?}",
+        lines[1].text
+    );
+    assert!(
+        !lines[1].text.contains(&format!("{idle_color}alpha")),
+        "stale label must not render in the plain idle color, got {:?}",
+        lines[1].text
+    );
+}
+
+#[test]
+fn stale_entry_undims_once_superseded_by_a_fresh_entry() {
+    // The recreation case: the exact same name, now reported fresh, must
+    // render in the ordinary idle color again — nothing about a name alone
+    // pins a line to stale forever.
+    let opts = ro(24, 0);
+    let idle_color = tc_fg(opts.theme.idle_text);
+    let stale_color = tc_fg(crate::theme::blend(opts.theme.idle_text, opts.theme.rail_bg, 0.5));
+
+    let stale_entries = vec![
+        badge_entry("work", true, 0, 0, None, false),
+        stale_badge_entry("alpha", false, 0, 0, None, false, true),
+    ];
+    let stale_lines = render_session_badge(&stale_entries, &opts);
+    assert!(stale_lines[1].text.contains(&format!("{stale_color}alpha")));
+
+    let fresh_entries = vec![
+        badge_entry("work", true, 0, 0, None, false),
+        badge_entry("alpha", false, 0, 0, None, false), // same name, now fresh
+    ];
+    let fresh_lines = render_session_badge(&fresh_entries, &opts);
+    assert!(
+        fresh_lines[1].text.contains(&format!("{idle_color}alpha")),
+        "a superseding fresh presence must undim the line back to the plain idle color"
+    );
+    assert!(!fresh_lines[1].text.contains(&format!("{stale_color}alpha")));
+}
+
+#[test]
+fn lone_fresh_own_entry_with_only_stale_peers_still_renders() {
+    // The single-session zero-line rule counts `entries.len()`, not fresh
+    // entries — a stale peer still counts toward the 2+ threshold, since the
+    // roster's whole point is remembering (task-14).
+    let entries = vec![
+        badge_entry("work", true, 0, 0, None, false),
+        stale_badge_entry("alpha", false, 0, 0, None, false, true),
+    ];
+    assert!(
+        !render_session_badge(&entries, &ro(24, 0)).is_empty(),
+        "a lone fresh own-entry plus only stale peers must still render the badge"
     );
 }

--- a/crates/plugin/src/render/tests.rs
+++ b/crates/plugin/src/render/tests.rs
@@ -3806,11 +3806,16 @@ fn badge_absent_with_single_session_and_lockstep_with_many() {
         badge_entry("alpha", false, 0, 1, Some(2), true),
     ];
     let lines = render_session_badge(&many, &ro(24, 0));
-    assert_eq!(lines.len(), 2);
+    // 2 entry lines + 1 trailing blank separator (only emitted because the
+    // badge itself emitted lines — see the doc comment on
+    // `render_session_badge`), so the section reads distinct from the cards
+    // below it.
+    assert_eq!(lines.len(), 3, "2 badge lines + 1 blank separator line");
     assert_eq!(lines[0].target, None, "own session line is not a cross-session click");
     let t = lines[1].target.clone().expect("peer line is clickable");
     assert_eq!(t.session.as_deref(), Some("alpha"));
     assert_eq!(t.tab_position, 2);
+    assert_eq!(lines[2].target, None, "separator line is click-inert");
 }
 
 #[test]

--- a/crates/plugin/src/render/tests.rs
+++ b/crates/plugin/src/render/tests.rs
@@ -121,6 +121,7 @@ fn ro(width: usize, now_tick: u64) -> RenderOpts {
         theme: crate::theme::DerivedColors::default(),
         now_epoch_s: 0,
         jump_hint: true,
+        badge: vec![],
     }
 }
 
@@ -299,6 +300,7 @@ fn rendered_rail_tracks_targets_for_each_emitted_line() {
         Some(RailTarget {
             tab_position: 0,
             pane_id: None,
+            session: None,
         })
     );
     assert_eq!(
@@ -306,6 +308,7 @@ fn rendered_rail_tracks_targets_for_each_emitted_line() {
         Some(RailTarget {
             tab_position: 0,
             pane_id: Some(10),
+            session: None,
         })
     );
     assert_eq!(
@@ -313,6 +316,7 @@ fn rendered_rail_tracks_targets_for_each_emitted_line() {
         Some(RailTarget {
             tab_position: 0,
             pane_id: Some(11),
+            session: None,
         })
     );
     assert_eq!(
@@ -320,6 +324,7 @@ fn rendered_rail_tracks_targets_for_each_emitted_line() {
         Some(RailTarget {
             tab_position: 1,
             pane_id: None,
+            session: None,
         })
     );
 }
@@ -2976,7 +2981,7 @@ fn ledger_entries_render_newest_first_and_click_to_their_tab() {
 
     assert_eq!(
         rail.target_at_line(entry1_line as isize),
-        Some(RailTarget { tab_position: 0, pane_id: None }),
+        Some(RailTarget { tab_position: 0, pane_id: None, session: None }),
         "the newer, still-open entry is clickable to its tab"
     );
     assert_eq!(
@@ -3480,11 +3485,11 @@ fn single_running_pane_with_detail_is_two_content_lines() {
 
 #[test]
 fn from_lines_derives_ansi_and_targets_in_lockstep() {
-    let t = RailTarget { tab_position: 2, pane_id: None };
+    let t = RailTarget { tab_position: 2, pane_id: None, session: None };
     let lines = vec![
-        Line::new("alpha\n".into(), Some(t), LineBg::None),
+        Line::new("alpha\n".into(), Some(t.clone()), LineBg::None),
         Line::new("beta\n".into(),  None,    LineBg::None),
-        Line::new("gamma\n".into(), Some(RailTarget { tab_position: 3, pane_id: Some(9) }), LineBg::None),
+        Line::new("gamma\n".into(), Some(RailTarget { tab_position: 3, pane_id: Some(9), session: None }), LineBg::None),
     ];
     let rr = RenderedRail::from_lines(lines);
     // ansi: joined, trailing newline popped.
@@ -3493,7 +3498,7 @@ fn from_lines_derives_ansi_and_targets_in_lockstep() {
     assert_eq!(rr.line_count(), 3);
     assert_eq!(rr.target_at_line(0), Some(t));
     assert_eq!(rr.target_at_line(1), None);
-    assert_eq!(rr.target_at_line(2), Some(RailTarget { tab_position: 3, pane_id: Some(9) }));
+    assert_eq!(rr.target_at_line(2), Some(RailTarget { tab_position: 3, pane_id: Some(9), session: None }));
     assert_eq!(rr.target_at_line(3), None);
     // Structural lockstep: every '\n'-terminated segment has a target slot.
     assert_eq!(rr.ansi.split('\n').count(), rr.line_count());
@@ -3677,7 +3682,7 @@ fn pending_pane_with_task_renders_identity_plus_question_line() {
     let q_line = grid.lines().position(|l| l.contains('↳')).unwrap();
     assert_eq!(
         rendered.target_at_line(q_line as isize),
-        Some(RailTarget { tab_position: 0, pane_id: Some(10) }),
+        Some(RailTarget { tab_position: 0, pane_id: Some(10), session: None }),
     );
 }
 
@@ -3764,5 +3769,77 @@ fn running_row_eases_to_slow_blink_after_long_runner_threshold() {
     assert!(
         !grid.contains(full_speed),
         "full-speed glyph must not leak through once eased:\n{grid}"
+    );
+}
+
+// ── Cross-session badge ─────────────────────────────────────────────────────
+
+/// Local test helper: field order matches `BadgeEntry`'s declaration EXCEPT
+/// `is_current` moves up next to `name` — the shape most test call sites
+/// read naturally ("work, current, 3 running, 0 attention, no attention tab,
+/// not selected").
+fn badge_entry(
+    name: &str,
+    is_current: bool,
+    running: usize,
+    attention: usize,
+    attention_tab_position: Option<usize>,
+    selected: bool,
+) -> BadgeEntry {
+    BadgeEntry {
+        name: name.to_string(),
+        running,
+        attention,
+        attention_tab_position,
+        is_current,
+        selected,
+    }
+}
+
+#[test]
+fn badge_absent_with_single_session_and_lockstep_with_many() {
+    let solo = vec![badge_entry("work", true, 1, 0, None, false)];
+    assert!(render_session_badge(&solo, &ro(24, 0)).is_empty(), "solo session renders nothing");
+
+    let many = vec![
+        badge_entry("work", true, 3, 0, None, false),
+        badge_entry("alpha", false, 0, 1, Some(2), true),
+    ];
+    let lines = render_session_badge(&many, &ro(24, 0));
+    assert_eq!(lines.len(), 2);
+    assert_eq!(lines[0].target, None, "own session line is not a cross-session click");
+    let t = lines[1].target.clone().expect("peer line is clickable");
+    assert_eq!(t.session.as_deref(), Some("alpha"));
+    assert_eq!(t.tab_position, 2);
+}
+
+#[test]
+fn badge_encodes_missing_attention_as_a_sentinel_not_tab_zero() {
+    // A peer with NOTHING needing attention (`attention_tab_position: None`)
+    // must not resolve to "tab 0" — that would force-focus a real tab in a
+    // session that has nothing to jump to. `RailTarget::for_session` bakes
+    // this in via a sentinel rather than `unwrap_or(0)`; `session_tab_position`
+    // is the one place that decodes it back, and both directions are pinned
+    // here so a future edit to either side trips this test, not a live click.
+    let many = vec![
+        badge_entry("work", true, 0, 0, None, false),
+        badge_entry("alpha", false, 0, 0, None, false),
+    ];
+    let lines = render_session_badge(&many, &ro(24, 0));
+    let t = lines[1].target.clone().expect("peer line is clickable");
+    assert_eq!(
+        t.session_tab_position(), None,
+        "no attention tab must decode back to None, not Some(0)"
+    );
+
+    let with_attention = vec![
+        badge_entry("work", true, 0, 0, None, false),
+        badge_entry("alpha", false, 0, 1, Some(0), false),
+    ];
+    let lines = render_session_badge(&with_attention, &ro(24, 0));
+    let t = lines[1].target.clone().expect("peer line is clickable");
+    assert_eq!(
+        t.session_tab_position(), Some(0),
+        "attention genuinely at tab 0 must still resolve to Some(0)"
     );
 }

--- a/crates/plugin/src/rollup/tests.rs
+++ b/crates/plugin/src/rollup/tests.rs
@@ -23,6 +23,7 @@ fn obs(origin: ObservationOrigin, status: Status, tick: u64) -> TrackedObservati
         exit_code: None,
         completed_epoch_s: None,
         pending_epoch_s: None,
+        acknowledged: false,
     }
 }
 
@@ -238,6 +239,7 @@ fn build(specs: &[Spec]) -> (Vec<TerminalPane>, HashMap<u32, TrackedObservation>
                     exit_code,
                     completed_epoch_s: None,
                     pending_epoch_s: None,
+                    acknowledged: false,
                 },
             );
         }

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -116,8 +116,10 @@ pub(crate) enum Effect {
     PersistPresence,
     /// Re-read every peer session's presence file and feed the result back
     /// through `presences_changed` — mirrors `ResolveCwd`'s
-    /// request/read-back pattern, except the read is unconditional each
-    /// timer fire rather than gated on a fresh set of pane ids.
+    /// request/read-back pattern, except the read is gated on cadence
+    /// (Fast fires only — see `timer`) rather than on a fresh set of pane
+    /// ids: one directory scan per second, only while Fast is armed, never
+    /// on the Slow heartbeat.
     ReadPresences,
     /// Commit a cross-session cycle selection: switch to `name` and, once
     /// there, jump straight to the tab that needs attention (if any).
@@ -254,10 +256,19 @@ pub(crate) struct PluginRuntime {
     /// session-list event lands — `project` withholds `Effect::PersistPresence`
     /// while empty, since an unnamed presence file is useless to peers.
     own_session_name: String,
-    /// The last own-`Presence` JSON actually published, so `project` can
+    /// The last own-`Presence` actually published, canonicalized with
+    /// `updated_epoch_s` zeroed before compare-and-cache — so `project` can
     /// content-compare and emit `Effect::PersistPresence` only on a real
-    /// edge — the same "write on edges only" rule `PersistSnapshot` follows.
-    last_presence_json: Option<String>,
+    /// *content* edge, the same "write on edges only" rule `PersistSnapshot`
+    /// follows. Comparing the raw JSON (epoch included) would fire on every
+    /// Fast tick even with unchanged counts, since `last_now_epoch_s` moves
+    /// every second — mirrors `sessions.rs::set_own`, whose badge-derived
+    /// change check already excludes `updated_epoch_s` the same way. The
+    /// real epoch still reaches peers: it's stamped fresh into whatever
+    /// `presence_json()` returns when the host actually handles the effect,
+    /// so it reads as "epoch of the last content edge", not "epoch of the
+    /// last tick".
+    last_presence: Option<Presence>,
     /// The most recent `now_epoch_s` any entry point has captured. Reused
     /// (never re-read from the clock) by call paths that have no epoch of
     /// their own to work with — `presence_json`, `session_update`,
@@ -333,14 +344,23 @@ impl PluginRuntime {
         // opened in that window would seed a rail missing the change — the same
         // cross-instance convergence pushed statuses get from `status_pipe`.
         let store_changed = self.radar.timer(self.tick, now);
-        // Cross-session peers: re-read every fire (Fast or Slow both fine —
-        // on Slow ticks peers refresh at most once a minute, acceptable for a
-        // badge) and, BEFORE re-arming below, commit an idle cycle selection
-        // if one is pending. Committing here — not after `project` re-arms —
-        // matters: a commit clears `Sessions::wants_fast_cadence`, and the
-        // chain must be free to decay to Slow on this same pass rather than
-        // one fire late.
-        effects.push(Effect::ReadPresences);
+        // Cross-session peers: re-read the directory bound to Fast fires only
+        // — "one directory scan per second, only while Fast is armed", never
+        // on the Slow heartbeat (which exists solely to repaint ledger ages
+        // and has no business paying for a peer scan). `elapsed_s` is also
+        // how `TimerChain::on_fire` above tells a stale fire from a live one:
+        // Fast fires report ~1s, Slow ~60s, and `STALE_FIRE_ELAPSED_S` sits
+        // safely between the two, so reusing it here (rather than inventing
+        // parallel state) is the same discrimination, applied to cadence
+        // instead of staleness.
+        if elapsed_s <= STALE_FIRE_ELAPSED_S {
+            effects.push(Effect::ReadPresences);
+        }
+        // BEFORE re-arming below, commit an idle cycle selection if one is
+        // pending. Committing here — not after `project` re-arms — matters:
+        // a commit clears `Sessions::wants_fast_cadence`, and the chain must
+        // be free to decay to Slow on this same pass rather than one fire
+        // late.
         let session_commit = self.sessions.tick(self.tick);
         if let Some(CommitTarget { name, attention_tab_position }) = session_commit {
             effects.push(Effect::SwitchSession { name, tab_position: attention_tab_position });
@@ -448,7 +468,7 @@ impl PluginRuntime {
     /// drift from what's on screen. `attention_tab_position` is the first
     /// (lowest-position) row that `needs_you()`, matching the position
     /// `Sessions`/`BadgeEntry` expect for a same-repo jump-on-arrival.
-    pub(crate) fn presence_json(&self) -> String {
+    fn own_presence(&self) -> Presence {
         let rows = self.radar.rows(self.tick);
         let running = rows.iter().filter(|r| r.display.status == Status::Running).count();
         let mut attention = 0usize;
@@ -468,7 +488,16 @@ impl PluginRuntime {
             attention_tab_position,
             updated_epoch_s: self.last_now_epoch_s,
         }
-        .to_json()
+    }
+
+    /// JSON the host actually writes to disk on `Effect::PersistPresence` —
+    /// see `own_presence` for the field derivation. Only the wasm glue
+    /// (Task 6) calls this in production; on a host build nothing here
+    /// invokes it (that wiring is still `project`'s `own_presence`
+    /// comparison), so it would otherwise read as dead code.
+    #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+    pub(crate) fn presence_json(&self) -> String {
+        self.own_presence().to_json()
     }
 
     /// True while [`timer`](Self::timer) still consumes a fresh
@@ -797,12 +826,15 @@ impl PluginRuntime {
     /// domain-change entry point funnels through here with its `now_epoch_s`,
     /// which this stores (`last_now_epoch_s`) for the call paths that have no
     /// epoch of their own — `presence_json`, `session_update`,
-    /// `presences_changed`. The freshly computed own-`Presence` JSON is
-    /// content-compared against the last one published; a real edge pushes
-    /// the effect and updates the cache, mirroring `PersistSnapshot`'s
-    /// "write on edges only" rule. Withheld while `own_session_name` is empty
-    /// — a presence file with no name is useless to peers — so it stays
-    /// quiet until `session_update` (also routed through here) learns it.
+    /// `presences_changed`. The freshly computed own-`Presence` is
+    /// content-compared against the last one published, EXCLUDING
+    /// `updated_epoch_s` (zeroed on both sides before the compare/cache) —
+    /// see `last_presence`'s doc for why a raw compare would defeat the edge
+    /// gate on Fast cadence. A real content edge pushes the effect and
+    /// updates the cache, mirroring `PersistSnapshot`'s "write on edges only"
+    /// rule. Withheld while `own_session_name` is empty — a presence file
+    /// with no name is useless to peers — so it stays quiet until
+    /// `session_update` (also routed through here) learns it.
     fn project(&mut self, mut fx: Vec<Effect>, c: RadarChange, now_epoch_s: u64) -> Outcome {
         self.last_now_epoch_s = now_epoch_s;
         fx.extend(self.effects_from_renames(c.renames));
@@ -810,9 +842,10 @@ impl PluginRuntime {
             fx.push(Effect::PersistSnapshot);
         }
         if !self.own_session_name.is_empty() {
-            let fresh = self.presence_json();
-            if self.last_presence_json.as_deref() != Some(fresh.as_str()) {
-                self.last_presence_json = Some(fresh);
+            let mut fresh = self.own_presence();
+            fresh.updated_epoch_s = 0;
+            if self.last_presence.as_ref() != Some(&fresh) {
+                self.last_presence = Some(fresh);
                 fx.push(Effect::PersistPresence);
             }
         }

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -278,7 +278,7 @@ pub(crate) struct PluginRuntime {
     last_presence: Option<Presence>,
     /// The most recent `now_epoch_s` any entry point has captured. Reused
     /// (never re-read from the clock) by call paths that have no epoch of
-    /// their own to work with — `presence_json`, `session_update`,
+    /// their own to work with — `presence_json`, `session_name_changed`,
     /// `presences_changed` — so a single event's "now" never forks in two
     /// directions.
     last_now_epoch_s: u64,
@@ -881,6 +881,11 @@ impl PluginRuntime {
     /// badge actually changed, so calling it every `project` pass (once the
     /// name is known) is correct AND is what closes the gap where the own
     /// row never updated as running/attention moved.
+    ///
+    /// Also the single point that de-dupes `Effect::PersistPresence` when the
+    /// seeded `fx` (e.g. `timer`'s unconditional Slow heartbeat) and this
+    /// pass's own edge-gated push both land — see the `retain` near the
+    /// bottom.
     fn project(&mut self, mut fx: Vec<Effect>, c: RadarChange, now_epoch_s: u64) -> Outcome {
         self.last_now_epoch_s = now_epoch_s;
         fx.extend(self.effects_from_renames(c.renames));
@@ -905,6 +910,26 @@ impl PluginRuntime {
         if c.settle {
             fx.extend(self.notify_effects());
         }
+        // `fx` can carry TWO `PersistPresence`s by the time we get here: the
+        // Slow-cadence heartbeat `timer` seeds unconditionally (its own
+        // liveness push, gate-blind by design) and the edge-gated push just
+        // above can both fire on the same pass — a Slow fire whose tick also
+        // promotes/mutates something that lands on a real content edge (e.g.
+        // a debounce promotion crossing paths with the 60s heartbeat).
+        // `project` is the single assembly point for every entry path, so
+        // it's the one place that can see both pushes at once and collapse
+        // them; keep the earliest (whichever reason got there first) rather
+        // than narrowing either push's own semantics.
+        let mut persist_presence_seen = false;
+        fx.retain(|effect| {
+            if matches!(effect, Effect::PersistPresence) {
+                let first = !persist_presence_seen;
+                persist_presence_seen = true;
+                first
+            } else {
+                true
+            }
+        });
         Outcome::with_effects(render, fx)
     }
 }

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -388,7 +388,7 @@ impl PluginRuntime {
         // a commit clears `Sessions::wants_fast_cadence`, and the chain must
         // be free to decay to Slow on this same pass rather than one fire
         // late.
-        let session_commit = self.sessions.tick(self.tick);
+        let session_commit = self.sessions.tick();
         if let Some(CommitTarget { name, attention_tab_position }) = session_commit {
             effects.push(Effect::SwitchSession { name, tab_position: attention_tab_position });
         }
@@ -458,7 +458,7 @@ impl PluginRuntime {
             }
             Verb::SessionNext | Verb::SessionPrev => {
                 let dir = if verb == Verb::SessionNext { Direction::Next } else { Direction::Prev };
-                let render = self.sessions.cycle(dir, self.tick);
+                let render = self.sessions.cycle(dir);
                 // A fresh tap must arm Fast immediately (not wait for the next
                 // domain change to pass through `project`), so the idle-commit
                 // in `timer` fires promptly rather than stalling behind a Slow

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -292,6 +292,13 @@ impl PluginRuntime {
         permission: PermissionProbe,
     ) -> Outcome {
         self.config = config;
+        // Load's single clock capture, stored eagerly (and reused by
+        // `begin_permission_flow`'s arm below, keeping one "now" per event):
+        // `session_name_changed` — often the very next event in — has no
+        // epoch of its own and replays `last_now_epoch_s`, so without this
+        // seed the first presence write would go out stamped
+        // `updated_epoch_s: 0`.
+        self.last_now_epoch_s = crate::clock::now_epoch_s();
         if let Some(raw) = snapshot {
             if let Some(tick) = self.radar.load_snapshot(raw) {
                 self.tick = tick;
@@ -712,8 +719,10 @@ impl PluginRuntime {
         // waiting on a peer's marker, or our own request is in-flight. Pre-grant
         // Zellij withholds the state events that would otherwise trigger a paint
         // (they need ReadApplicationState), so this timer is the only thing that
-        // gets the needs_permission screen onto the rail.
-        self.arm_timer_if_needed(crate::clock::now_epoch_s(), &mut effects);
+        // gets the needs_permission screen onto the rail. `last_now_epoch_s`
+        // is the capture `load` (this fn's sole caller) took at entry — not a
+        // second clock read, so the whole load event sees a single "now".
+        self.arm_timer_if_needed(self.last_now_epoch_s, &mut effects);
         // Load always initializes the sidebar's selectability, every arm.
         effects.push(Effect::SetSelectable(self.permission.selectable()));
         Outcome::with_effects(false, effects)
@@ -738,16 +747,22 @@ impl PluginRuntime {
     }
 
     /// Spec §10 cadence function. Fast (1s) while anything tick-windowed is
-    /// live; Slow (60s) while ledger ages are still changing; None once every
-    /// age is saturated ("1h+") — the battery property's full-disarm state.
-    /// A *denied* rail disarms unconditionally: without `ReadApplicationState`
-    /// none of the events that clear domain work ever arrive, so a stale
-    /// `Running` loaded from a snapshot would otherwise pin Fast ticks and
-    /// repaints forever behind a static needs-permission face.
+    /// live; Slow (60s) while ledger ages are still changing — or, once
+    /// `session_name_changed` has landed, forever. None — the battery
+    /// property's full-disarm state — therefore survives in exactly two
+    /// shapes: *pre-name* (no `ModeUpdate` has delivered a session name yet,
+    /// so there is no presence file whose liveness needs a heartbeat) and
+    /// *denied*. A *denied* rail disarms unconditionally: without
+    /// `ReadApplicationState` none of the events that clear domain work ever
+    /// arrive, so a stale `Running` loaded from a snapshot would otherwise
+    /// pin Fast ticks and repaints forever behind a static needs-permission
+    /// face.
     /// `now_epoch_s` is the event's single clock capture (the stores already
     /// take epochs as arguments; this extends that discipline up through the
     /// runtime so one event never sees two different "now"s).
     fn desired_cadence(&self, now_epoch_s: u64) -> Option<Cadence> {
+        // The early return outranks the name check below by construction: a
+        // denied rail must fully disarm even though its name is known.
         if self.permission.denied() {
             return None;
         }
@@ -762,10 +777,19 @@ impl PluginRuntime {
             Some(Cadence::Fast)
         } else if self.radar.ledger_any_unsaturated(now_epoch_s)
             || self.radar.pending_wait_unsaturated(now_epoch_s)
+            // A known name means this session has published a presence file
+            // whose mtime is the ONLY liveness signal peers read
+            // (`session_files::PRESENCE_LIVE_TTL`), and `timer`'s Slow-fire
+            // heartbeat is the only writer keeping it fresh. Fully disarming
+            // would freeze that mtime and get a still-alive idle session
+            // dropped from every peer's badge 180s later — so the chain must
+            // stay (at least) Slow-armed for as long as the name is known.
+            || !self.own_session_name.is_empty()
         {
             // Slow ticks exist to advance minute-granular ages: ledger rows'
-            // relative ages and pending rows' `· Nm` wait tags. Both freeze at
-            // 1h+ (saturation), which is what lets the timer disarm fully.
+            // relative ages and pending rows' `· Nm` wait tags. Both freeze
+            // at 1h+ (saturation) — which, before the name is learned, is
+            // what lets the timer disarm fully.
             Some(Cadence::Slow)
         } else {
             None

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -339,13 +339,25 @@ impl PluginRuntime {
         if !self.permission.granted() {
             return Outcome::none();
         }
-        let dir = match verb {
-            Verb::AttentionNext => Direction::Next,
-            Verb::AttentionPrev => Direction::Prev,
-        };
-        match self.radar.next_attention_tab(dir) {
-            Some(position) => Outcome::with_effects(false, vec![Effect::SwitchTab { position }]),
-            None => Outcome::none(),
+        match verb {
+            Verb::AttentionNext => {
+                let dir = Direction::Next;
+                match self.radar.next_attention_tab(dir) {
+                    Some(position) => Outcome::with_effects(false, vec![Effect::SwitchTab { position }]),
+                    None => Outcome::none(),
+                }
+            }
+            Verb::AttentionPrev => {
+                let dir = Direction::Prev;
+                match self.radar.next_attention_tab(dir) {
+                    Some(position) => Outcome::with_effects(false, vec![Effect::SwitchTab { position }]),
+                    None => Outcome::none(),
+                }
+            }
+            Verb::SessionNext | Verb::SessionPrev => {
+                // Session-cycle dispatch wiring is a later task; verbs parse but are inert for now.
+                Outcome::none()
+            }
         }
     }
 

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -132,6 +132,17 @@ pub(crate) enum Effect {
     /// there, jump straight to the tab that needs attention (if any).
     /// Emitted by `timer` when `Sessions::tick` reports an idle commit.
     SwitchSession { name: String, tab_position: Option<usize> },
+    /// Delete every on-disk presence file whose `session_name` matches
+    /// `name` — all of them, since a name can have multiple pid-keyed
+    /// corpses (`sessions.rs`'s dedup doc). Emitted by `mouse_right_click`
+    /// right after `Sessions::dismiss` has already dropped the name from
+    /// THIS instance's in-memory roster (the instant-feedback half); this
+    /// is the on-disk half, so every peer's next Fast read converges too.
+    /// Never destructive to a live session: if the dismissed name is
+    /// secretly still alive, its next heartbeat/edge re-publishes a fresh
+    /// presence file and it simply reappears, fresh (see
+    /// `Sessions::dismiss`).
+    DismissPresence { name: String },
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -436,6 +447,42 @@ impl PluginRuntime {
             Effect::SwitchTab { position: target.tab_position }
         };
         Outcome::with_effects(false, vec![effect])
+    }
+
+    /// Right-click: dismiss a STALE cross-session badge entry — the manual
+    /// complement to the 6h open-time sweep (`session_files`'s
+    /// `PRESENCE_MAX_AGE`), for a session the user already knows is dead.
+    /// Resolves the clicked line exactly like `mouse_click` (same cached
+    /// `RenderedRail`, same permission gate), but acts only when the target
+    /// is a peer-session line (`session: Some(name)`) whose name currently
+    /// reads stale on the badge. Everything else — a fresh peer, this
+    /// session's own line (click-inert: no target), a tab/pane line, an
+    /// empty line — is a strict no-op; right-click grows no behavior beyond
+    /// this one gesture. A hit does two things: `Sessions::dismiss` drops
+    /// the name from this instance's in-memory roster right away (the entry
+    /// vanishes without waiting on a file read), and `Effect::DismissPresence`
+    /// deletes the on-disk files so every peer converges on its own next
+    /// Fast read. `&mut self` where `mouse_click` is `&self` — dismissing
+    /// mutates the roster, not just reads it.
+    pub(crate) fn mouse_right_click(&mut self, line: isize) -> Outcome {
+        if !self.permission.granted() {
+            return Outcome::none();
+        }
+        let Some(target) = self.last_rendered.target_at_line(line) else {
+            return Outcome::none();
+        };
+        let Some(name) = target.session else {
+            return Outcome::none();
+        };
+        // Staleness is judged against the CURRENT badge, not anything baked
+        // into the click target at render time — the entry may have gone
+        // fresh (its session came back) between the paint and the click, and
+        // a dismiss must never race a live session's heartbeat.
+        if !self.sessions.badge().iter().any(|b| b.name == name && b.stale) {
+            return Outcome::none();
+        }
+        let render = self.sessions.dismiss(&name);
+        Outcome::with_effects(render, vec![Effect::DismissPresence { name }])
     }
 
     /// Run an imperative command verb. `AttentionNext/Prev` resolve a

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -22,8 +22,12 @@
 //!   [`control`](PluginRuntime::control) /
 //!   [`control_pipe`](PluginRuntime::control_pipe) — runtime config + remote
 //!   commands.
+//! - [`session_update`](PluginRuntime::session_update) — Zellij's live
+//!   session list (also how the runtime learns its own session's name).
+//! - [`presences_changed`](PluginRuntime::presences_changed) — peer presence
+//!   files, freshly read from disk.
 //! - [`timer`](PluginRuntime::timer) — periodic tick (animation +
-//!   permission-flow coordination).
+//!   permission-flow coordination + cross-session cycle commit).
 //! - [`mouse_click`](PluginRuntime::mouse_click) — resolved against the cached
 //!   [`RenderedRail`] for click-to-switch.
 //! - [`permission_result`](PluginRuntime::permission_result) — Zellij's grant /
@@ -32,9 +36,12 @@
 use crate::control::Verb;
 use crate::config;
 use crate::permission::{PermissionMarker, PermissionPolicy, PermissionProbe, PermissionState, Transition};
+use crate::presence::Presence;
 use crate::radar_state::{Direction, PaneUpdate, RadarChange, RadarState, RadarTab};
 use crate::render::{self, RenderedRail};
 use crate::rollup::TabRow;
+use crate::sessions::{CommitTarget, SessionLite, Sessions};
+use crate::status::Status;
 use crate::tab_namer::TabRename;
 use crate::theme;
 use std::collections::BTreeMap;
@@ -103,6 +110,19 @@ pub(crate) enum Effect {
     /// key to elect exactly one dispatcher (`SessionFiles::claim_notification`)
     /// so N visited tabs don't produce N identical toasts.
     Notify { key: String, title: String, body: String },
+    /// Publish this session's own [`Presence`] for peer rails to read.
+    /// Content-compared at the edge in `project` — lib.rs does
+    /// `files.persist_presence(&runtime.presence_json())`.
+    PersistPresence,
+    /// Re-read every peer session's presence file and feed the result back
+    /// through `presences_changed` — mirrors `ResolveCwd`'s
+    /// request/read-back pattern, except the read is unconditional each
+    /// timer fire rather than gated on a fresh set of pane ids.
+    ReadPresences,
+    /// Commit a cross-session cycle selection: switch to `name` and, once
+    /// there, jump straight to the tab that needs attention (if any).
+    /// Emitted by `timer` when `Sessions::tick` reports an idle commit.
+    SwitchSession { name: String, tab_position: Option<usize> },
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -227,6 +247,23 @@ pub(crate) struct PluginRuntime {
     pub(crate) theme: theme::DerivedColors,
     last_rendered: RenderedRail,
     notify_prev: BTreeMap<u32, crate::status::Status>,
+    /// Cross-session peer state + the Alt+[/] cycle selection machine.
+    sessions: Sessions,
+    /// This session's own name, learned from `session_update` (the
+    /// `SessionLite` with `is_current == true`). Empty until Zellij's first
+    /// session-list event lands — `project` withholds `Effect::PersistPresence`
+    /// while empty, since an unnamed presence file is useless to peers.
+    own_session_name: String,
+    /// The last own-`Presence` JSON actually published, so `project` can
+    /// content-compare and emit `Effect::PersistPresence` only on a real
+    /// edge — the same "write on edges only" rule `PersistSnapshot` follows.
+    last_presence_json: Option<String>,
+    /// The most recent `now_epoch_s` any entry point has captured. Reused
+    /// (never re-read from the clock) by call paths that have no epoch of
+    /// their own to work with — `presence_json`, `session_update`,
+    /// `presences_changed` — so a single event's "now" never forks in two
+    /// directions.
+    last_now_epoch_s: u64,
 }
 
 impl PluginRuntime {
@@ -296,6 +333,18 @@ impl PluginRuntime {
         // opened in that window would seed a rail missing the change — the same
         // cross-instance convergence pushed statuses get from `status_pipe`.
         let store_changed = self.radar.timer(self.tick, now);
+        // Cross-session peers: re-read every fire (Fast or Slow both fine —
+        // on Slow ticks peers refresh at most once a minute, acceptable for a
+        // badge) and, BEFORE re-arming below, commit an idle cycle selection
+        // if one is pending. Committing here — not after `project` re-arms —
+        // matters: a commit clears `Sessions::wants_fast_cadence`, and the
+        // chain must be free to decay to Slow on this same pass rather than
+        // one fire late.
+        effects.push(Effect::ReadPresences);
+        let session_commit = self.sessions.tick(self.tick);
+        if let Some(CommitTarget { name, attention_tab_position }) = session_commit {
+            effects.push(Effect::SwitchSession { name, tab_position: attention_tab_position });
+        }
         // Capture before re-arming: an in-flight permission request must repaint
         // the needs_permission screen each tick until the user answers.
         let awaiting_permission = self.sidebar_should_be_selectable();
@@ -332,32 +381,94 @@ impl PluginRuntime {
         Outcome::with_effects(false, vec![effect])
     }
 
-    /// Run an imperative command verb. Read-only navigation today: resolves a
-    /// deterministic target tab and emits `SwitchTab`. Inert until permission is
-    /// granted, mirroring `mouse_click`.
-    pub(crate) fn control(&self, verb: Verb) -> Outcome {
+    /// Run an imperative command verb. `AttentionNext/Prev` resolve a
+    /// deterministic target tab and emit `SwitchTab`; `SessionNext/Prev`
+    /// advance the cross-session cycle selection (`Sessions::cycle`) and
+    /// render the highlight move — the actual switch is a *later* idle-commit
+    /// (see `timer`), not an immediate effect here. Inert until permission is
+    /// granted, mirroring `mouse_click`: session switching is
+    /// `ChangeApplicationState` territory, same as `SwitchTab`.
+    pub(crate) fn control(&mut self, verb: Verb) -> Outcome {
         if !self.permission.granted() {
             return Outcome::none();
         }
-        let dir = match verb {
-            Verb::AttentionNext => Direction::Next,
-            Verb::AttentionPrev => Direction::Prev,
-            // Parsed but not yet dispatched — session cycling lands with the
-            // sessions state machine in a later change.
-            Verb::SessionNext | Verb::SessionPrev => return Outcome::none(),
-        };
-        match self.radar.next_attention_tab(dir) {
-            Some(position) => Outcome::with_effects(false, vec![Effect::SwitchTab { position }]),
-            None => Outcome::none(),
+        match verb {
+            Verb::AttentionNext | Verb::AttentionPrev => {
+                let dir = if verb == Verb::AttentionNext { Direction::Next } else { Direction::Prev };
+                match self.radar.next_attention_tab(dir) {
+                    Some(position) => Outcome::with_effects(false, vec![Effect::SwitchTab { position }]),
+                    None => Outcome::none(),
+                }
+            }
+            Verb::SessionNext | Verb::SessionPrev => {
+                let dir = if verb == Verb::SessionNext { Direction::Next } else { Direction::Prev };
+                let render = self.sessions.cycle(dir, self.tick);
+                // A fresh tap must arm Fast immediately (not wait for the next
+                // domain change to pass through `project`), so the idle-commit
+                // in `timer` fires promptly rather than stalling behind a Slow
+                // or fully-disarmed chain.
+                let mut effects = Vec::new();
+                self.arm_timer_if_needed(self.last_now_epoch_s, &mut effects);
+                Outcome::with_effects(render, effects)
+            }
         }
     }
 
     /// Parse a `cmd.v1` payload and dispatch it. Unknown verbs are a no-op.
-    pub(crate) fn control_pipe(&self, payload: &str) -> Outcome {
+    pub(crate) fn control_pipe(&mut self, payload: &str) -> Outcome {
         match crate::control::parse(payload) {
             Some(verb) => self.control(verb),
             None => Outcome::none(),
         }
+    }
+
+    /// Zellij's live session list. Also how the runtime learns its own
+    /// session's name (the entry with `is_current == true`) — needed by
+    /// `presence_json` and gating `Effect::PersistPresence` in `project`.
+    pub(crate) fn session_update(&mut self, live: Vec<SessionLite>) -> Outcome {
+        if let Some(me) = live.iter().find(|s| s.is_current) {
+            self.own_session_name = me.name.clone();
+        }
+        let render = self.sessions.update_live(live);
+        let change = RadarChange { render, settle: false, persist_snapshot: false, renames: vec![], cwd_bootstrap: vec![] };
+        self.project(vec![], change, self.last_now_epoch_s)
+    }
+
+    /// A fresh read of every peer session's presence file
+    /// (`Effect::ReadPresences`'s read-back). Renders only when the derived
+    /// badge actually changed.
+    pub(crate) fn presences_changed(&mut self, raw: Vec<String>) -> Outcome {
+        let render = self.sessions.update_presences(raw);
+        let change = RadarChange { render, settle: false, persist_snapshot: false, renames: vec![], cwd_bootstrap: vec![] };
+        self.project(vec![], change, self.last_now_epoch_s)
+    }
+
+    /// This session's own `Presence`, derived from the same rows the rail
+    /// renders (`radar.rows`) — never a separately-tracked count that could
+    /// drift from what's on screen. `attention_tab_position` is the first
+    /// (lowest-position) row that `needs_you()`, matching the position
+    /// `Sessions`/`BadgeEntry` expect for a same-repo jump-on-arrival.
+    pub(crate) fn presence_json(&self) -> String {
+        let rows = self.radar.rows(self.tick);
+        let running = rows.iter().filter(|r| r.display.status == Status::Running).count();
+        let mut attention = 0usize;
+        let mut attention_tab_position = None;
+        for r in &rows {
+            if r.display.status.needs_you() {
+                attention += 1;
+                if attention_tab_position.is_none() {
+                    attention_tab_position = Some(r.number as usize - 1);
+                }
+            }
+        }
+        Presence {
+            session_name: self.own_session_name.clone(),
+            running,
+            attention,
+            attention_tab_position,
+            updated_epoch_s: self.last_now_epoch_s,
+        }
+        .to_json()
     }
 
     /// True while [`timer`](Self::timer) still consumes a fresh
@@ -574,7 +685,14 @@ impl PluginRuntime {
         if self.permission.denied() {
             return None;
         }
-        if self.permission.is_waiting() || self.permission.selectable() || self.timer_should_continue() {
+        if self.permission.is_waiting()
+            || self.permission.selectable()
+            || self.timer_should_continue()
+            // A pending cross-session cycle selection needs the idle-commit
+            // in `timer` to fire promptly, not wait out a Slow (or fully
+            // disarmed) chain.
+            || self.sessions.wants_fast_cadence()
+        {
             Some(Cadence::Fast)
         } else if self.radar.ledger_any_unsaturated(now_epoch_s)
             || self.radar.pending_wait_unsaturated(now_epoch_s)
@@ -665,18 +783,38 @@ impl PluginRuntime {
     /// The sole projection from a domain [`RadarChange`] to host [`Effect`]s.
     /// `fx` is a caller-supplied seed so the `timer` handler's permission
     /// effects come first, without a post-hoc splice. Canonical order: renames
-    /// → snapshot → cwd → `SetTimeout` → notify — identical to today's
-    /// `panes_changed`, so that handler is byte-for-byte unchanged. `settle`
-    /// is the per-handler stamp described in `## Settle` (`CONTEXT.md`): this
-    /// is the sole caller of `notify_effects`, and the only *domain-change* path
-    /// that arms the timer (the permission flow arms it separately in
-    /// `begin_permission_flow`). `TimerChain::arm` self-guards on the armed cadence and on
-    /// whether there's anything to arm for, so calling it unconditionally
-    /// here is a no-op wherever a handler has no pending work to arm for.
+    /// → snapshot → presence → cwd → `SetTimeout` → notify — identical to
+    /// today's `panes_changed` apart from the presence edge, so that handler
+    /// is otherwise byte-for-byte unchanged. `settle` is the per-handler stamp
+    /// described in `## Settle` (`CONTEXT.md`): this is the sole caller of
+    /// `notify_effects`, and the only *domain-change* path that arms the timer
+    /// (the permission flow arms it separately in `begin_permission_flow`).
+    /// `TimerChain::arm` self-guards on the armed cadence and on whether
+    /// there's anything to arm for, so calling it unconditionally here is a
+    /// no-op wherever a handler has no pending work to arm for.
+    ///
+    /// Also the single point deciding `Effect::PersistPresence`: every
+    /// domain-change entry point funnels through here with its `now_epoch_s`,
+    /// which this stores (`last_now_epoch_s`) for the call paths that have no
+    /// epoch of their own — `presence_json`, `session_update`,
+    /// `presences_changed`. The freshly computed own-`Presence` JSON is
+    /// content-compared against the last one published; a real edge pushes
+    /// the effect and updates the cache, mirroring `PersistSnapshot`'s
+    /// "write on edges only" rule. Withheld while `own_session_name` is empty
+    /// — a presence file with no name is useless to peers — so it stays
+    /// quiet until `session_update` (also routed through here) learns it.
     fn project(&mut self, mut fx: Vec<Effect>, c: RadarChange, now_epoch_s: u64) -> Outcome {
+        self.last_now_epoch_s = now_epoch_s;
         fx.extend(self.effects_from_renames(c.renames));
         if c.persist_snapshot {
             fx.push(Effect::PersistSnapshot);
+        }
+        if !self.own_session_name.is_empty() {
+            let fresh = self.presence_json();
+            if self.last_presence_json.as_deref() != Some(fresh.as_str()) {
+                self.last_presence_json = Some(fresh);
+                fx.push(Effect::PersistPresence);
+            }
         }
         if !c.cwd_bootstrap.is_empty() {
             fx.push(Effect::ResolveCwd { pane_ids: c.cwd_bootstrap });

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -22,8 +22,15 @@
 //!   [`control`](PluginRuntime::control) /
 //!   [`control_pipe`](PluginRuntime::control_pipe) — runtime config + remote
 //!   commands.
-//! - [`session_update`](PluginRuntime::session_update) — Zellij's live
-//!   session list (also how the runtime learns its own session's name).
+//! - [`session_name_changed`](PluginRuntime::session_name_changed) —
+//!   `Event::ModeUpdate`'s `session_name`, the push-style source that
+//!   replaced `SessionUpdate` for learning this session's own name
+//!   (task-8b-brief.md: `SessionUpdate`'s peer list never populates without
+//!   a plugin calling the blocking `get_session_list()`, which stock
+//!   zj-radar never does — see `task-8-report.md`). Liveness itself no
+//!   longer comes from a Zellij-reported peer list at all: it's implicit in
+//!   which presence files `session_files::read_peer_presences` returns
+//!   (its mtime gate IS the liveness signal).
 //! - [`presences_changed`](PluginRuntime::presences_changed) — peer presence
 //!   files, freshly read from disk.
 //! - [`timer`](PluginRuntime::timer) — periodic tick (animation +
@@ -40,7 +47,7 @@ use crate::presence::Presence;
 use crate::radar_state::{Direction, PaneUpdate, RadarChange, RadarState, RadarTab};
 use crate::render::{self, RenderedRail};
 use crate::rollup::TabRow;
-use crate::sessions::{CommitTarget, SessionLite, Sessions};
+use crate::sessions::{CommitTarget, Sessions};
 use crate::status::Status;
 use crate::tab_namer::TabRename;
 use crate::theme;
@@ -251,9 +258,9 @@ pub(crate) struct PluginRuntime {
     notify_prev: BTreeMap<u32, crate::status::Status>,
     /// Cross-session peer state + the Alt+[/] cycle selection machine.
     sessions: Sessions,
-    /// This session's own name, learned from `session_update` (the
-    /// `SessionLite` with `is_current == true`). Empty until Zellij's first
-    /// session-list event lands — `project` withholds `Effect::PersistPresence`
+    /// This session's own name, learned from `session_name_changed`
+    /// (`Event::ModeUpdate`'s `ModeInfo.session_name`). Empty until Zellij's
+    /// first `ModeUpdate` lands — `project` withholds `Effect::PersistPresence`
     /// while empty, since an unnamed presence file is useless to peers.
     own_session_name: String,
     /// The last own-`Presence` actually published, canonicalized with
@@ -355,6 +362,19 @@ impl PluginRuntime {
         // instead of staleness.
         if elapsed_s <= STALE_FIRE_ELAPSED_S {
             effects.push(Effect::ReadPresences);
+        } else if !self.own_session_name.is_empty() {
+            // Idle-but-alive heartbeat, the Slow-cadence complement of the
+            // Fast-only `ReadPresences` gate above. `project`'s own
+            // `PersistPresence` is content-edge-gated (`last_presence`'s
+            // compare-and-cache), which is right for Fast cadence — but a
+            // session with nothing new to report can sit on an unchanged
+            // edge forever, and its presence file's mtime (the only
+            // liveness signal peers read — `session_files::PRESENCE_LIVE_TTL`)
+            // would go stale even though the session is still up. Bypass the
+            // edge gate here, unconditionally, so an idle session's file
+            // still gets touched at least once per Slow (60s) tick — well
+            // inside the 180s TTL even with a skipped/delayed fire.
+            effects.push(Effect::PersistPresence);
         }
         // BEFORE re-arming below, commit an idle cycle selection if one is
         // pending. Committing here — not after `project` re-arms — matters:
@@ -451,16 +471,22 @@ impl PluginRuntime {
         }
     }
 
-    /// Zellij's live session list. Also how the runtime learns its own
-    /// session's name (the entry with `is_current == true`) — needed by
-    /// `presence_json` and gating `Effect::PersistPresence` in `project`.
-    pub(crate) fn session_update(&mut self, live: Vec<SessionLite>) -> Outcome {
-        if let Some(me) = live.iter().find(|s| s.is_current) {
-            self.own_session_name = me.name.clone();
-        }
-        let render = self.sessions.update_live(live);
-        let change = RadarChange { render, settle: false, persist_snapshot: false, renames: vec![], cwd_bootstrap: vec![] };
-        self.project(vec![], change, self.last_now_epoch_s)
+    /// Learn (or relearn) this session's own name — the push-style source
+    /// that replaced `SessionUpdate` (task-8b-brief.md): `Event::ModeUpdate`'s
+    /// `ModeInfo.session_name`. `None` is a true no-op: Zellij can in
+    /// principle fire `ModeUpdate` before the session has a name, and there
+    /// is nothing to do with that yet — re-projecting on every such event
+    /// would waste a `project()` pass for nothing new to report. A `Some`
+    /// always re-projects, even a repeat of the already-known name:
+    /// `ModeUpdate` fires on far more than name changes (any mode/keybind/
+    /// pane-group change too), and letting `project`'s own idempotent
+    /// content-compares (`PersistPresence`'s cache, `Sessions::set_own`'s
+    /// badge diff) absorb the repeats is simpler, and no less correct, than
+    /// hand-rolling an equality check here.
+    pub(crate) fn session_name_changed(&mut self, name: Option<String>) -> Outcome {
+        let Some(name) = name else { return Outcome::none() };
+        self.own_session_name = name;
+        self.project(vec![], RadarChange::default(), self.last_now_epoch_s)
     }
 
     /// A fresh read of every peer session's presence file
@@ -836,7 +862,7 @@ impl PluginRuntime {
     /// Also the single point deciding `Effect::PersistPresence`: every
     /// domain-change entry point funnels through here with its `now_epoch_s`,
     /// which this stores (`last_now_epoch_s`) for the call paths that have no
-    /// epoch of their own — `presence_json`, `session_update`,
+    /// epoch of their own — `presence_json`, `session_name_changed`,
     /// `presences_changed`. The freshly computed own-`Presence` is
     /// content-compared against the last one published, EXCLUDING
     /// `updated_epoch_s` (zeroed on both sides before the compare/cache) —
@@ -845,18 +871,30 @@ impl PluginRuntime {
     /// updates the cache, mirroring `PersistSnapshot`'s "write on edges only"
     /// rule. Withheld while `own_session_name` is empty — a presence file
     /// with no name is useless to peers — so it stays quiet until
-    /// `session_update` (also routed through here) learns it.
+    /// `session_name_changed` (also routed through here) learns it.
+    ///
+    /// Same gate also feeds `Sessions::set_own` — the single path for own
+    /// counts into the OWN badge row (task-8b-brief.md un-deads it: nothing
+    /// called it before this). Unlike `PersistPresence`, this is NOT
+    /// edge-gated by `last_presence`'s cache — `Sessions::set_own` already
+    /// does its own badge-derived content-compare and reports whether the
+    /// badge actually changed, so calling it every `project` pass (once the
+    /// name is known) is correct AND is what closes the gap where the own
+    /// row never updated as running/attention moved.
     fn project(&mut self, mut fx: Vec<Effect>, c: RadarChange, now_epoch_s: u64) -> Outcome {
         self.last_now_epoch_s = now_epoch_s;
         fx.extend(self.effects_from_renames(c.renames));
         if c.persist_snapshot {
             fx.push(Effect::PersistSnapshot);
         }
+        let mut render = c.render;
         if !self.own_session_name.is_empty() {
-            let mut fresh = self.own_presence();
-            fresh.updated_epoch_s = 0;
-            if self.last_presence.as_ref() != Some(&fresh) {
-                self.last_presence = Some(fresh);
+            let fresh = self.own_presence();
+            render |= self.sessions.set_own(fresh.clone());
+            let mut compare = fresh;
+            compare.updated_epoch_s = 0;
+            if self.last_presence.as_ref() != Some(&compare) {
+                self.last_presence = Some(compare);
                 fx.push(Effect::PersistPresence);
             }
         }
@@ -867,7 +905,7 @@ impl PluginRuntime {
         if c.settle {
             fx.extend(self.notify_effects());
         }
-        Outcome::with_effects(c.render, fx)
+        Outcome::with_effects(render, fx)
     }
 }
 

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -143,6 +143,22 @@ pub(crate) enum Effect {
     /// presence file and it simply reappears, fresh (see
     /// `Sessions::dismiss`).
     DismissPresence { name: String },
+    /// Re-broadcast a `zj_radar.status.v1` payload over the shared pipe —
+    /// `payload` is already wire-encoded (`payload::to_wire`), ready to hand
+    /// to `zellij pipe`. Emitted by `mouse_right_click`'s pending-pane
+    /// acknowledge: dismissing a pending pane must be a SHARED signal (issue
+    /// #5's design constraint — clearing it only in the clicking instance
+    /// repeats the removed focus-clear mistake, where a background tab's
+    /// rail never learns the card changed). So the click never mutates
+    /// `radar` directly; it only ever produces this effect, and every
+    /// instance — including the one that clicked, via the same fan-out a
+    /// real producer's broadcast gets — converges through the normal
+    /// `status_pipe` → `StatusStore::apply` intake once the pipe echoes it
+    /// back. `apply`'s existing identical-rebroadcast no-op (same
+    /// `(status, msg)` twice: no `completed_epoch_s` re-stamp, no second
+    /// ledger edge) is what makes that convergence idempotent rather than a
+    /// second race.
+    BroadcastStatus { payload: String },
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -449,21 +465,25 @@ impl PluginRuntime {
         Outcome::with_effects(false, vec![effect])
     }
 
-    /// Right-click: dismiss a STALE cross-session badge entry — the manual
-    /// complement to the 6h open-time sweep (`session_files`'s
-    /// `PRESENCE_MAX_AGE`), for a session the user already knows is dead.
-    /// Resolves the clicked line exactly like `mouse_click` (same cached
-    /// `RenderedRail`, same permission gate), but acts only when the target
-    /// is a peer-session line (`session: Some(name)`) whose name currently
-    /// reads stale on the badge. Everything else — a fresh peer, this
-    /// session's own line (click-inert: no target), a tab/pane line, an
-    /// empty line — is a strict no-op; right-click grows no behavior beyond
-    /// this one gesture. A hit does two things: `Sessions::dismiss` drops
-    /// the name from this instance's in-memory roster right away (the entry
-    /// vanishes without waiting on a file read), and `Effect::DismissPresence`
-    /// deletes the on-disk files so every peer converges on its own next
-    /// Fast read. `&mut self` where `mouse_click` is `&self` — dismissing
-    /// mutates the roster, not just reads it.
+    /// Right-click: the rail's acknowledge/dismiss verb (left-click stays
+    /// pure navigation). Resolves the clicked line exactly like `mouse_click`
+    /// (same cached `RenderedRail`, same permission gate), then branches on
+    /// what the target resolved to:
+    ///
+    /// - **A peer-session badge line** (`session: Some(name)`) — dismiss a
+    ///   STALE cross-session entry, the manual complement to the 6h
+    ///   open-time sweep (`session_files`'s `PRESENCE_MAX_AGE`), for a
+    ///   session the user already knows is dead. This branch is untouched
+    ///   from before issue #5 and takes precedence: a session target never
+    ///   also carries a `pane_id`, but checking it first keeps the cases
+    ///   visibly exclusive rather than relying on that absence. Everything
+    ///   else about it — fresh peer / own line / no-op — is exactly as
+    ///   documented at `Effect::DismissPresence`.
+    /// - **A pane or tab row** — acknowledge a pending pane: see
+    ///   `acknowledge_pending_targets`. This is issue #5's fix for the
+    ///   completed-turn-ending-in-a-courtesy-question trap: `Pending` has no
+    ///   exit besides another broadcast, so a click that means "I saw it,
+    ///   stop asking" has to BE one.
     pub(crate) fn mouse_right_click(&mut self, line: isize) -> Outcome {
         if !self.permission.granted() {
             return Outcome::none();
@@ -471,18 +491,75 @@ impl PluginRuntime {
         let Some(target) = self.last_rendered.target_at_line(line) else {
             return Outcome::none();
         };
-        let Some(name) = target.session else {
-            return Outcome::none();
-        };
-        // Staleness is judged against the CURRENT badge, not anything baked
-        // into the click target at render time — the entry may have gone
-        // fresh (its session came back) between the paint and the click, and
-        // a dismiss must never race a live session's heartbeat.
-        if !self.sessions.badge().iter().any(|b| b.name == name && b.stale) {
-            return Outcome::none();
+        // `.clone()`, not a move: a session-line miss falls through to the
+        // pane/tab branch below, which still needs the rest of `target`.
+        if let Some(name) = target.session.clone() {
+            // Staleness is judged against the CURRENT badge, not anything
+            // baked into the click target at render time — the entry may
+            // have gone fresh (its session came back) between the paint and
+            // the click, and a dismiss must never race a live session's
+            // heartbeat.
+            if !self.sessions.badge().iter().any(|b| b.name == name && b.stale) {
+                return Outcome::none();
+            }
+            let render = self.sessions.dismiss(&name);
+            return Outcome::with_effects(render, vec![Effect::DismissPresence { name }]);
         }
-        let render = self.sessions.dismiss(&name);
-        Outcome::with_effects(render, vec![Effect::DismissPresence { name }])
+        Outcome::with_effects(false, self.acknowledge_pending_targets(&target))
+    }
+
+    /// The pane-or-tab half of `mouse_right_click`: every pane a click on
+    /// `target` should check for a dismissible `Pending` — one pane for a
+    /// pane row (`target.pane_id: Some(p)`), every pane in the tab for a tab
+    /// row (`target.pane_id: None` — a tab's header line, or a plain tab with
+    /// no per-pane detail line at all) — turned into one `Effect::BroadcastStatus`
+    /// per pane whose STATUS-PIPE observation (`RadarState::status_observation`;
+    /// never command-origin, which is untouched by design) currently reads
+    /// `Pending`. A target with nothing Pending on it — including every
+    /// other status, and a tab with no tracked panes at all — produces no
+    /// effects: `Outcome::with_effects(false, vec![])` equals `Outcome::none()`,
+    /// so this is a strict no-op, not a render with nothing to show for it.
+    /// Deliberately returns `render: false` from the caller regardless: this
+    /// gesture never mutates `radar` — see `Effect::BroadcastStatus`'s doc for
+    /// why the convergence has to ride the pipe instead.
+    fn acknowledge_pending_targets(&self, target: &render::RailTarget) -> Vec<Effect> {
+        let pane_ids = match target.pane_id {
+            Some(pane_id) => vec![pane_id],
+            None => self.radar.pane_ids_for_tab(target.tab_position),
+        };
+        pane_ids
+            .into_iter()
+            .filter_map(|pane_id| self.acknowledge_pending_payload(pane_id))
+            .map(|payload| Effect::BroadcastStatus { payload })
+            .collect()
+    }
+
+    /// The synthetic `zj_radar.status.v1` payload that acknowledges `pane_id`
+    /// — `None` unless the status store currently reads it as `Pending`
+    /// (anything else, including a command-origin observation the status
+    /// store never held in the first place, is left alone). Carries the
+    /// observation's own repo/branch/msg forward — only `status` moves,
+    /// Pending → Done — and re-derives `source` from its already-classified
+    /// `kind` via `Kind::as_source`, the exact inverse of the intake
+    /// classification (`Kind::from_source`), so the pane's `Kind` survives
+    /// the round trip unchanged. `task` is left absent (empty): `StatusStore::apply`
+    /// treats an empty `task` on a non-Idle status as "leave the sticky label
+    /// alone", so the turn's task stays put rather than this dismiss quietly
+    /// erasing it.
+    fn acknowledge_pending_payload(&self, pane_id: u32) -> Option<String> {
+        let obs = self.radar.status_observation(pane_id)?;
+        if obs.status != Status::Pending {
+            return None;
+        }
+        Some(crate::payload::to_wire(&crate::payload::StatusPayload {
+            pane_id,
+            status: Status::Done,
+            repo: obs.repo.clone(),
+            branch: obs.branch.clone(),
+            msg: obs.msg.clone(),
+            task: String::new(),
+            source: obs.kind.as_source().to_string(),
+        }))
     }
 
     /// Run an imperative command verb. `AttentionNext/Prev` resolve a

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -339,25 +339,16 @@ impl PluginRuntime {
         if !self.permission.granted() {
             return Outcome::none();
         }
-        match verb {
-            Verb::AttentionNext => {
-                let dir = Direction::Next;
-                match self.radar.next_attention_tab(dir) {
-                    Some(position) => Outcome::with_effects(false, vec![Effect::SwitchTab { position }]),
-                    None => Outcome::none(),
-                }
-            }
-            Verb::AttentionPrev => {
-                let dir = Direction::Prev;
-                match self.radar.next_attention_tab(dir) {
-                    Some(position) => Outcome::with_effects(false, vec![Effect::SwitchTab { position }]),
-                    None => Outcome::none(),
-                }
-            }
-            Verb::SessionNext | Verb::SessionPrev => {
-                // Session-cycle dispatch wiring is a later task; verbs parse but are inert for now.
-                Outcome::none()
-            }
+        let dir = match verb {
+            Verb::AttentionNext => Direction::Next,
+            Verb::AttentionPrev => Direction::Prev,
+            // Parsed but not yet dispatched — session cycling lands with the
+            // sessions state machine in a later change.
+            Verb::SessionNext | Verb::SessionPrev => return Outcome::none(),
+        };
+        match self.radar.next_attention_tab(dir) {
+            Some(position) => Outcome::with_effects(false, vec![Effect::SwitchTab { position }]),
+            None => Outcome::none(),
         }
     }
 

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -375,12 +375,13 @@ impl PluginRuntime {
             // `PersistPresence` is content-edge-gated (`last_presence`'s
             // compare-and-cache), which is right for Fast cadence — but a
             // session with nothing new to report can sit on an unchanged
-            // edge forever, and its presence file's mtime (the only
-            // liveness signal peers read — `session_files::PRESENCE_LIVE_TTL`)
-            // would go stale even though the session is still up. Bypass the
-            // edge gate here, unconditionally, so an idle session's file
-            // still gets touched at least once per Slow (60s) tick — well
-            // inside the 180s TTL even with a skipped/delayed fire.
+            // edge forever, and its presence file's mtime (the signal peers
+            // read to tell fresh from stale — `sessions::STALE_AFTER_SECS`)
+            // would age past that threshold even though the session is
+            // still up. Bypass the edge gate here, unconditionally, so an
+            // idle session's file still gets touched at least once per Slow
+            // (60s) tick — well inside the 90s stale threshold even with a
+            // skipped/delayed fire.
             effects.push(Effect::PersistPresence);
         }
         // BEFORE re-arming below, commit an idle cycle selection if one is
@@ -496,10 +497,11 @@ impl PluginRuntime {
         self.project(vec![], RadarChange::default(), self.last_now_epoch_s)
     }
 
-    /// A fresh read of every peer session's presence file
-    /// (`Effect::ReadPresences`'s read-back). Renders only when the derived
-    /// badge actually changed.
-    pub(crate) fn presences_changed(&mut self, raw: Vec<String>) -> Outcome {
+    /// A fresh read of every peer session's presence file, each paired with
+    /// its file's mtime age in seconds (`Effect::ReadPresences`'s
+    /// read-back — `session_files::read_peer_presences`'s `age_secs`).
+    /// Renders only when the derived badge actually changed.
+    pub(crate) fn presences_changed(&mut self, raw: Vec<(String, u64)>) -> Outcome {
         let render = self.sessions.update_presences(raw);
         let change = RadarChange { render, settle: false, persist_snapshot: false, renames: vec![], cwd_bootstrap: vec![] };
         self.project(vec![], change, self.last_now_epoch_s)
@@ -778,12 +780,14 @@ impl PluginRuntime {
         } else if self.radar.ledger_any_unsaturated(now_epoch_s)
             || self.radar.pending_wait_unsaturated(now_epoch_s)
             // A known name means this session has published a presence file
-            // whose mtime is the ONLY liveness signal peers read
-            // (`session_files::PRESENCE_LIVE_TTL`), and `timer`'s Slow-fire
+            // whose mtime is the signal peers read to tell fresh from stale
+            // (`sessions::STALE_AFTER_SECS`), and `timer`'s Slow-fire
             // heartbeat is the only writer keeping it fresh. Fully disarming
             // would freeze that mtime and get a still-alive idle session
-            // dropped from every peer's badge 180s later — so the chain must
-            // stay (at least) Slow-armed for as long as the name is known.
+            // dimmed to stale on every peer's badge 90s later (never
+            // dropped — task-14 — but still a needless false alarm) — so
+            // the chain must stay (at least) Slow-armed for as long as the
+            // name is known.
             || !self.own_session_name.is_empty()
         {
             // Slow ticks exist to advance minute-granular ages: ledger rows'

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -392,11 +392,20 @@ impl PluginRuntime {
         let Some(target) = self.last_rendered.target_at_line(line) else {
             return Outcome::none();
         };
-        let effect = match target.pane_id {
-            Some(pane_id) => Effect::ShowPane { pane_id },
-            None => Effect::SwitchTab {
-                position: target.tab_position,
-            },
+        // A cross-session badge line (`session: Some(name)`) always wins the
+        // match — those targets never carry a `pane_id`, but checking
+        // `session` first (rather than falling into the `pane_id`/`tab_position`
+        // arms below) keeps the three cases visibly mutually exclusive rather
+        // than relying on that absence. `tab_position` is read through
+        // `session_tab_position` (not the raw field), which undoes the
+        // `RailTarget::for_session` sentinel encoding back into the
+        // `Option<usize>` the effect needs — see both docs.
+        let effect = if let Some(name) = target.session.clone() {
+            Effect::SwitchSession { name, tab_position: target.session_tab_position() }
+        } else if let Some(pane_id) = target.pane_id {
+            Effect::ShowPane { pane_id }
+        } else {
+            Effect::SwitchTab { position: target.tab_position }
         };
         Outcome::with_effects(false, vec![effect])
     }
@@ -585,6 +594,7 @@ impl PluginRuntime {
             theme: self.theme.clone(),
             now_epoch_s: crate::clock::now_epoch_s(),
             jump_hint: self.config.jump_hint.shows(),
+            badge: self.sessions.badge(),
         };
         let ledger = self.radar.ledger_lines();
         let rail = if !self.permission.granted() {
@@ -619,6 +629,7 @@ impl PluginRuntime {
             theme: self.theme.clone(),
             now_epoch_s: crate::clock::now_epoch_s(),
             jump_hint: self.config.jump_hint.shows(),
+            badge: self.sessions.badge(),
         };
         render::body_line_count(&tabrows, &self.radar.ledger_lines(), &opts)
     }

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -545,7 +545,10 @@ impl PluginRuntime {
     /// the round trip unchanged. `task` is left absent (empty): `StatusStore::apply`
     /// treats an empty `task` on a non-Idle status as "leave the sticky label
     /// alone", so the turn's task stays put rather than this dismiss quietly
-    /// erasing it.
+    /// erasing it. Rides with `ack: true`: this Done means "the user has seen
+    /// it", so the notifier must stay silent in EVERY instance the echo
+    /// reaches — a gesture that means "stop flagging this" must not flag it
+    /// one more time (`notify_rules::diff` skips acknowledged observations).
     fn acknowledge_pending_payload(&self, pane_id: u32) -> Option<String> {
         let obs = self.radar.status_observation(pane_id)?;
         if obs.status != Status::Pending {
@@ -559,6 +562,7 @@ impl PluginRuntime {
             msg: obs.msg.clone(),
             task: String::new(),
             source: obs.kind.as_source().to_string(),
+            ack: true,
         }))
     }
 

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -1231,6 +1231,55 @@ fn double_delivery_of_the_acknowledge_broadcast_is_idempotent() {
 }
 
 #[test]
+fn acknowledge_echo_never_fires_a_done_notification() {
+    // Right-click means "I've seen this, stop flagging it" — so the synthetic
+    // Done it broadcasts must never itself pop a notification. The echo rides
+    // the same intake as every real broadcast (by design), and a background
+    // Pending → Done edge WOULD normally notify (`needs_attention` includes
+    // Done, `notify_done` defaults true) — the ack has to be exempt.
+    let mut rt = runtime_with_pending_panes();
+    // First settle advances the notify baseline past the seeded Pendings
+    // (firing THEIR notifications — the flagging the user is responding to).
+    let _ = rt.timer_fast(PermissionProbe::default());
+
+    let out = rt.mouse_right_click(3); // pane 10, Pending, background
+    let Effect::BroadcastStatus { payload } = &out.effects[0] else {
+        panic!("expected BroadcastStatus, got {:?}", out.effects);
+    };
+    let payload = payload.clone();
+    rt.status_pipe(&payload); // the echo lands: Pending → Done
+    assert_eq!(rt.radar.status(10).unwrap().status, Status::Done, "setup: the echo must converge");
+
+    // No later settle may notify for the acknowledged pane — not the first
+    // (which carries the deferred edge) nor any that follow.
+    for _ in 0..4 {
+        let t = rt.timer_fast(PermissionProbe::default());
+        assert!(
+            !t.effects.iter().any(|e| matches!(e, Effect::Notify { .. })),
+            "an acknowledge must never notify; effects = {:?}", t.effects
+        );
+    }
+}
+
+#[test]
+fn a_real_pending_to_done_broadcast_still_notifies() {
+    // The companion bound to the test above: the ack exemption must be carried
+    // by the PAYLOAD, not inferred from the Pending → Done edge shape — that
+    // edge happens for real (answer a question, tab away, a short no-tool turn
+    // ends in Done) and that completion notification is wanted.
+    let mut rt = runtime_with_pending_panes();
+    let _ = rt.timer_fast(PermissionProbe::default()); // baseline: Pending
+
+    rt.status_pipe(&payload_json(10, "done")); // a genuine producer Done
+    let tick = rt.timer_fast(PermissionProbe::default());
+    assert_eq!(
+        tick.effects.iter().filter(|e| matches!(e, Effect::Notify { .. })).count(),
+        1,
+        "a real background Pending → Done must still notify; effects = {:?}", tick.effects
+    );
+}
+
+#[test]
 fn own_badge_row_updates_live_as_running_and_attention_move() {
     // Task-6 flagged `Sessions::set_own` as dead code: nothing called it, so
     // the own row of the cross-session badge never reflected the running/

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -1092,6 +1092,144 @@ fn right_click_without_permission_is_inert_even_on_stale_session_line() {
     );
 }
 
+// ── Right-click: pending-pane acknowledge (issue #5) ───────────────────────
+
+/// Two tabs for the pending-pane acknowledge tests: tab 0 has panes 10
+/// (Pending), 11 (Running), 12 (Pending); tab 1 has one pane, 20 (Pending).
+/// Rendered once so `last_rendered` carries the click-target map. Line
+/// layout, pinned by inspection the same way every other click-mapping test
+/// in this file hard-codes its lines (Compact density, header:true):
+///   0/1 global header
+///   2   tab0 header line   → (tab_position: 0, pane_id: None)
+///   3   tab0 pane 10 line  → (0, Some(10)) — Pending
+///   4   tab0 pane 11 line  → (0, Some(11)) — Running
+///   5   tab0 pane 12 line  → (0, Some(12)) — Pending
+///   6   tab1 header line   → (1, None)
+///   7   tab1 pane 20 line  → (1, Some(20)) — Pending
+fn runtime_with_pending_panes() -> PluginRuntime {
+    let mut rt = PluginRuntime {
+        permission: PermissionState::Resolved { granted: true },
+        config: config(),
+        ..Default::default()
+    };
+    rt.tabs_changed(vec![tab(0, "a", false), tab(1, "b", false)]);
+    rt.radar.set_tab_panes_for_position(0, vec![pane(10), pane(11), pane(12)]);
+    rt.radar.set_tab_panes_for_position(1, vec![pane(20)]);
+    rt.status_pipe(&payload_json(10, "pending"));
+    rt.status_pipe(&payload_json(11, "running"));
+    rt.status_pipe(&payload_json(12, "pending"));
+    rt.status_pipe(&payload_json(20, "pending"));
+    let _ = rt.render(100, 80);
+    rt
+}
+
+#[test]
+fn right_click_on_pending_pane_broadcasts_and_leaves_local_state_untouched_until_the_echo_lands() {
+    let mut rt = runtime_with_pending_panes();
+
+    let out = rt.mouse_right_click(3); // tab0 pane 10, Pending
+    assert!(!out.render, "the click itself must not mutate local state — see Effect::BroadcastStatus's doc");
+    assert_eq!(out.effects.len(), 1, "exactly one pending pane on this line, got {:?}", out.effects);
+    let Effect::BroadcastStatus { payload } = &out.effects[0] else {
+        panic!("expected BroadcastStatus, got {:?}", out.effects);
+    };
+
+    // Pending survives the click alone — convergence rides the pipe, not a
+    // local write (the design constraint issue #5 leads with: a local clear
+    // would repeat the removed focus-clear mistake).
+    assert_eq!(rt.radar.status(10).unwrap().status, Status::Pending, "no local mutation from the click alone");
+
+    // Only once the payload is driven back through `status_pipe` — exactly
+    // how every instance, including this one, receives the broadcast it
+    // just emitted — does the row actually converge.
+    let payload = payload.clone();
+    rt.status_pipe(&payload);
+    assert_eq!(rt.radar.status(10).unwrap().status, Status::Done, "the echo converges Pending -> Done");
+}
+
+#[test]
+fn right_click_on_tab_row_broadcasts_every_pending_pane_in_that_tab_only() {
+    let mut rt = runtime_with_pending_panes();
+
+    let out = rt.mouse_right_click(2); // tab0 header line, pane_id: None
+    assert!(!out.render);
+    let acked: Vec<u32> = out
+        .effects
+        .iter()
+        .map(|e| {
+            let Effect::BroadcastStatus { payload } = e else {
+                panic!("expected BroadcastStatus, got {e:?}");
+            };
+            payload::parse(payload).expect("synthetic payload must parse").pane_id
+        })
+        .collect();
+    assert_eq!(acked.len(), 2, "tab0 has exactly 2 pending panes (10 and 12), got {acked:?}");
+    assert!(acked.contains(&10) && acked.contains(&12));
+    assert!(!acked.contains(&11), "pane 11 is Running, not Pending — untouched");
+    assert!(!acked.contains(&20), "tab1's pending pane must be untouched by a tab0 click");
+}
+
+#[test]
+fn right_click_on_a_running_pane_row_is_a_strict_no_op() {
+    let mut rt = runtime_with_pending_panes();
+    assert_eq!(rt.mouse_right_click(4), Outcome::default(), "pane 11 is Running, not Pending");
+}
+
+#[test]
+fn right_click_on_a_tab_row_with_no_tracked_panes_is_a_strict_no_op() {
+    let mut rt = PluginRuntime {
+        permission: PermissionState::Resolved { granted: true },
+        config: config(),
+        ..Default::default()
+    };
+    rt.tabs_changed(vec![tab(0, "a", false)]);
+    let _ = rt.render(100, 80);
+    assert_eq!(rt.mouse_right_click(2), Outcome::default(), "no panes at all in this tab");
+}
+
+#[test]
+fn acknowledge_payload_round_trips_and_carries_the_original_source_and_kind() {
+    let mut rt = runtime_with_pending_panes();
+    let out = rt.mouse_right_click(3); // pane 10, Pending, source "claude" via payload_for
+    let Effect::BroadcastStatus { payload } = &out.effects[0] else {
+        panic!("expected BroadcastStatus, got {:?}", out.effects);
+    };
+
+    let parsed = payload::parse(payload).expect("synthetic payload must parse (wire-compat)");
+    assert_eq!(parsed.pane_id, 10);
+    assert_eq!(parsed.status, Status::Done);
+    assert_eq!(parsed.repo, "repo");
+    assert_eq!(parsed.branch, "main");
+    assert_eq!(parsed.msg, "working", "the original msg is carried forward unchanged");
+    assert_eq!(parsed.source, "claude", "Kind::as_source must round-trip the original classification");
+    assert_eq!(crate::kind::Kind::from_source(&parsed.source), crate::kind::Kind::Claude);
+}
+
+#[test]
+fn double_delivery_of_the_acknowledge_broadcast_is_idempotent() {
+    let mut rt = runtime_with_pending_panes();
+    let out = rt.mouse_right_click(3);
+    let Effect::BroadcastStatus { payload } = &out.effects[0] else {
+        panic!("expected BroadcastStatus, got {:?}", out.effects);
+    };
+    let payload = payload.clone();
+
+    rt.status_pipe(&payload);
+    let completed_at_first = rt.radar.status(10).unwrap().completed_epoch_s;
+    assert!(completed_at_first.is_some(), "Done must stamp a completion epoch");
+
+    // A second, later delivery of the SAME payload — e.g. a duplicate fire of
+    // the pipe, or another instance's echo racing this one — must be a
+    // no-op: `StatusStore::apply`'s identical-(status,msg)-rebroadcast rule
+    // keeps the ORIGINAL completion stamp rather than re-stamping it.
+    rt.status_pipe(&payload);
+    assert_eq!(
+        rt.radar.status(10).unwrap().completed_epoch_s,
+        completed_at_first,
+        "an identical re-delivery must not re-stamp the completion"
+    );
+}
+
 #[test]
 fn own_badge_row_updates_live_as_running_and_attention_move() {
     // Task-6 flagged `Sessions::set_own` as dead code: nothing called it, so
@@ -2269,3 +2407,4 @@ mod timer_chain_fuzz {
         }
     }
 }
+

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -1417,6 +1417,10 @@ fn idle_with_fresh_history_arms_slow_and_repaints() {
 
 #[test]
 fn saturated_history_fully_disarms() {
+    // The battery property's full-disarm pin — deliberately PRE-NAME (no
+    // `session_name_changed` ever lands, so `own_session_name` stays at its
+    // Default empty). Once a name is known the presence-liveness heartbeat
+    // keeps Slow armed instead — see the sibling test below.
     let mut rt = PluginRuntime {
         permission: PermissionState::Resolved { granted: true },
         config: config(),
@@ -1445,6 +1449,66 @@ fn saturated_history_fully_disarms() {
         outcome.effects
     );
     assert!(rt.timer_chain.armed().is_none());
+}
+
+#[test]
+fn saturated_history_with_known_name_keeps_slow_armed_for_the_heartbeat() {
+    // Sibling of `saturated_history_fully_disarms`, adding the one
+    // ingredient that test leaves out: a learned own-session name. Once the
+    // name is known this session owns a presence file, and that file's
+    // mtime is the ONLY liveness signal peers read
+    // (`session_files::PRESENCE_LIVE_TTL`) — refreshed solely by `timer`'s
+    // Slow-fire heartbeat. Were the chain to fully disarm on a saturated
+    // idle rail, that heartbeat would never fire again, the mtime would
+    // freeze, and after 180s every peer would drop this still-alive
+    // session's badge — exactly the idle-but-visible case the feature
+    // exists for. So: saturation may step the cadence down to Slow, but
+    // never to None while the name is known.
+    let mut rt = PluginRuntime {
+        permission: PermissionState::Resolved { granted: true },
+        config: config(),
+        ..Default::default()
+    };
+    rt.radar.ledger_mut().push(crate::ledger::LedgerEntry {
+        at_epoch_s: 0,
+        outcome: crate::ledger::LedgerOutcome::Done,
+        tab_id: TabId::new(1),
+        tab_name: "work".into(),
+        label: "cargo test".into(),
+        pane_id: 5,
+    });
+    // Seed `last_now_epoch_s` with a real wall-clock capture (any entry
+    // point that owns an epoch does) BEFORE the name lands, so the arm
+    // decision inside `session_name_changed`'s project pass evaluates at
+    // true "now" — where the 0-stamped ledger entry above reads as
+    // saturated — and not at the Default epoch 0, where that entry would
+    // still look fresh and arm Slow for the wrong reason.
+    let nameless = rt.tabs_changed(vec![]);
+    assert!(
+        !nameless.effects.iter().any(|e| matches!(e, Effect::SetTimeout(_))),
+        "setup: nameless + saturated must stay fully disarmed, got {:?}",
+        nameless.effects
+    );
+
+    let named = rt.session_name_changed(Some("work".into()));
+    assert!(
+        named.effects.contains(&Effect::SetTimeout(Cadence::Slow)),
+        "learning the name must arm the Slow heartbeat, got {:?}",
+        named.effects
+    );
+    assert_eq!(rt.timer_chain.armed(), Some(Cadence::Slow));
+
+    // The Slow fire must refresh the presence mtime AND re-arm itself —
+    // the self-sustaining loop that keeps an idle session inside the TTL.
+    let slow = rt.timer(PermissionProbe::default(), Cadence::Slow.seconds());
+    assert!(
+        slow.effects.contains(&Effect::PersistPresence),
+        "the heartbeat refreshes the presence file, got {:?}", slow.effects
+    );
+    assert!(
+        slow.effects.contains(&Effect::SetTimeout(Cadence::Slow)),
+        "the heartbeat chain re-arms itself, got {:?}", slow.effects
+    );
 }
 
 #[test]
@@ -1663,6 +1727,16 @@ fn slow_heartbeat_coincident_with_a_genuine_presence_edge_persists_exactly_once(
     drive_tabs_and_panes(&mut rt); // tab 0 / pane 7, the row `own_presence` reads
 
     rt.command_changed(7, &["cargo".into(), "test".into()], true); // pending, not yet Running
+
+    // The named-idle heartbeat pre-armed Slow inside the helper's
+    // `session_name_changed`, so `command_changed`'s Fast arm above was a
+    // Slow→Fast top-up: TWO fires are now in flight, and the probe below
+    // needs its Slow fire to land as the LIVE chain. Retire the stale
+    // slow-armed fire first (the "rare order" of
+    // `stale_slow_fire_landing_first_is_swallowed`): swallowed whole, so it
+    // doesn't advance the debounce tick count either.
+    let stale = rt.timer(PermissionProbe::default(), Cadence::Slow.seconds());
+    assert_eq!(stale, Outcome::none(), "setup: the pre-armed slow fire is stale and swallowed");
 
     // Ticks short of the debounce window: quiet, and don't disturb the fire
     // count `timer`'s final Slow fire below needs to land as the live chain.

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -836,6 +836,14 @@ fn payload_json(pane_id: u32, status: &str) -> String {
     payload::to_wire(&payload_for(pane_id, Status::from_wire(status)))
 }
 
+/// A peer presence JSON literal paired with a fresh (age-0) mtime — the
+/// shape `presences_changed` now takes (`session_files::read_peer_presences`'s
+/// `(json, age_secs)` pairing). Most tests want a live-looking peer; use the
+/// tuple literal directly when a test needs to exercise staleness.
+fn fresh(json: &str) -> (String, u64) {
+    (json.to_string(), 0)
+}
+
 #[test]
 fn status_edge_persists_presence_once_and_not_on_identical_state() {
     let mut rt = runtime_with_granted_permission();
@@ -915,7 +923,7 @@ fn session_cycle_commits_via_switch_session_effect_on_idle_tick() {
     // report IS its liveness (task-8b-brief.md: no more `SessionUpdate` peer
     // list to cross-check against).
     rt.presences_changed(vec![
-        r#"{"session_name":"alpha","running":0,"attention":1,"attention_tab_position":1}"#.into(),
+        fresh(r#"{"session_name":"alpha","running":0,"attention":1,"attention_tab_position":1}"#),
     ]);
 
     let out = rt.control_pipe("session-next");
@@ -944,14 +952,14 @@ fn session_cycle_commits_via_switch_session_effect_on_idle_tick() {
 fn session_cycle_is_inert_without_permission() {
     let mut rt = PluginRuntime::default();
     rt.session_name_changed(Some("work".into()));
-    rt.presences_changed(vec![r#"{"session_name":"alpha","running":0,"attention":0}"#.into()]);
+    rt.presences_changed(vec![fresh(r#"{"session_name":"alpha","running":0,"attention":0}"#)]);
     assert_eq!(rt.control_pipe("session-next"), Outcome::default());
 }
 
 #[test]
 fn session_cycle_arms_fast_cadence_for_the_idle_commit() {
     let mut rt = runtime_with_granted_permission();
-    rt.presences_changed(vec![r#"{"session_name":"alpha","running":0,"attention":0}"#.into()]);
+    rt.presences_changed(vec![fresh(r#"{"session_name":"alpha","running":0,"attention":0}"#)]);
     let out = rt.control_pipe("session-next");
     assert!(
         out.effects.contains(&Effect::SetTimeout(Cadence::Fast)),
@@ -973,7 +981,7 @@ fn clicking_a_session_line_emits_switch_session() {
     let mut rt = runtime_with_granted_permission(); // own session name "work"
     rt.tabs_changed(vec![tab(0, "team", false)]);
     rt.presences_changed(vec![
-        r#"{"session_name":"alpha","running":0,"attention":1,"attention_tab_position":2}"#.into(),
+        fresh(r#"{"session_name":"alpha","running":0,"attention":1,"attention_tab_position":2}"#),
     ]);
 
     let ansi = rt.render(100, 80);
@@ -1006,7 +1014,7 @@ fn own_badge_row_updates_live_as_running_and_attention_move() {
     let mut rt = runtime_with_granted_permission(); // own session name "work"
     // A second session must exist for the badge to render at all
     // (`render_session_badge` renders zero lines for `entries.len() <= 1`).
-    rt.presences_changed(vec![r#"{"session_name":"alpha","running":0,"attention":0}"#.into()]);
+    rt.presences_changed(vec![fresh(r#"{"session_name":"alpha","running":0,"attention":0}"#)]);
     drive_tabs_and_panes(&mut rt); // tab 0, pane 7
 
     let before = rt.render(100, 80);
@@ -1465,14 +1473,15 @@ fn saturated_history_with_known_name_keeps_slow_armed_for_the_heartbeat() {
     // Sibling of `saturated_history_fully_disarms`, adding the one
     // ingredient that test leaves out: a learned own-session name. Once the
     // name is known this session owns a presence file, and that file's
-    // mtime is the ONLY liveness signal peers read
-    // (`session_files::PRESENCE_LIVE_TTL`) — refreshed solely by `timer`'s
+    // mtime is the signal peers read to tell fresh from stale
+    // (`sessions::STALE_AFTER_SECS`) — refreshed solely by `timer`'s
     // Slow-fire heartbeat. Were the chain to fully disarm on a saturated
     // idle rail, that heartbeat would never fire again, the mtime would
-    // freeze, and after 180s every peer would drop this still-alive
-    // session's badge — exactly the idle-but-visible case the feature
-    // exists for. So: saturation may step the cadence down to Slow, but
-    // never to None while the name is known.
+    // freeze, and after 90s every peer would dim this still-alive session's
+    // badge to stale (never drop it — task-14 — but still a needless false
+    // alarm) — exactly the idle-but-visible case the feature exists for.
+    // So: saturation may step the cadence down to Slow, but never to None
+    // while the name is known.
     let mut rt = PluginRuntime {
         permission: PermissionState::Resolved { granted: true },
         config: config(),
@@ -1691,13 +1700,13 @@ fn lone_slow_fire_processes_as_the_live_chain() {
 fn idle_alive_session_heartbeats_presence_unconditionally_on_slow_fires_only() {
     // An idle-but-alive session (nothing fast-worthy happening) has no
     // content edge to trigger `project`'s compare-and-cache `PersistPresence`
-    // — but its presence file's mtime is the ONLY signal peers use to tell
-    // it apart from a dead session (`session_files::PRESENCE_LIVE_TTL`, the
-    // amendment's whole point: liveness is no longer `SessionUpdate`-derived
-    // at all). The Slow (60s) heartbeat must therefore emit `PersistPresence`
-    // unconditionally, bypassing the content-compare gate; Fast (1s) fires
-    // must NOT — that would be needless per-second churn for a signal that
-    // only needs to beat a 180s TTL.
+    // — but its presence file's mtime is the signal peers use to tell fresh
+    // from stale (`sessions::STALE_AFTER_SECS`; liveness is no longer
+    // `SessionUpdate`-derived at all, and past task-14 it's never a hard
+    // drop either — just a dim). The Slow (60s) heartbeat must therefore
+    // emit `PersistPresence` unconditionally, bypassing the content-compare
+    // gate; Fast (1s) fires must NOT — that would be needless per-second
+    // churn for a signal that only needs to beat a 90s staleness window.
     let mut rt = runtime_with_granted_permission(); // own session name is "work"
 
     // A Fast fire with nothing changed must stay quiet — the edge gate

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -844,6 +844,25 @@ fn fresh(json: &str) -> (String, u64) {
     (json.to_string(), 0)
 }
 
+/// `fresh`'s stale counterpart: the same JSON paired with an mtime age just
+/// past `STALE_AFTER_SECS`, so the entry dims on the badge — the state the
+/// right-click dismiss tests need to hit.
+fn stale(json: &str) -> (String, u64) {
+    (json.to_string(), crate::sessions::STALE_AFTER_SECS + 1)
+}
+
+/// Shared setup for the right-click tests: one tab + one "alpha" peer, then
+/// a real render so `last_rendered` carries the badge's click targets. The
+/// resulting line indices follow `clicking_a_session_line_emits_switch_session`'s
+/// bookkeeping — 0/1 header, 2 own "work" line (click-inert), 3 peer "alpha"
+/// line, 4 the badge's blank separator, 5 the tab header.
+fn render_with_badge(rt: &mut PluginRuntime, peer: (String, u64)) {
+    rt.tabs_changed(vec![tab(0, "team", false)]);
+    rt.presences_changed(vec![peer]);
+    let ansi = rt.render(100, 80);
+    assert!(ansi.contains("alpha"), "setup: the peer's badge line must actually render");
+}
+
 #[test]
 fn status_edge_persists_presence_once_and_not_on_identical_state() {
     let mut rt = runtime_with_granted_permission();
@@ -999,6 +1018,77 @@ fn clicking_a_session_line_emits_switch_session() {
     assert_eq!(
         peer_click.effects,
         vec![Effect::SwitchSession { name: "alpha".into(), tab_position: Some(2) }]
+    );
+}
+
+#[test]
+fn right_click_on_stale_session_line_dismisses_and_emits_delete_effect() {
+    let mut rt = runtime_with_granted_permission();
+    render_with_badge(&mut rt, stale(r#"{"session_name":"alpha","running":0,"attention":1}"#));
+
+    let out = rt.mouse_right_click(3);
+
+    assert_eq!(
+        out,
+        Outcome {
+            render: true,
+            effects: vec![Effect::DismissPresence { name: "alpha".into() }],
+        }
+    );
+    assert!(
+        !rt.sessions.badge().iter().any(|b| b.name == "alpha"),
+        "dismissed stale peer must disappear from this runtime's badge"
+    );
+}
+
+#[test]
+fn right_click_on_fresh_session_line_is_inert() {
+    let mut rt = runtime_with_granted_permission();
+    render_with_badge(&mut rt, fresh(r#"{"session_name":"alpha","running":0,"attention":1}"#));
+
+    let out = rt.mouse_right_click(3);
+
+    assert_eq!(out, Outcome::default());
+    assert!(
+        rt.sessions.badge().iter().any(|b| b.name == "alpha"),
+        "fresh peer must remain on the badge"
+    );
+}
+
+#[test]
+fn right_click_on_own_session_line_is_inert() {
+    let mut rt = runtime_with_granted_permission();
+    render_with_badge(&mut rt, stale(r#"{"session_name":"alpha","running":0,"attention":1}"#));
+
+    assert_eq!(rt.mouse_right_click(2), Outcome::default());
+}
+
+#[test]
+fn right_click_on_tab_line_is_inert() {
+    let mut rt = runtime_with_granted_permission();
+    render_with_badge(&mut rt, stale(r#"{"session_name":"alpha","running":0,"attention":1}"#));
+
+    assert_eq!(rt.mouse_right_click(5), Outcome::default());
+}
+
+#[test]
+fn right_click_on_empty_line_is_inert() {
+    let mut rt = runtime_with_granted_permission();
+    render_with_badge(&mut rt, stale(r#"{"session_name":"alpha","running":0,"attention":1}"#));
+
+    assert_eq!(rt.mouse_right_click(99), Outcome::default());
+}
+
+#[test]
+fn right_click_without_permission_is_inert_even_on_stale_session_line() {
+    let mut rt = runtime_with_granted_permission();
+    render_with_badge(&mut rt, stale(r#"{"session_name":"alpha","running":0,"attention":1}"#));
+    rt.permission = PermissionState::default();
+
+    assert_eq!(rt.mouse_right_click(3), Outcome::default());
+    assert!(
+        rt.sessions.badge().iter().any(|b| b.name == "alpha"),
+        "ungranted right-click must not mutate the badge"
     );
 }
 

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -810,7 +810,7 @@ fn control_pipe_unknown_verb_is_no_op() {
 // ── Cross-session presence + cycling ───────────────────────────────────────
 
 /// A granted runtime whose own session name is already known (as it would be
-/// in production once Zellij's first `SessionUpdate` lands) — needed for the
+/// in production once Zellij's first `ModeUpdate` lands) — needed for the
 /// presence edge in `project` to ever fire.
 fn runtime_with_granted_permission() -> PluginRuntime {
     let mut rt = PluginRuntime {
@@ -818,7 +818,7 @@ fn runtime_with_granted_permission() -> PluginRuntime {
         config: config(),
         ..Default::default()
     };
-    rt.session_update(vec![SessionLite { name: "work".into(), is_current: true }]);
+    rt.session_name_changed(Some("work".into()));
     rt
 }
 
@@ -911,10 +911,9 @@ fn presence_withheld_until_own_session_name_is_known() {
 #[test]
 fn session_cycle_commits_via_switch_session_effect_on_idle_tick() {
     let mut rt = runtime_with_granted_permission(); // own session name is "work"
-    rt.session_update(vec![
-        SessionLite { name: "work".into(), is_current: true },
-        SessionLite { name: "alpha".into(), is_current: false },
-    ]);
+    // "alpha" needs no separate liveness registration anymore — its presence
+    // report IS its liveness (task-8b-brief.md: no more `SessionUpdate` peer
+    // list to cross-check against).
     rt.presences_changed(vec![
         r#"{"session_name":"alpha","running":0,"attention":1,"attention_tab_position":1}"#.into(),
     ]);
@@ -935,20 +934,15 @@ fn session_cycle_commits_via_switch_session_effect_on_idle_tick() {
 #[test]
 fn session_cycle_is_inert_without_permission() {
     let mut rt = PluginRuntime::default();
-    rt.session_update(vec![
-        SessionLite { name: "work".into(), is_current: true },
-        SessionLite { name: "alpha".into(), is_current: false },
-    ]);
+    rt.session_name_changed(Some("work".into()));
+    rt.presences_changed(vec![r#"{"session_name":"alpha","running":0,"attention":0}"#.into()]);
     assert_eq!(rt.control_pipe("session-next"), Outcome::default());
 }
 
 #[test]
 fn session_cycle_arms_fast_cadence_for_the_idle_commit() {
     let mut rt = runtime_with_granted_permission();
-    rt.session_update(vec![
-        SessionLite { name: "work".into(), is_current: true },
-        SessionLite { name: "alpha".into(), is_current: false },
-    ]);
+    rt.presences_changed(vec![r#"{"session_name":"alpha","running":0,"attention":0}"#.into()]);
     let out = rt.control_pipe("session-next");
     assert!(
         out.effects.contains(&Effect::SetTimeout(Cadence::Fast)),
@@ -969,10 +963,6 @@ fn clicking_a_session_line_emits_switch_session() {
     // cross-session target), 3 = peer "alpha" badge line (clickable).
     let mut rt = runtime_with_granted_permission(); // own session name "work"
     rt.tabs_changed(vec![tab(0, "team", false)]);
-    rt.session_update(vec![
-        SessionLite { name: "work".into(), is_current: true },
-        SessionLite { name: "alpha".into(), is_current: false },
-    ]);
     rt.presences_changed(vec![
         r#"{"session_name":"alpha","running":0,"attention":1,"attention_tab_position":2}"#.into(),
     ]);
@@ -992,6 +982,33 @@ fn clicking_a_session_line_emits_switch_session() {
     assert_eq!(
         peer_click.effects,
         vec![Effect::SwitchSession { name: "alpha".into(), tab_position: Some(2) }]
+    );
+}
+
+#[test]
+fn own_badge_row_updates_live_as_running_and_attention_move() {
+    // Task-6 flagged `Sessions::set_own` as dead code: nothing called it, so
+    // the own row of the cross-session badge never reflected the running/
+    // attention counts actually moving underneath it — it would render
+    // whatever it started at (0/0) forever. task-8b-brief.md revives it by
+    // having `project` call it every pass once the name is known; this pins
+    // that the own row's rendered counts actually track a later status edge,
+    // not just its state at the moment the name became known.
+    let mut rt = runtime_with_granted_permission(); // own session name "work"
+    // A second session must exist for the badge to render at all
+    // (`render_session_badge` renders zero lines for `entries.len() <= 1`).
+    rt.presences_changed(vec![r#"{"session_name":"alpha","running":0,"attention":0}"#.into()]);
+    drive_tabs_and_panes(&mut rt); // tab 0, pane 7
+
+    let before = rt.render(100, 80);
+    assert!(!before.contains("work 1"), "setup: own row must start at zero running, got {before:?}");
+
+    rt.status_pipe(&payload_json(7, "running"));
+    let after = rt.render(100, 80);
+    let running_glyph = Status::Running.glyph_for(GlyphSet::Plain);
+    assert!(
+        after.contains(&format!("work 1{running_glyph}")),
+        "own badge row must show the fresh running count, got {after:?}"
     );
 }
 
@@ -1594,6 +1611,40 @@ fn lone_slow_fire_processes_as_the_live_chain() {
         tick.effects.contains(&Effect::SetTimeout(Cadence::Slow)),
         "the lone slow chain re-arms itself, got {:?}",
         tick.effects
+    );
+}
+
+#[test]
+fn idle_alive_session_heartbeats_presence_unconditionally_on_slow_fires_only() {
+    // An idle-but-alive session (nothing fast-worthy happening) has no
+    // content edge to trigger `project`'s compare-and-cache `PersistPresence`
+    // — but its presence file's mtime is the ONLY signal peers use to tell
+    // it apart from a dead session (`session_files::PRESENCE_LIVE_TTL`, the
+    // amendment's whole point: liveness is no longer `SessionUpdate`-derived
+    // at all). The Slow (60s) heartbeat must therefore emit `PersistPresence`
+    // unconditionally, bypassing the content-compare gate; Fast (1s) fires
+    // must NOT — that would be needless per-second churn for a signal that
+    // only needs to beat a 180s TTL.
+    let mut rt = runtime_with_granted_permission(); // own session name is "work"
+
+    // A Fast fire with nothing changed must stay quiet — the edge gate
+    // already published once, inside `runtime_with_granted_permission`'s
+    // `session_name_changed` call.
+    let fast = rt.timer(PermissionProbe::default(), Cadence::Fast.seconds());
+    assert!(
+        !fast.effects.contains(&Effect::PersistPresence),
+        "a fast fire with unchanged content must not republish, got {:?}", fast.effects
+    );
+
+    // A Slow fire, even with identical content, must heartbeat anyway —
+    // exactly once, not doubled up with `project`'s own (correctly
+    // no-op, since content is unchanged) edge-gated push.
+    let slow = rt.timer(PermissionProbe::default(), Cadence::Slow.seconds());
+    let persists = slow.effects.iter().filter(|e| matches!(e, Effect::PersistPresence)).count();
+    assert_eq!(
+        persists, 1,
+        "an idle session's slow heartbeat must refresh its presence file's \
+         mtime unconditionally, exactly once, got {:?}", slow.effects
     );
 }
 

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -1784,3 +1784,380 @@ fn read_presences_is_bound_to_fast_fires_only() {
     let slow = rt.timer(PermissionProbe::default(), Cadence::Slow.seconds());
     assert!(!slow.effects.contains(&Effect::ReadPresences), "a Slow fire must not scan peers, got {:?}", slow.effects);
 }
+
+// ── Fast-decay heartbeat survival (task-13 investigation) ───────────────
+//
+// Field reports: sessions that had Fast-cadence activity and then decayed
+// to idle stopped heartbeating (their presence file's mtime froze), while
+// a session idle from birth (never armed Fast) kept heartbeating forever.
+// Suspected mechanism: the Fast→Slow decay stranding `TimerChain` — the
+// original stale Slow arm from before the top-up lands, gets swallowed as
+// stale (`TimerChain::on_fire`'s elapsed+pending check), and the chain
+// never re-arms. The tests below drive `PluginRuntime::timer` through a
+// real fire-order simulation (`FireSim`, not hand-picked `elapsed_s`
+// values) across the exact interleaving, a long sustained-busy variant, a
+// flapping-activity variant, and a property-fuzzed search over thousands
+// of random event/fire orderings (`timer_chain_fuzz` below) — all confirm
+// the *current* `arm`/`on_fire` bookkeeping self-corrects: whichever fire
+// is chronologically last to land is always the one treated as live, and
+// it always re-arms (see task-13-report.md for the full trace). Kept as
+// permanent regression coverage for this exact hypothesis, not as a
+// reproduction of a confirmed bug.
+
+/// A one-shot, non-cancellable `set_timeout` queue, exactly like Zellij's:
+/// every `Effect::SetTimeout` schedules a real future fire at `now + dur`,
+/// and fires are delivered in absolute-time order (never reordered) —
+/// mirroring lib.rs's `set_timeout(cadence.seconds())` and Zellij's own
+/// single-threaded event loop. Used to drive `PluginRuntime::timer` the way
+/// production actually does, instead of hand-picking `elapsed_s` values.
+struct FireSim {
+    now_ms: u64,
+    queue: std::collections::BinaryHeap<std::cmp::Reverse<(u64, u64)>>,
+}
+impl FireSim {
+    fn new() -> Self {
+        Self { now_ms: 0, queue: Default::default() }
+    }
+    fn schedule_from(&mut self, effects: &[Effect]) {
+        for e in effects {
+            if let Effect::SetTimeout(c) = e {
+                let dur_ms = (c.seconds() * 1000.0).round() as u64;
+                self.queue.push(std::cmp::Reverse((self.now_ms + dur_ms, dur_ms)));
+            }
+        }
+    }
+    /// Pop the earliest scheduled fire and report it as `timer()` wants:
+    /// `elapsed_s` = the duration it was armed with (matches lib.rs's
+    /// documented approximation).
+    fn pop(&mut self) -> Option<f64> {
+        let std::cmp::Reverse((at, dur_ms)) = self.queue.pop()?;
+        self.now_ms = at;
+        Some(dur_ms as f64 / 1000.0)
+    }
+}
+
+#[test]
+fn slow_heartbeat_survives_a_fast_decay_indefinitely() {
+    // The exact suspected interleaving: Slow-armed idle, a Fast top-up,
+    // several Fast fires driving real work, activity ends, and the
+    // ORIGINAL stale Slow arm lands somewhere in the stream. Run it out
+    // past 15 minutes of virtual time and assert every live Slow fire
+    // still re-arms and still heartbeats.
+    let mut rt = PluginRuntime {
+        permission: PermissionState::Resolved { granted: true },
+        config: config(),
+        ..Default::default()
+    };
+    let mut sim = FireSim::new();
+
+    // name-known: arms Slow immediately (idle from birth so far).
+    let named = rt.session_name_changed(Some("work".into()));
+    sim.schedule_from(&named.effects);
+    drive_tabs_and_panes(&mut rt);
+
+    // busy: a running command tops up Fast on top of the still-outstanding
+    // Slow arm — exactly the "TWO in flight" case 24968b1's tests pinned.
+    let busy = rt.status_pipe(&payload_json(7, "running"));
+    sim.schedule_from(&busy.effects);
+    assert_eq!(rt.timer_chain.armed(), Some(Cadence::Fast), "setup: busy tops up Fast");
+
+    // Drive real fires for a few seconds of Fast-cadence "work", then end
+    // the activity (status -> done, which settles and lets the row go
+    // idle), continuing to drain the FireSim exactly as Zellij would
+    // deliver it — including the original stale Slow fire, whenever in
+    // this stream it actually lands.
+    let mut ended_activity = false;
+    let mut stale_swallows = 0;
+    for i in 0.. {
+        let Some(elapsed) = sim.pop() else { break };
+        let out = rt.timer(PermissionProbe::default(), elapsed);
+        if out == Outcome::none() {
+            stale_swallows += 1;
+        }
+        sim.schedule_from(&out.effects);
+
+        if i == 3 && !ended_activity {
+            ended_activity = true;
+            let done = rt.status_pipe(&payload_json(7, "done"));
+            sim.schedule_from(&done.effects);
+        }
+        // Stop once we've drained past the point business has settled AND
+        // the chain has decayed back to Slow-only (no Fast desire left).
+        if ended_activity && rt.timer_chain.armed() == Some(Cadence::Slow) && sim.queue.len() <= 1 {
+            break;
+        }
+        if i > 500 {
+            panic!("setup: never settled back to a single Slow chain");
+        }
+    }
+    assert!(
+        stale_swallows >= 1,
+        "setup: the original Slow arm must actually land and get swallowed as \
+         stale during this drain — otherwise this test never exercises the \
+         'two in flight' interleaving at all"
+    );
+
+    // Now simulate 15 minutes of virtual time purely via the FireSim queue
+    // — no more domain events, exactly an idle-but-alive session. Every
+    // live fire must be a Slow fire that (a) re-arms and (b) heartbeats.
+    let mut live_fires = 0;
+    while sim.now_ms < 15 * 60 * 1000 {
+        let Some(elapsed) = sim.pop() else {
+            panic!(
+                "TimerChain starved: nothing scheduled at virtual t={:.1}s \
+                 (armed={:?}) — the chain believes itself armed with no \
+                 timeout outstanding",
+                sim.now_ms as f64 / 1000.0,
+                rt.timer_chain.armed(),
+            );
+        };
+        let out = rt.timer(PermissionProbe::default(), elapsed);
+        sim.schedule_from(&out.effects);
+
+        if out == Outcome::none() {
+            continue; // correctly-swallowed stale fire
+        }
+        live_fires += 1;
+        assert!(
+            elapsed > STALE_FIRE_ELAPSED_S,
+            "expected only Slow fires once idle, got elapsed={elapsed} at t={:.1}s",
+            sim.now_ms as f64 / 1000.0
+        );
+        assert!(
+            out.effects.contains(&Effect::PersistPresence),
+            "live Slow fire at t={:.1}s must heartbeat, got {:?}",
+            sim.now_ms as f64 / 1000.0,
+            out.effects
+        );
+        assert!(
+            out.effects.contains(&Effect::SetTimeout(Cadence::Slow)),
+            "live Slow fire at t={:.1}s must re-arm, got {:?}",
+            sim.now_ms as f64 / 1000.0,
+            out.effects
+        );
+    }
+    assert!(
+        live_fires >= 10,
+        "expected at least 10 live Slow heartbeats over 15 virtual minutes, got {live_fires}"
+    );
+}
+
+/// Drain `sim`/`rt` until the chain is Slow-only-armed with nothing else
+/// outstanding, feeding every fire (live or stale) back through `timer`.
+/// Panics past a generous bound instead of looping forever on a genuine
+/// stall, so a hang shows up as a normal test failure.
+fn drain_to_settled_slow(rt: &mut PluginRuntime, sim: &mut FireSim) {
+    for _ in 0..2000 {
+        if rt.timer_chain.armed() == Some(Cadence::Slow) && sim.queue.len() <= 1 {
+            return;
+        }
+        let Some(elapsed) = sim.pop() else { panic!("starved before settling to Slow") };
+        let out = rt.timer(PermissionProbe::default(), elapsed);
+        sim.schedule_from(&out.effects);
+    }
+    panic!("never settled back to a single Slow chain");
+}
+
+/// Run `sim`/`rt` forward for `minutes` of pure idle virtual time (no more
+/// domain events), asserting every live fire is a heartbeating Slow fire.
+/// Returns the live-fire count.
+fn assert_heartbeats_for(rt: &mut PluginRuntime, sim: &mut FireSim, minutes: u64) -> u64 {
+    let deadline_ms = sim.now_ms + minutes * 60_000;
+    let mut live_fires = 0;
+    while sim.now_ms < deadline_ms {
+        let Some(elapsed) = sim.pop() else {
+            panic!(
+                "TimerChain starved at virtual t={:.1}s (armed={:?})",
+                sim.now_ms as f64 / 1000.0,
+                rt.timer_chain.armed(),
+            );
+        };
+        let out = rt.timer(PermissionProbe::default(), elapsed);
+        sim.schedule_from(&out.effects);
+        if out == Outcome::none() {
+            continue;
+        }
+        live_fires += 1;
+        assert!(
+            out.effects.contains(&Effect::PersistPresence),
+            "live fire at t={:.1}s must heartbeat, got {:?}",
+            sim.now_ms as f64 / 1000.0,
+            out.effects
+        );
+    }
+    live_fires
+}
+
+#[test]
+fn slow_heartbeat_survives_a_long_sustained_busy_period() {
+    // Variant where the original stale Slow fire's 60s deadline actually
+    // elapses WHILE Fast activity is still ongoing (not right at the
+    // boundary), so it gets swallowed mid-burst rather than right at the
+    // busy/idle seam.
+    let mut rt = PluginRuntime { permission: PermissionState::Resolved { granted: true }, config: config(), ..Default::default() };
+    let mut sim = FireSim::new();
+    let named = rt.session_name_changed(Some("work".into()));
+    sim.schedule_from(&named.effects);
+    drive_tabs_and_panes(&mut rt);
+
+    let busy = rt.status_pipe(&payload_json(7, "running"));
+    sim.schedule_from(&busy.effects);
+
+    // Sustain Fast for 200 virtual seconds (>> the 60s Slow deadline) of
+    // pure timer-driven work — no further domain events.
+    for _ in 0..200 {
+        let Some(elapsed) = sim.pop() else { panic!("starved mid-burst") };
+        let out = rt.timer(PermissionProbe::default(), elapsed);
+        sim.schedule_from(&out.effects);
+    }
+    assert_eq!(rt.timer_chain.armed(), Some(Cadence::Fast), "setup: still busy at t=200s");
+
+    let done = rt.status_pipe(&payload_json(7, "done"));
+    sim.schedule_from(&done.effects);
+    drain_to_settled_slow(&mut rt, &mut sim);
+
+    let live_fires = assert_heartbeats_for(&mut rt, &mut sim, 15);
+    assert!(live_fires >= 10, "expected >=10 heartbeats, got {live_fires}");
+}
+
+#[test]
+fn slow_heartbeat_survives_flapping_activity_then_settling() {
+    // The "actively-used agent" shape: many short bursts with brief idle
+    // gaps in between (too short for even one Slow fire to land), each one
+    // a fresh Slow->Fast top-up stacking a fresh stale-Slow-to-be behind
+    // the last — then a final, permanent idle settle.
+    let mut rt = PluginRuntime { permission: PermissionState::Resolved { granted: true }, config: config(), ..Default::default() };
+    let mut sim = FireSim::new();
+    let named = rt.session_name_changed(Some("work".into()));
+    sim.schedule_from(&named.effects);
+    drive_tabs_and_panes(&mut rt);
+
+    for cycle in 0..40 {
+        let busy = rt.status_pipe(&payload_json(7, "running"));
+        sim.schedule_from(&busy.effects);
+        for _ in 0..3 {
+            let Some(elapsed) = sim.pop() else { panic!("starved in flap cycle {cycle}") };
+            let out = rt.timer(PermissionProbe::default(), elapsed);
+            sim.schedule_from(&out.effects);
+        }
+        let done = rt.status_pipe(&payload_json(7, "done"));
+        sim.schedule_from(&done.effects);
+        // A couple settle ticks, then straight into the next burst — no
+        // time for the chain to fully decay to a lone Slow.
+        for _ in 0..2 {
+            let Some(elapsed) = sim.pop() else { panic!("starved settling flap cycle {cycle}") };
+            let out = rt.timer(PermissionProbe::default(), elapsed);
+            sim.schedule_from(&out.effects);
+        }
+    }
+
+    drain_to_settled_slow(&mut rt, &mut sim);
+    let live_fires = assert_heartbeats_for(&mut rt, &mut sim, 15);
+    assert!(live_fires >= 10, "expected >=10 heartbeats after flapping settled, got {live_fires}");
+}
+
+mod timer_chain_fuzz {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[derive(Clone, Debug)]
+    enum Step {
+        /// Pop and deliver the earliest scheduled fire (real FIFO order).
+        Fire,
+        /// A domain edge that can flip `has_running_work` — the real trigger
+        /// for a Slow<->Fast cadence transition.
+        SetRunning(bool),
+        /// The cross-session cycle's own direct `arm_timer_if_needed` call
+        /// site (`control()`), which bypasses `project()` entirely.
+        SessionCycle,
+    }
+
+    fn arb_step() -> impl Strategy<Value = Step> {
+        prop_oneof![
+            4 => Just(Step::Fire),
+            1 => any::<bool>().prop_map(Step::SetRunning),
+            1 => Just(Step::SessionCycle),
+        ]
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(2000))]
+        #[test]
+        fn timer_chain_never_starves_a_named_granted_session(
+            steps in proptest::collection::vec(arb_step(), 0..300)
+        ) {
+            let mut rt = PluginRuntime {
+                permission: PermissionState::Resolved { granted: true },
+                config: config(),
+                ..Default::default()
+            };
+            let mut sim = FireSim::new();
+            let named = rt.session_name_changed(Some("work".into()));
+            sim.schedule_from(&named.effects);
+            drive_tabs_and_panes(&mut rt);
+
+            for step in steps {
+                match step {
+                    Step::Fire => {
+                        if let Some(elapsed) = sim.pop() {
+                            let out = rt.timer(PermissionProbe::default(), elapsed);
+                            sim.schedule_from(&out.effects);
+                        }
+                    }
+                    Step::SetRunning(running) => {
+                        let status = if running { "running" } else { "done" };
+                        let out = rt.status_pipe(&payload_json(7, status));
+                        sim.schedule_from(&out.effects);
+                    }
+                    Step::SessionCycle => {
+                        let out = rt.control(Verb::SessionNext);
+                        sim.schedule_from(&out.effects);
+                    }
+                }
+                // The invariant: a named, permission-granted session's
+                // `desired_cadence` is NEVER `None` (barring denial, which
+                // never happens on this path) — so the moment nothing is
+                // physically outstanding, the chain has permanently
+                // stranded itself; no future event will ever revive it,
+                // because nothing left to arm/on_fire from.
+                prop_assert!(
+                    !sim.queue.is_empty(),
+                    "TimerChain starved: no physical timer outstanding \
+                     (armed={:?}) after step, session still named+granted",
+                    rt.timer_chain.armed(),
+                );
+            }
+
+            // Stronger post-condition, independent of the starve check
+            // above: after the random churn stops, force any dangling
+            // `status_pipe`-origin busy edge closed (a *still-running*
+            // agent legitimately keeps Fast armed forever — that's correct,
+            // not a bug, so it must not be mistaken for one here) and let
+            // no more domain events land. A generous drain (well past
+            // DONE_TTL_TICKS=60 and any plausible stacked-stale-fire
+            // backlog) must still reach a genuine Slow heartbeat —
+            // catching a chain that's stuck "armed" on paper but only ever
+            // fires (or only ever gets swallowed as stale) without ever
+            // landing a live, presence-persisting Slow fire again.
+            let close = rt.status_pipe(&payload_json(7, "done"));
+            sim.schedule_from(&close.effects);
+            let mut settled = false;
+            for _ in 0..5000 {
+                let Some(elapsed) = sim.pop() else { break };
+                let out = rt.timer(PermissionProbe::default(), elapsed);
+                sim.schedule_from(&out.effects);
+                if elapsed > STALE_FIRE_ELAPSED_S && out.effects.contains(&Effect::PersistPresence) {
+                    settled = true;
+                    break;
+                }
+            }
+            prop_assert!(
+                settled,
+                "no live Slow heartbeat landed within 5000 drained fires after churn stopped \
+                 (armed={:?}, queue_len={})",
+                rt.timer_chain.armed(),
+                sim.queue.len(),
+            );
+        }
+    }
+}

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -894,7 +894,7 @@ fn presence_edge_ignores_timestamp_but_still_reacts_to_content() {
 
 #[test]
 fn presence_withheld_until_own_session_name_is_known() {
-    // Same status edge as above, but WITHOUT `session_update` ever landing —
+    // Same status edge as above, but WITHOUT `session_name_changed` ever landing —
     // an unnamed presence file is useless to peers, so `project` must not
     // emit `PersistPresence` no matter what the own counts do.
     let mut rt = PluginRuntime {
@@ -1645,6 +1645,40 @@ fn idle_alive_session_heartbeats_presence_unconditionally_on_slow_fires_only() {
         persists, 1,
         "an idle session's slow heartbeat must refresh its presence file's \
          mtime unconditionally, exactly once, got {:?}", slow.effects
+    );
+}
+
+#[test]
+fn slow_heartbeat_coincident_with_a_genuine_presence_edge_persists_exactly_once() {
+    // Sibling of `idle_alive_session_heartbeats_presence_unconditionally_
+    // on_slow_fires_only`, but for the case that test's own comment waves
+    // off as "correctly no-op": here the Slow fire's OWN tick is what
+    // produces the content edge, not an unrelated prior call. A live Slow
+    // fire that promotes a debounced command to Running crosses `project`'s
+    // edge gate (running 0 -> 1) on the exact same pass where `timer`'s
+    // unconditional Slow heartbeat has already seeded a `PersistPresence`
+    // — two independently-correct pushes landing in the same `fx`, which
+    // must still collapse to one effect.
+    let mut rt = runtime_with_granted_permission(); // own session name is "work"
+    drive_tabs_and_panes(&mut rt); // tab 0 / pane 7, the row `own_presence` reads
+
+    rt.command_changed(7, &["cargo".into(), "test".into()], true); // pending, not yet Running
+
+    // Ticks short of the debounce window: quiet, and don't disturb the fire
+    // count `timer`'s final Slow fire below needs to land as the live chain.
+    for _ in 1..DEBOUNCE_TICKS {
+        rt.timer_fast(PermissionProbe::default());
+    }
+
+    // The debounce-completing tick, reported as a Slow (60s) fire — the
+    // reviewer's exact probe: a live Slow fire whose own tick promotes
+    // pending -> Running, landing a genuine content edge.
+    let tick = rt.timer(PermissionProbe::default(), Cadence::Slow.seconds());
+    let persists = tick.effects.iter().filter(|e| matches!(e, Effect::PersistPresence)).count();
+    assert_eq!(
+        persists, 1,
+        "a Slow heartbeat coinciding with a real content edge must still \
+         publish exactly once, got {:?}", tick.effects
     );
 }
 

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -220,6 +220,7 @@ fn peer_waits_then_requests_after_granted_marker() {
             Effect::RequestPermission,
             Effect::SetSelectable(true),
             Effect::HeartbeatPermissionLock,
+            Effect::ReadPresences,
             Effect::SetTimeout(Cadence::Fast),
         ]
     );
@@ -596,7 +597,7 @@ fn cwd_change_renames_default_named_tab_and_command_uses_cwd() {
         let quiet = runtime.timer_fast(PermissionProbe::default());
         assert_eq!(
             quiet.effects,
-            vec![Effect::SetTimeout(Cadence::Fast)],
+            vec![Effect::ReadPresences, Effect::SetTimeout(Cadence::Fast)],
             "still pending short of the debounce window"
         );
     }
@@ -605,7 +606,10 @@ fn cwd_change_renames_default_named_tab_and_command_uses_cwd() {
     assert!(timer.render);
     // The promotion mutates the command store, so this tick persists the
     // snapshot too (late-spawned instances must see the Running command).
-    assert_eq!(timer.effects, vec![Effect::PersistSnapshot, Effect::SetTimeout(Cadence::Fast)]);
+    assert_eq!(
+        timer.effects,
+        vec![Effect::ReadPresences, Effect::PersistSnapshot, Effect::SetTimeout(Cadence::Fast)]
+    );
     let state = runtime
         .radar
         .command_store()
@@ -794,13 +798,119 @@ fn command_no_op_when_no_attention() {
 
 #[test]
 fn control_pipe_unknown_verb_is_no_op() {
-    let runtime = PluginRuntime {
+    let mut runtime = PluginRuntime {
         permission: PermissionState::Resolved { granted: true },
         config: config(),
         ..Default::default()
     };
     assert_eq!(runtime.control_pipe("attention-top"), Outcome::default());
     assert_eq!(runtime.control_pipe(""), Outcome::default());
+}
+
+// ── Cross-session presence + cycling ───────────────────────────────────────
+
+/// A granted runtime whose own session name is already known (as it would be
+/// in production once Zellij's first `SessionUpdate` lands) — needed for the
+/// presence edge in `project` to ever fire.
+fn runtime_with_granted_permission() -> PluginRuntime {
+    let mut rt = PluginRuntime {
+        permission: PermissionState::Resolved { granted: true },
+        config: config(),
+        ..Default::default()
+    };
+    rt.session_update(vec![SessionLite { name: "work".into(), is_current: true }]);
+    rt
+}
+
+/// One tab (position 0), one tracked pane (id 7) — the minimal topology a
+/// status edge needs to land on a row `presence_json` can see.
+fn drive_tabs_and_panes(rt: &mut PluginRuntime) {
+    rt.tabs_changed(vec![tab(0, "a", true)]);
+    rt.radar.set_tab_panes_for_position(0, vec![pane(7)]);
+}
+
+/// A `zj_radar.status.v1` wire payload for `pane_id` at `status` ("running" /
+/// "pending" / etc.) — `payload_for` takes the typed `Status`, so this bridges
+/// from the wire vocabulary the way a real producer would send it.
+fn payload_json(pane_id: u32, status: &str) -> String {
+    payload::to_wire(&payload_for(pane_id, Status::from_wire(status)))
+}
+
+#[test]
+fn status_edge_persists_presence_once_and_not_on_identical_state() {
+    let mut rt = runtime_with_granted_permission();
+    drive_tabs_and_panes(&mut rt);
+
+    let out = rt.status_pipe(&payload_json(7, "running"));
+    assert!(out.effects.contains(&Effect::PersistPresence), "running-count edge publishes presence, got {:?}", out.effects);
+
+    let again = rt.status_pipe(&payload_json(7, "running"));
+    assert!(!again.effects.contains(&Effect::PersistPresence), "identical state does not re-publish, got {:?}", again.effects);
+}
+
+#[test]
+fn presence_withheld_until_own_session_name_is_known() {
+    // Same status edge as above, but WITHOUT `session_update` ever landing —
+    // an unnamed presence file is useless to peers, so `project` must not
+    // emit `PersistPresence` no matter what the own counts do.
+    let mut rt = PluginRuntime {
+        permission: PermissionState::Resolved { granted: true },
+        config: config(),
+        ..Default::default()
+    };
+    drive_tabs_and_panes(&mut rt);
+
+    let out = rt.status_pipe(&payload_json(7, "running"));
+    assert!(!out.effects.contains(&Effect::PersistPresence), "no session name yet, got {:?}", out.effects);
+}
+
+#[test]
+fn session_cycle_commits_via_switch_session_effect_on_idle_tick() {
+    let mut rt = runtime_with_granted_permission(); // own session name is "work"
+    rt.session_update(vec![
+        SessionLite { name: "work".into(), is_current: true },
+        SessionLite { name: "alpha".into(), is_current: false },
+    ]);
+    rt.presences_changed(vec![
+        r#"{"session_name":"alpha","running":0,"attention":1,"attention_tab_position":1}"#.into(),
+    ]);
+
+    let out = rt.control_pipe("session-next");
+    assert!(out.render, "selection highlight renders");
+
+    let tick = rt.timer_fast(PermissionProbe::default()); // next Fast tick, no tap since
+    assert!(
+        tick.effects.iter().any(|e| matches!(
+            e, Effect::SwitchSession { name, tab_position: Some(1) } if name == "alpha"
+        )),
+        "idle tick commits the pending selection, got {:?}",
+        tick.effects
+    );
+}
+
+#[test]
+fn session_cycle_is_inert_without_permission() {
+    let mut rt = PluginRuntime::default();
+    rt.session_update(vec![
+        SessionLite { name: "work".into(), is_current: true },
+        SessionLite { name: "alpha".into(), is_current: false },
+    ]);
+    assert_eq!(rt.control_pipe("session-next"), Outcome::default());
+}
+
+#[test]
+fn session_cycle_arms_fast_cadence_for_the_idle_commit() {
+    let mut rt = runtime_with_granted_permission();
+    rt.session_update(vec![
+        SessionLite { name: "work".into(), is_current: true },
+        SessionLite { name: "alpha".into(), is_current: false },
+    ]);
+    let out = rt.control_pipe("session-next");
+    assert!(
+        out.effects.contains(&Effect::SetTimeout(Cadence::Fast)),
+        "a pending cycle selection must arm Fast so the idle-commit fires promptly, got {:?}",
+        out.effects
+    );
 }
 
 // ── Effect::Notify integration ─────────────────────────────────────────────

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -921,7 +921,16 @@ fn session_cycle_commits_via_switch_session_effect_on_idle_tick() {
     let out = rt.control_pipe("session-next");
     assert!(out.render, "selection highlight renders");
 
-    let tick = rt.timer_fast(PermissionProbe::default()); // next Fast tick, no tap since
+    // The Fast fire covering the tap itself must not commit (task-14: the
+    // taps-since-last-fire flag resets the deadline instead) — only the
+    // NEXT, fully quiet fire may.
+    let covering = rt.timer_fast(PermissionProbe::default());
+    assert!(
+        !covering.effects.iter().any(|e| matches!(e, Effect::SwitchSession { .. })),
+        "the fire covering the tap must not commit, got {:?}",
+        covering.effects
+    );
+    let tick = rt.timer_fast(PermissionProbe::default()); // the next, quiet Fast tick
     assert!(
         tick.effects.iter().any(|e| matches!(
             e, Effect::SwitchSession { name, tab_position: Some(1) } if name == "alpha"

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -957,6 +957,44 @@ fn session_cycle_arms_fast_cadence_for_the_idle_commit() {
     );
 }
 
+#[test]
+fn clicking_a_session_line_emits_switch_session() {
+    // Two live sessions (own "work" + peer "alpha") put two badge lines
+    // between the header and the first tab card (`render::render_session_badge`,
+    // wired into the body in Task 7). Mirrors
+    // `render_records_targets_and_mouse_click_returns_host_effect`'s line-index
+    // bookkeeping: Compact density + header:true is a 2-line header (title,
+    // rule — "line 2 = tab header" there), so with the badge inserted here:
+    // line 0 = title, 1 = rule, 2 = own "work" badge line (click-inert, no
+    // cross-session target), 3 = peer "alpha" badge line (clickable).
+    let mut rt = runtime_with_granted_permission(); // own session name "work"
+    rt.tabs_changed(vec![tab(0, "team", false)]);
+    rt.session_update(vec![
+        SessionLite { name: "work".into(), is_current: true },
+        SessionLite { name: "alpha".into(), is_current: false },
+    ]);
+    rt.presences_changed(vec![
+        r#"{"session_name":"alpha","running":0,"attention":1,"attention_tab_position":2}"#.into(),
+    ]);
+
+    let ansi = rt.render(100, 80);
+    assert!(ansi.contains("alpha"), "setup: the peer's badge line must actually render");
+
+    let own_click = rt.mouse_click(2);
+    assert_eq!(
+        own_click,
+        Outcome::default(),
+        "the own-session badge line has no click target, got {:?}",
+        own_click
+    );
+
+    let peer_click = rt.mouse_click(3);
+    assert_eq!(
+        peer_click.effects,
+        vec![Effect::SwitchSession { name: "alpha".into(), tab_position: Some(2) }]
+    );
+}
+
 // ── Effect::Notify integration ─────────────────────────────────────────────
 
 /// Helper: two tabs; pane 5 focused in active tab 0, pane 7 in background

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -849,6 +849,50 @@ fn status_edge_persists_presence_once_and_not_on_identical_state() {
 }
 
 #[test]
+fn presence_edge_ignores_timestamp_but_still_reacts_to_content() {
+    // Finding 1 pin: `presence_json` embeds `updated_epoch_s`, which on Fast
+    // cadence moves every tick. If `project`'s change check compared the raw
+    // JSON (epoch included), advancing the epoch alone — with unchanged
+    // counts — would look like an edge and re-fire `PersistPresence` every
+    // second. It must not: only a real content change (running/attention/
+    // attention_tab_position) counts, mirroring `sessions.rs::set_own`'s
+    // badge-derived check, which already excludes `updated_epoch_s`.
+    let mut rt = runtime_with_granted_permission();
+    drive_tabs_and_panes(&mut rt);
+
+    let first = rt.status_pipe(&payload_json(7, "running"));
+    assert!(first.effects.contains(&Effect::PersistPresence), "setup: first edge publishes, got {:?}", first.effects);
+
+    // Drive `project` directly (as `project_emits_effects_in_canonical_order`
+    // does) with a no-op domain change but a strictly advancing epoch each
+    // call — the seam that lets this test move "now" without sleeping.
+    let noop = RadarChange::default();
+    let same_epoch_advanced_once = rt.project(vec![], noop.clone(), 1_000);
+    assert!(
+        !same_epoch_advanced_once.effects.contains(&Effect::PersistPresence),
+        "epoch-only change (unchanged counts) must not republish, got {:?}",
+        same_epoch_advanced_once.effects
+    );
+    let same_epoch_advanced_again = rt.project(vec![], noop, 2_000);
+    assert!(
+        !same_epoch_advanced_again.effects.contains(&Effect::PersistPresence),
+        "epoch-only change (unchanged counts, again) must not republish, got {:?}",
+        same_epoch_advanced_again.effects
+    );
+
+    // A real content edge (attention 0 -> 1) evaluated at the SAME epoch as
+    // the call just above still publishes — the exclusion is timestamp-only,
+    // not a blanket suppression of `PersistPresence`.
+    rt.radar.status_mut().apply(payload_for(7, Status::Pending), rt.tick, 2_000);
+    let content_edge = rt.project(vec![], RadarChange::default(), 2_000);
+    assert!(
+        content_edge.effects.contains(&Effect::PersistPresence),
+        "a counts change at an unchanged epoch must still publish, got {:?}",
+        content_edge.effects
+    );
+}
+
+#[test]
 fn presence_withheld_until_own_session_name_is_known() {
     // Same status edge as above, but WITHOUT `session_update` ever landing —
     // an unnamed presence file is useless to peers, so `project` must not
@@ -1513,4 +1557,33 @@ fn lone_slow_fire_processes_as_the_live_chain() {
         "the lone slow chain re-arms itself, got {:?}",
         tick.effects
     );
+}
+
+#[test]
+fn read_presences_is_bound_to_fast_fires_only() {
+    // Finding 2 pin: the brief bounds `Effect::ReadPresences` to "one
+    // directory scan per second, only while Fast is armed" — it must not
+    // ride along on the Slow (60s) heartbeat, which exists purely to repaint
+    // ledger ages. `timer` tells Fast from Slow the same way `TimerChain::
+    // on_fire` tells live from stale: by `elapsed_s` against
+    // `STALE_FIRE_ELAPSED_S`.
+    let mut rt = PluginRuntime {
+        permission: PermissionState::Resolved { granted: true },
+        config: config(),
+        ..Default::default()
+    };
+
+    let fast = rt.timer(PermissionProbe::default(), Cadence::Fast.seconds());
+    assert!(fast.effects.contains(&Effect::ReadPresences), "a Fast fire must scan peers, got {:?}", fast.effects);
+
+    // A lone Slow fire (nothing else in flight, so it's the live chain, not
+    // a stale leftover — see `lone_slow_fire_processes_as_the_live_chain`)
+    // must not.
+    let mut rt = PluginRuntime {
+        permission: PermissionState::Resolved { granted: true },
+        config: config(),
+        ..Default::default()
+    };
+    let slow = rt.timer(PermissionProbe::default(), Cadence::Slow.seconds());
+    assert!(!slow.effects.contains(&Effect::ReadPresences), "a Slow fire must not scan peers, got {:?}", slow.effects);
 }

--- a/crates/plugin/src/session_files.rs
+++ b/crates/plugin/src/session_files.rs
@@ -256,6 +256,43 @@ impl SessionFiles {
         out
     }
 
+    /// Delete every presence file in the shared root whose raw JSON content
+    /// satisfies `matches` — the on-disk half of a manual dismiss
+    /// (`Effect::DismissPresence`), and the only forgetting besides the
+    /// open-time `PRESENCE_MAX_AGE` sweep. Same file recognizer as
+    /// `read_peer_presences` (prefix + `.json`, so tmp files and snapshots
+    /// never match), but deliberately no own-file exclusion: this is
+    /// content-driven, not identity-driven, and the runtime only ever calls
+    /// it for a name it has confirmed stale — the own entry is never stale
+    /// (`sessions::Sessions::dismiss`). Every match is deleted, not just the
+    /// freshest: a name can have multiple pid-keyed corpses on disk (see
+    /// `update_presences`'s dedup doc in `sessions.rs`). Parse-agnostic on
+    /// purpose — the predicate receives raw file content, and the caller
+    /// (lib.rs's effect handler) supplies a `Presence::parse`-based closure,
+    /// so name matching stays exactly as lenient as every other presence
+    /// read path without this module learning about `Presence` at all.
+    /// A no-op in disabled mode (no writable root).
+    pub(crate) fn remove_presences_matching(&self, matches: impl Fn(&str) -> bool) {
+        let Some(paths) = &self.paths else {
+            return;
+        };
+        let Ok(entries) = std::fs::read_dir(&paths.root) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if !name.starts_with(PRESENCE_PREFIX) || !name.ends_with(".json") {
+                continue; // tmp files and snapshots don't match
+            }
+            if let Ok(json) = std::fs::read_to_string(entry.path()) {
+                if matches(&json) {
+                    let _ = std::fs::remove_file(entry.path());
+                }
+            }
+        }
+    }
+
     /// Re-probe the permission state for a timer tick: re-read the marker and,
     /// if still unmarked, re-attempt lock ownership (reclaiming a now-stale
     /// lock). This lets a waiting peer take over a prompt whose owner has gone,
@@ -1049,5 +1086,48 @@ mod tests {
             SNAPSHOT_MAX_AGE,
         );
         assert!(s.files.read_peer_presences().is_empty());
+    }
+
+    #[test]
+    fn remove_presences_matching_deletes_every_file_satisfying_the_predicate_and_spares_others() {
+        let dir = tempfile::tempdir().unwrap();
+        let reader = SessionFiles::open_with_roots_at(
+            SessionFileIds { plugin_id: 1, zellij_pid: 100 },
+            [dir.path().to_path_buf()],
+            SystemTime::now(),
+            SNAPSHOT_MAX_AGE,
+        );
+        let alpha_a = SessionFiles::open_with_roots_at(
+            SessionFileIds { plugin_id: 2, zellij_pid: 200 },
+            [dir.path().to_path_buf()],
+            SystemTime::now(),
+            SNAPSHOT_MAX_AGE,
+        );
+        let alpha_b = SessionFiles::open_with_roots_at(
+            SessionFileIds { plugin_id: 3, zellij_pid: 300 },
+            [dir.path().to_path_buf()],
+            SystemTime::now(),
+            SNAPSHOT_MAX_AGE,
+        );
+        let beta = SessionFiles::open_with_roots_at(
+            SessionFileIds { plugin_id: 4, zellij_pid: 400 },
+            [dir.path().to_path_buf()],
+            SystemTime::now(),
+            SNAPSHOT_MAX_AGE,
+        );
+        alpha_a.files.persist_presence(r#"{"session_name":"alpha","running":1,"attention":0}"#);
+        alpha_b.files.persist_presence(r#"{"session_name":"alpha","running":2,"attention":0}"#);
+        beta.files.persist_presence(r#"{"session_name":"beta","running":1,"attention":0}"#);
+
+        reader.files.remove_presences_matching(|json| json.contains(r#""alpha""#));
+
+        assert!(!dir.path().join("zj-radar.presence.200.json").exists());
+        assert!(!dir.path().join("zj-radar.presence.300.json").exists());
+        assert!(dir.path().join("zj-radar.presence.400.json").exists());
+    }
+
+    #[test]
+    fn remove_presences_matching_is_a_noop_in_disabled_mode() {
+        SessionFiles::default().remove_presences_matching(|_| true);
     }
 }

--- a/crates/plugin/src/session_files.rs
+++ b/crates/plugin/src/session_files.rs
@@ -35,11 +35,27 @@ const NOTIFY_CLAIM_TTL: Duration = Duration::from_secs(30);
 const NOTIFY_CLAIM_SWEEP_AGE: Duration = Duration::from_secs(300);
 const PERMISSION_GRANTED_MARKER: &str = "granted";
 const PERMISSION_DENIED_MARKER: &str = "denied";
-/// Horizon after which a presence file no longer describes a live session's
-/// radar. Liveness is authoritative from `SessionUpdate`; this sweep only
-/// stops dead servers' files from accumulating in the shared root. Generous:
-/// a detached-but-alive session whose timer idles must not be reaped.
+/// Horizon after which a presence file is deleted as debris at `open` time,
+/// regardless of liveness. Distinct from (and much longer than)
+/// `PRESENCE_LIVE_TTL`, which gates the READ path: a session can be dead
+/// long before its file turns 6h old, so the read-time gate is what peers
+/// actually rely on to stop showing it — this sweep only exists so a long
+/// string of dead sessions' files don't accumulate forever in the shared
+/// root. Generous: a detached-but-alive session whose timer idles must not
+/// be reaped.
 const PRESENCE_MAX_AGE: Duration = Duration::from_secs(6 * 60 * 60);
+/// A presence file whose mtime is older than this belongs to a session that
+/// stopped heartbeating (dead server, or a session that was killed) — the
+/// reader treats it as gone. This is the liveness signal itself, now that
+/// there is no `SessionUpdate` peer list to cross-check against (see
+/// task-8b-brief.md): `runtime.rs`'s timer heartbeats an idle-but-alive
+/// session's own file at least once per Slow (60s) tick, so 180s gives wide
+/// margin against scheduler jitter while still reaping a dead session's
+/// badge row promptly. Distinct from `PRESENCE_MAX_AGE` (6h), which merely
+/// deletes debris at `open` — this gates the READ path (`read_peer_presences`)
+/// itself and does not delete anything (the open-time sweep above still owns
+/// deletion; a stale-but-not-yet-swept file is simply skipped here).
+const PRESENCE_LIVE_TTL: Duration = Duration::from_secs(180);
 /// Deliberately distinct from `SNAPSHOT_PREFIX` (`zj-radar.<pid>`) so
 /// `is_owned_session_file` / `is_current_session_file` and the snapshot sweep
 /// never match a presence file — presence gets its own recognizer and sweep
@@ -191,10 +207,19 @@ impl SessionFiles {
     }
 
     /// Raw JSON of every OTHER session's presence file (own pid excluded, tmp
-    /// files excluded). Parsing/validation is the caller's job (`Presence::parse`
-    /// skips corrupt peers). Read on timer ticks only — bounded by live session
-    /// count, never per-pane.
+    /// files excluded, stale mtimes excluded). Parsing/validation is the
+    /// caller's job (`Presence::parse` skips corrupt peers) — liveness,
+    /// though, IS this method's job: a peer whose file's mtime has drifted
+    /// past `PRESENCE_LIVE_TTL` is treated as gone (its session stopped
+    /// heartbeating — dead server or a killed session), same as if the file
+    /// didn't exist. Read-only: a stale file is skipped, never deleted here
+    /// (the open-time sweep owns deletion). Read on timer ticks only —
+    /// bounded by live session count, never per-pane.
     pub(crate) fn read_peer_presences(&self) -> Vec<String> {
+        self.read_peer_presences_at(SystemTime::now())
+    }
+
+    fn read_peer_presences_at(&self, now: SystemTime) -> Vec<String> {
         let Some(paths) = &self.paths else {
             return Vec::new();
         };
@@ -210,6 +235,15 @@ impl SessionFiles {
             }
             if paths.is_own_presence_file(&name) {
                 continue;
+            }
+            let stale = entry
+                .metadata()
+                .and_then(|m| m.modified())
+                .ok()
+                .and_then(|modified| now.duration_since(modified).ok())
+                .is_some_and(|age| age > PRESENCE_LIVE_TTL);
+            if stale {
+                continue; // dead peer: skip, don't delete (read path stays read-only)
             }
             if let Ok(json) = std::fs::read_to_string(entry.path()) {
                 out.push(json);
@@ -947,6 +981,56 @@ mod tests {
         s.files.persist_presence(r#"{"session_name":"me"}"#);
         let fresh = dir.path().join("zj-radar.presence.100.json");
         assert!(fresh.exists());
+    }
+
+    #[test]
+    fn read_peer_presences_skips_a_stale_mtime_peer_but_keeps_a_fresh_one() {
+        // Liveness itself, not just open-time debris removal: a peer whose
+        // file hasn't been heartbeated in over PRESENCE_LIVE_TTL must be
+        // invisible to the READ path even though `prune_stale_files` (a much
+        // longer horizon, and only run at `open`) would still leave it on
+        // disk untouched.
+        let dir = tempfile::tempdir().unwrap();
+        let reader = SessionFiles::open_with_roots_at(
+            SessionFileIds { plugin_id: 1, zellij_pid: 100 },
+            [dir.path().to_path_buf()],
+            SystemTime::now(),
+            SNAPSHOT_MAX_AGE,
+        );
+        let fresh_peer = SessionFiles::open_with_roots_at(
+            SessionFileIds { plugin_id: 2, zellij_pid: 200 },
+            [dir.path().to_path_buf()],
+            SystemTime::now(),
+            SNAPSHOT_MAX_AGE,
+        );
+        let stale_peer = SessionFiles::open_with_roots_at(
+            SessionFileIds { plugin_id: 3, zellij_pid: 300 },
+            [dir.path().to_path_buf()],
+            SystemTime::now(),
+            SNAPSHOT_MAX_AGE,
+        );
+        fresh_peer.files.persist_presence(r#"{"session_name":"fresh"}"#);
+        stale_peer.files.persist_presence(r#"{"session_name":"stale"}"#);
+
+        // Both are visible while both are fresh.
+        assert_eq!(
+            reader.files.read_peer_presences(),
+            vec![r#"{"session_name":"fresh"}"#.to_string(), r#"{"session_name":"stale"}"#.to_string()]
+        );
+
+        // Backdate only the "stale" peer's file past the live TTL — a dead
+        // server's file just sitting there with an old mtime, not something
+        // any sweep has touched.
+        let stale_path = dir.path().join("zj-radar.presence.300.json");
+        let old = SystemTime::now() - PRESENCE_LIVE_TTL - Duration::from_secs(5);
+        std::fs::File::open(&stale_path).unwrap().set_modified(old).unwrap();
+
+        assert_eq!(
+            reader.files.read_peer_presences(),
+            vec![r#"{"session_name":"fresh"}"#.to_string()],
+            "a peer whose file's mtime is older than PRESENCE_LIVE_TTL must be skipped by the read path"
+        );
+        assert!(stale_path.exists(), "the read path must not delete a stale file — only skip it");
     }
 
     #[test]

--- a/crates/plugin/src/session_files.rs
+++ b/crates/plugin/src/session_files.rs
@@ -35,27 +35,16 @@ const NOTIFY_CLAIM_TTL: Duration = Duration::from_secs(30);
 const NOTIFY_CLAIM_SWEEP_AGE: Duration = Duration::from_secs(300);
 const PERMISSION_GRANTED_MARKER: &str = "granted";
 const PERMISSION_DENIED_MARKER: &str = "denied";
-/// Horizon after which a presence file is deleted as debris at `open` time,
-/// regardless of liveness. Distinct from (and much longer than)
-/// `PRESENCE_LIVE_TTL`, which gates the READ path: a session can be dead
-/// long before its file turns 6h old, so the read-time gate is what peers
-/// actually rely on to stop showing it — this sweep only exists so a long
-/// string of dead sessions' files don't accumulate forever in the shared
-/// root. Generous: a detached-but-alive session whose timer idles must not
-/// be reaped.
+/// Horizon after which a presence file is deleted as debris at `open` time —
+/// the ONLY true forgetting a peer's roster entry is subject to (task-14,
+/// user decision: a remembered session must never silently vanish from the
+/// badge). Peers dead well before their file turns 6h old still keep
+/// showing up in every other session's badge, dimmed as stale
+/// (`sessions::STALE_AFTER_SECS`) rather than dropped — this sweep only
+/// exists so a long string of genuinely dead sessions' files don't
+/// accumulate forever in the shared root. Generous: a detached-but-alive
+/// session whose timer idles must not be reaped.
 const PRESENCE_MAX_AGE: Duration = Duration::from_secs(6 * 60 * 60);
-/// A presence file whose mtime is older than this belongs to a session that
-/// stopped heartbeating (dead server, or a session that was killed) — the
-/// reader treats it as gone. This is the liveness signal itself, now that
-/// there is no `SessionUpdate` peer list to cross-check against (see
-/// task-8b-brief.md): `runtime.rs`'s timer heartbeats an idle-but-alive
-/// session's own file at least once per Slow (60s) tick, so 180s gives wide
-/// margin against scheduler jitter while still reaping a dead session's
-/// badge row promptly. Distinct from `PRESENCE_MAX_AGE` (6h), which merely
-/// deletes debris at `open` — this gates the READ path (`read_peer_presences`)
-/// itself and does not delete anything (the open-time sweep above still owns
-/// deletion; a stale-but-not-yet-swept file is simply skipped here).
-const PRESENCE_LIVE_TTL: Duration = Duration::from_secs(180);
 /// Deliberately distinct from the pid-scoped `session_prefix` (`zj-radar.<pid>`) so
 /// `is_owned_session_file` / `is_current_session_file` and the snapshot sweep
 /// never match a presence file — presence gets its own recognizer and sweep
@@ -66,6 +55,15 @@ const PRESENCE_PREFIX: &str = "zj-radar.presence.";
 pub(crate) struct SessionFileIds {
     pub plugin_id: u32,
     pub zellij_pid: u32,
+}
+
+/// One peer's presence file as read off disk — see
+/// [`SessionFiles::read_peer_presences`]'s doc for why `age_secs` is
+/// measured off the file's mtime rather than trusted from the JSON content.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PeerPresenceFile {
+    pub json: String,
+    pub age_secs: u64,
 }
 
 #[derive(Debug)]
@@ -207,19 +205,26 @@ impl SessionFiles {
     }
 
     /// Raw JSON of every OTHER session's presence file (own pid excluded, tmp
-    /// files excluded, stale mtimes excluded). Parsing/validation is the
-    /// caller's job (`Presence::parse` skips corrupt peers) — liveness,
-    /// though, IS this method's job: a peer whose file's mtime has drifted
-    /// past `PRESENCE_LIVE_TTL` is treated as gone (its session stopped
-    /// heartbeating — dead server or a killed session), same as if the file
-    /// didn't exist. Read-only: a stale file is skipped, never deleted here
-    /// (the open-time sweep owns deletion). Read on timer ticks only —
-    /// bounded by live session count, never per-pane.
-    pub(crate) fn read_peer_presences(&self) -> Vec<String> {
+    /// files excluded), paired with how long ago its mtime was last touched.
+    /// Parsing/validation is the caller's job (`Presence::parse` skips
+    /// corrupt peers) — and so, now, is staleness: this method used to treat
+    /// an old mtime as "peer is gone" and skip it outright, but task-14's
+    /// user decision is that a remembered session must never silently
+    /// vanish from the badge, so every peer file found comes back
+    /// unconditionally. `age_secs` is measured off THIS session's own
+    /// filesystem clock reading the file's mtime — not the peer's
+    /// self-reported `updated_epoch_s` inside the JSON, which a corrupt or
+    /// merely-slow-to-update peer could get wrong — and lets
+    /// `sessions::Sessions::update_presences` mark an entry stale
+    /// (`sessions::STALE_AFTER_SECS`) without doing its own filesystem I/O.
+    /// Read-only regardless: nothing is ever deleted here (the open-time
+    /// sweep, `PRESENCE_MAX_AGE`, owns the only actual forgetting). Read on
+    /// timer ticks only — bounded by live session count, never per-pane.
+    pub(crate) fn read_peer_presences(&self) -> Vec<PeerPresenceFile> {
         self.read_peer_presences_at(SystemTime::now())
     }
 
-    fn read_peer_presences_at(&self, now: SystemTime) -> Vec<String> {
+    fn read_peer_presences_at(&self, now: SystemTime) -> Vec<PeerPresenceFile> {
         let Some(paths) = &self.paths else {
             return Vec::new();
         };
@@ -236,20 +241,18 @@ impl SessionFiles {
             if paths.is_own_presence_file(&name) {
                 continue;
             }
-            let stale = entry
+            let age_secs = entry
                 .metadata()
                 .and_then(|m| m.modified())
                 .ok()
                 .and_then(|modified| now.duration_since(modified).ok())
-                .is_some_and(|age| age > PRESENCE_LIVE_TTL);
-            if stale {
-                continue; // dead peer: skip, don't delete (read path stays read-only)
-            }
+                .map(|age| age.as_secs())
+                .unwrap_or(0); // metadata/clock hiccup: treat as fresh rather than drop the peer
             if let Ok(json) = std::fs::read_to_string(entry.path()) {
-                out.push(json);
+                out.push(PeerPresenceFile { json, age_secs });
             }
         }
-        out.sort();
+        out.sort_by(|a, b| a.json.cmp(&b.json));
         out
     }
 
@@ -960,8 +963,10 @@ mod tests {
         a.files.persist_presence(r#"{"session_name":"alpha"}"#);
         b.files.persist_presence(r#"{"session_name":"beta"}"#);
         // Each session sees the OTHER's presence, never its own.
-        assert_eq!(a.files.read_peer_presences(), vec![r#"{"session_name":"beta"}"#.to_string()]);
-        assert_eq!(b.files.read_peer_presences(), vec![r#"{"session_name":"alpha"}"#.to_string()]);
+        let a_json: Vec<String> = a.files.read_peer_presences().into_iter().map(|p| p.json).collect();
+        let b_json: Vec<String> = b.files.read_peer_presences().into_iter().map(|p| p.json).collect();
+        assert_eq!(a_json, vec![r#"{"session_name":"beta"}"#.to_string()]);
+        assert_eq!(b_json, vec![r#"{"session_name":"alpha"}"#.to_string()]);
     }
 
     #[test]
@@ -984,12 +989,14 @@ mod tests {
     }
 
     #[test]
-    fn read_peer_presences_skips_a_stale_mtime_peer_but_keeps_a_fresh_one() {
-        // Liveness itself, not just open-time debris removal: a peer whose
-        // file hasn't been heartbeated in over PRESENCE_LIVE_TTL must be
-        // invisible to the READ path even though `prune_stale_files` (a much
-        // longer horizon, and only run at `open`) would still leave it on
-        // disk untouched.
+    fn read_peer_presences_never_drops_an_old_mtime_peer_and_reports_its_age() {
+        // task-14, user decision: a remembered session must never silently
+        // vanish from the badge. This method used to skip a peer once its
+        // file's mtime drifted past a liveness TTL; now it must keep
+        // returning that peer unconditionally — dropping only ever happens
+        // at `open`'s much-longer `PRESENCE_MAX_AGE` sweep — and report an
+        // honest age so the caller (`sessions::Sessions`) can mark it stale
+        // instead.
         let dir = tempfile::tempdir().unwrap();
         let reader = SessionFiles::open_with_roots_at(
             SessionFileIds { plugin_id: 1, zellij_pid: 100 },
@@ -1003,34 +1010,31 @@ mod tests {
             SystemTime::now(),
             SNAPSHOT_MAX_AGE,
         );
-        let stale_peer = SessionFiles::open_with_roots_at(
+        let old_peer = SessionFiles::open_with_roots_at(
             SessionFileIds { plugin_id: 3, zellij_pid: 300 },
             [dir.path().to_path_buf()],
             SystemTime::now(),
             SNAPSHOT_MAX_AGE,
         );
         fresh_peer.files.persist_presence(r#"{"session_name":"fresh"}"#);
-        stale_peer.files.persist_presence(r#"{"session_name":"stale"}"#);
+        old_peer.files.persist_presence(r#"{"session_name":"old"}"#);
 
-        // Both are visible while both are fresh.
-        assert_eq!(
-            reader.files.read_peer_presences(),
-            vec![r#"{"session_name":"fresh"}"#.to_string(), r#"{"session_name":"stale"}"#.to_string()]
-        );
+        // Backdate only the "old" peer's file — a dead server's file just
+        // sitting there with an old mtime, not something any sweep has
+        // touched (well short of `PRESENCE_MAX_AGE`, so `open` would not
+        // have reaped it either).
+        let old_path = dir.path().join("zj-radar.presence.300.json");
+        let old_age = Duration::from_secs(400); // well past sessions::STALE_AFTER_SECS (90s)
+        std::fs::File::open(&old_path).unwrap().set_modified(SystemTime::now() - old_age).unwrap();
 
-        // Backdate only the "stale" peer's file past the live TTL — a dead
-        // server's file just sitting there with an old mtime, not something
-        // any sweep has touched.
-        let stale_path = dir.path().join("zj-radar.presence.300.json");
-        let old = SystemTime::now() - PRESENCE_LIVE_TTL - Duration::from_secs(5);
-        std::fs::File::open(&stale_path).unwrap().set_modified(old).unwrap();
-
-        assert_eq!(
-            reader.files.read_peer_presences(),
-            vec![r#"{"session_name":"fresh"}"#.to_string()],
-            "a peer whose file's mtime is older than PRESENCE_LIVE_TTL must be skipped by the read path"
-        );
-        assert!(stale_path.exists(), "the read path must not delete a stale file — only skip it");
+        let mut peers = reader.files.read_peer_presences();
+        peers.sort_by(|a, b| a.json.cmp(&b.json));
+        assert_eq!(peers.len(), 2, "both peers must still be returned regardless of mtime age");
+        let fresh = peers.iter().find(|p| p.json.contains("fresh")).expect("fresh peer present");
+        let old = peers.iter().find(|p| p.json.contains("\"old\"")).expect("old-mtime peer still present, not dropped");
+        assert!(fresh.age_secs < 5, "freshly-written peer's age should read ~0s, got {}", fresh.age_secs);
+        assert!(old.age_secs >= old_age.as_secs(), "backdated peer's age must reflect its real mtime, got {}", old.age_secs);
+        assert!(old_path.exists(), "the read path must never delete anything — only the open-time sweep does");
     }
 
     #[test]

--- a/crates/plugin/src/session_files.rs
+++ b/crates/plugin/src/session_files.rs
@@ -35,6 +35,16 @@ const NOTIFY_CLAIM_TTL: Duration = Duration::from_secs(30);
 const NOTIFY_CLAIM_SWEEP_AGE: Duration = Duration::from_secs(300);
 const PERMISSION_GRANTED_MARKER: &str = "granted";
 const PERMISSION_DENIED_MARKER: &str = "denied";
+/// Horizon after which a presence file no longer describes a live session's
+/// radar. Liveness is authoritative from `SessionUpdate`; this sweep only
+/// stops dead servers' files from accumulating in the shared root. Generous:
+/// a detached-but-alive session whose timer idles must not be reaped.
+const PRESENCE_MAX_AGE: Duration = Duration::from_secs(6 * 60 * 60);
+/// Deliberately distinct from `SNAPSHOT_PREFIX` (`zj-radar.<pid>`) so
+/// `is_owned_session_file` / `is_current_session_file` and the snapshot sweep
+/// never match a presence file — presence gets its own recognizer and sweep
+/// horizon (see `PRESENCE_MAX_AGE`).
+const PRESENCE_PREFIX: &str = "zj-radar.presence.";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct SessionFileIds {
@@ -63,6 +73,8 @@ struct SessionPaths {
     permission_marker: PathBuf,
     permission_marker_tmp: PathBuf,
     permission_lock: PathBuf,
+    presence: PathBuf,
+    presence_tmp: PathBuf,
 }
 
 impl SessionFiles {
@@ -161,6 +173,50 @@ impl SessionFiles {
         } else {
             let _ = std::fs::remove_file(&paths.snapshot_tmp);
         }
+    }
+
+    /// Publish this session's presence for peer sessions' badges. Same atomic
+    /// tmp+rename discipline as `persist_snapshot`; disabled mode is a no-op.
+    pub(crate) fn persist_presence(&self, json: &str) {
+        let Some(paths) = &self.paths else {
+            return;
+        };
+        if std::fs::write(&paths.presence_tmp, json.as_bytes()).is_ok() {
+            if std::fs::rename(&paths.presence_tmp, &paths.presence).is_err() {
+                let _ = std::fs::remove_file(&paths.presence_tmp);
+            }
+        } else {
+            let _ = std::fs::remove_file(&paths.presence_tmp);
+        }
+    }
+
+    /// Raw JSON of every OTHER session's presence file (own pid excluded, tmp
+    /// files excluded). Parsing/validation is the caller's job (`Presence::parse`
+    /// skips corrupt peers). Read on timer ticks only — bounded by live session
+    /// count, never per-pane.
+    pub(crate) fn read_peer_presences(&self) -> Vec<String> {
+        let Some(paths) = &self.paths else {
+            return Vec::new();
+        };
+        let Ok(entries) = std::fs::read_dir(&paths.root) else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if !name.starts_with(PRESENCE_PREFIX) || !name.ends_with(".json") {
+                continue; // tmp files and snapshots don't match
+            }
+            if paths.is_own_presence_file(&name) {
+                continue;
+            }
+            if let Ok(json) = std::fs::read_to_string(entry.path()) {
+                out.push(json);
+            }
+        }
+        out.sort();
+        out
     }
 
     /// Re-probe the permission state for a timer tick: re-read the marker and,
@@ -295,6 +351,11 @@ impl SessionPaths {
             ids.plugin_id
         ));
         let permission_lock = root.join(format!("{session_prefix}.permissions.lock"));
+        let presence = root.join(format!("{PRESENCE_PREFIX}{}.json", ids.zellij_pid));
+        let presence_tmp = root.join(format!(
+            "{PRESENCE_PREFIX}{}.json.{}.tmp",
+            ids.zellij_pid, ids.plugin_id
+        ));
         Self {
             root,
             session_prefix,
@@ -303,6 +364,8 @@ impl SessionPaths {
             permission_marker,
             permission_marker_tmp,
             permission_lock,
+            presence,
+            presence_tmp,
         }
     }
 
@@ -320,6 +383,16 @@ impl SessionPaths {
             || (name.starts_with(&format!("{}.permissions.", self.session_prefix))
                 && name.ends_with(".tmp"))
             || name.starts_with(&format!("{}.notify.", self.session_prefix))
+    }
+
+    fn is_own_presence_file(&self, name: &str) -> bool {
+        self.presence
+            .file_name()
+            .is_some_and(|n| n.to_string_lossy() == name)
+            || self
+                .presence_tmp
+                .file_name()
+                .is_some_and(|n| n.to_string_lossy() == name)
     }
 }
 
@@ -353,6 +426,21 @@ fn prune_stale_files(paths: &SessionPaths, now: SystemTime, max_age: Duration) {
     for entry in entries.flatten() {
         let name = entry.file_name();
         let name = name.to_string_lossy();
+        if name.starts_with(PRESENCE_PREFIX) {
+            if paths.is_own_presence_file(&name) {
+                continue;
+            }
+            let stale = entry
+                .metadata()
+                .and_then(|m| m.modified())
+                .ok()
+                .and_then(|modified| now.duration_since(modified).ok())
+                .is_some_and(|age| age > PRESENCE_MAX_AGE);
+            if stale {
+                let _ = std::fs::remove_file(entry.path());
+            }
+            continue;
+        }
         if !is_owned_session_file(&name) || paths.is_current_session_file(&name) {
             continue;
         }
@@ -818,5 +906,60 @@ mod tests {
         assert!(dir.join("zj-radar.1.unknown").exists());
         assert!(dir.join("zj-radar.1.json.tmp").exists());
         assert!(dir.join("zj-radar.1.permissions.tmp").exists());
+    }
+
+    #[test]
+    fn presence_round_trips_between_two_session_roots() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = SessionFiles::open_with_roots_at(
+            SessionFileIds { plugin_id: 1, zellij_pid: 100 },
+            [dir.path().to_path_buf()],
+            SystemTime::now(),
+            SNAPSHOT_MAX_AGE,
+        );
+        let b = SessionFiles::open_with_roots_at(
+            SessionFileIds { plugin_id: 7, zellij_pid: 200 },
+            [dir.path().to_path_buf()],
+            SystemTime::now(),
+            SNAPSHOT_MAX_AGE,
+        );
+        a.files.persist_presence(r#"{"session_name":"alpha"}"#);
+        b.files.persist_presence(r#"{"session_name":"beta"}"#);
+        // Each session sees the OTHER's presence, never its own.
+        assert_eq!(a.files.read_peer_presences(), vec![r#"{"session_name":"beta"}"#.to_string()]);
+        assert_eq!(b.files.read_peer_presences(), vec![r#"{"session_name":"alpha"}"#.to_string()]);
+    }
+
+    #[test]
+    fn open_sweeps_stale_presence_but_keeps_fresh() {
+        let dir = tempfile::tempdir().unwrap();
+        let stale = dir.path().join("zj-radar.presence.999.json");
+        std::fs::write(&stale, "{}").unwrap();
+        let old = SystemTime::now() + PRESENCE_MAX_AGE + Duration::from_secs(60);
+        // Re-open "later": the sweep runs against `old` as now.
+        let s = SessionFiles::open_with_roots_at(
+            SessionFileIds { plugin_id: 1, zellij_pid: 100 },
+            [dir.path().to_path_buf()],
+            old,
+            SNAPSHOT_MAX_AGE,
+        );
+        assert!(!stale.exists(), "stale presence swept at open");
+        s.files.persist_presence(r#"{"session_name":"me"}"#);
+        let fresh = dir.path().join("zj-radar.presence.100.json");
+        assert!(fresh.exists());
+    }
+
+    #[test]
+    fn read_peer_presences_ignores_tmp_and_non_presence_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("zj-radar.presence.300.json.9.tmp"), "x").unwrap();
+        std::fs::write(dir.path().join("zj-radar.300.json"), "snapshot-not-presence").unwrap();
+        let s = SessionFiles::open_with_roots_at(
+            SessionFileIds { plugin_id: 1, zellij_pid: 100 },
+            [dir.path().to_path_buf()],
+            SystemTime::now(),
+            SNAPSHOT_MAX_AGE,
+        );
+        assert!(s.files.read_peer_presences().is_empty());
     }
 }

--- a/crates/plugin/src/session_files.rs
+++ b/crates/plugin/src/session_files.rs
@@ -56,7 +56,7 @@ const PRESENCE_MAX_AGE: Duration = Duration::from_secs(6 * 60 * 60);
 /// itself and does not delete anything (the open-time sweep above still owns
 /// deletion; a stale-but-not-yet-swept file is simply skipped here).
 const PRESENCE_LIVE_TTL: Duration = Duration::from_secs(180);
-/// Deliberately distinct from `SNAPSHOT_PREFIX` (`zj-radar.<pid>`) so
+/// Deliberately distinct from the pid-scoped `session_prefix` (`zj-radar.<pid>`) so
 /// `is_owned_session_file` / `is_current_session_file` and the snapshot sweep
 /// never match a presence file — presence gets its own recognizer and sweep
 /// horizon (see `PRESENCE_MAX_AGE`).

--- a/crates/plugin/src/sessions.rs
+++ b/crates/plugin/src/sessions.rs
@@ -17,6 +17,8 @@
 //! and `cycle()` (what Alt+[/] steps through): current session first, then
 //! `attention > 0` sessions by name, then the rest by name.
 
+use std::collections::HashMap;
+
 use crate::presence::Presence;
 use crate::radar_state::Direction;
 
@@ -82,7 +84,26 @@ impl Sessions {
     /// the runtime only repaints on real content change.
     pub(crate) fn update_presences(&mut self, raw: Vec<String>) -> bool {
         let before = self.badge();
-        self.peers = raw.iter().filter_map(|s| Presence::parse(s)).collect();
+        // WHY: presence files are keyed by server pid on disk, not by
+        // session name. A session killed and recreated under the same name
+        // gets a fresh presence file at a new pid path, but the old one (a
+        // "corpse") isn't unlinked — it just sits there parsing as a second
+        // live peer under the same name until PRESENCE_LIVE_TTL reaps it
+        // (up to 3 minutes). Left undeduped, `badge()` would render that
+        // name twice. Collapse by `session_name` here, keeping the presence
+        // with the greatest `updated_epoch_s` — that's the newest write, i.e.
+        // the live session; the corpse is whatever was on disk before the
+        // kill. On a tie, `>` (not `>=`) below makes the later entry in
+        // `raw` win deterministically, without needing separate tie-break
+        // code.
+        let mut by_name: HashMap<String, Presence> = HashMap::new();
+        for p in raw.iter().filter_map(|s| Presence::parse(s)) {
+            match by_name.get(&p.session_name) {
+                Some(existing) if existing.updated_epoch_s > p.updated_epoch_s => {} // existing is strictly fresher: keep it
+                _ => { by_name.insert(p.session_name.clone(), p); }
+            }
+        }
+        self.peers = by_name.into_values().collect();
         self.badge() != before
     }
 
@@ -198,7 +219,20 @@ impl Sessions {
     fn ordered(&self) -> Vec<OrderedEntry<'_>> {
         let mut attention: Vec<OrderedEntry> = Vec::new();
         let mut rest: Vec<OrderedEntry> = Vec::new();
+        let own_name = self.own.as_ref().map(|p| p.session_name.as_str());
         for p in &self.peers {
+            // WHY: a peer presence sharing our own session's name is
+            // necessarily either a stale corpse of this very session (pid-
+            // keyed presence files: a restarted session under the same name
+            // can coexist with a peer-visible copy of its old self) or a
+            // race between reading peer files and set_own. `own`'s counts
+            // come from set_own's direct knowledge, never from a peer file
+            // (see its doc comment) — it must always win a name collision,
+            // so the colliding peer is dropped outright rather than shown
+            // as a second line for the same name.
+            if own_name == Some(p.session_name.as_str()) {
+                continue;
+            }
             let entry = OrderedEntry { presence: p, is_current: false };
             if p.attention > 0 {
                 attention.push(entry);
@@ -429,6 +463,48 @@ mod tests {
 
         let t = s.tick(3).expect("idle tick commits");
         assert_eq!(t.name, "beta", "after vanished selection, cycle must restart and select the first non-current entry");
+    }
+
+    // -- Pinning: duplicate-name dedup (killed-then-recreated session) ------
+    // Presence files are pid-keyed on disk, not name-keyed: a session killed
+    // and recreated under the same name leaves its old presence file (a
+    // "corpse") coexisting with the fresh one until PRESENCE_LIVE_TTL reaps
+    // it. Without a dedup, `badge()` would render the same name twice for up
+    // to 3 minutes — exactly the bug the user observed.
+
+    #[test]
+    fn update_presences_dedupes_by_name_keeping_freshest() {
+        let mut s = Sessions::default();
+        let stale = r#"{"session_name":"alpha","running":1,"attention":0,"updated_epoch_s":10}"#;
+        let fresh = r#"{"session_name":"alpha","running":5,"attention":2,"updated_epoch_s":20}"#;
+        s.update_presences(vec![stale.to_string(), fresh.to_string()]);
+        let badge = s.badge();
+        let alphas: Vec<&BadgeEntry> = badge.iter().filter(|b| b.name == "alpha").collect();
+        assert_eq!(alphas.len(), 1, "two presences for the same name must collapse to one badge entry");
+        assert_eq!(alphas[0].running, 5, "the surviving entry must carry the fresher (greater updated_epoch_s) counts");
+        assert_eq!(alphas[0].attention, 2, "the surviving entry must carry the fresher (greater updated_epoch_s) counts");
+    }
+
+    #[test]
+    fn peer_presence_claiming_own_name_does_not_duplicate_own_entry() {
+        // A killed-then-recreated session's corpse can also collide with
+        // OUR OWN name specifically (the pid changed, the name didn't).
+        // `own` is this session's own direct knowledge (set_own's doc
+        // comment: never read back from disk) and must win outright, not
+        // merely "whichever is fresher" — the peer here claims a higher
+        // updated_epoch_s and larger counts, and must still lose.
+        let mut s = Sessions::default();
+        s.set_own(Presence { session_name: "work".into(), running: 3, attention: 0,
+                             attention_tab_position: None, updated_epoch_s: 50 });
+        s.update_presences(vec![
+            r#"{"session_name":"work","running":9,"attention":9,"updated_epoch_s":999}"#.to_string(),
+        ]);
+        let badge = s.badge();
+        let work_entries: Vec<&BadgeEntry> = badge.iter().filter(|b| b.name == "work").collect();
+        assert_eq!(work_entries.len(), 1, "a peer claiming our own name must not add a second badge line");
+        assert!(work_entries[0].is_current, "the surviving line must be the own entry");
+        assert_eq!(work_entries[0].running, 3, "own's own-known counts must win over a peer claiming the same name");
+        assert_eq!(work_entries[0].attention, 0, "own's own-known counts must win over a peer claiming the same name");
     }
 
     #[test]

--- a/crates/plugin/src/sessions.rs
+++ b/crates/plugin/src/sessions.rs
@@ -1,9 +1,17 @@
 //! Cross-session peer state + the Alt+[/] cycle state machine — pure: no
-//! zellij-tile, no filesystem. The runtime (Task 5) feeds this module parsed
-//! facts (the live session list, peer presence JSON, this session's own
-//! counts) and it derives the ordered badge on demand, mirroring the
-//! rows-derived-on-render doctrine (`CONTEXT.md`) rather than caching a
-//! badge that could drift from `live`/`peers`/`own`.
+//! zellij-tile, no filesystem. The runtime feeds this module parsed facts
+//! (peer presence JSON, this session's own counts) and it derives the
+//! ordered badge on demand, mirroring the rows-derived-on-render doctrine
+//! (`CONTEXT.md`) rather than caching a badge that could drift from
+//! `peers`/`own`.
+//!
+//! Liveness is implicit, not a separately-tracked list (task-8b-brief.md):
+//! there is no `SessionUpdate` peer roster to cross-check against anymore.
+//! Whatever `update_presences` was just handed IS the live peer set — a
+//! stale peer has already been filtered out one layer down, by
+//! `session_files::read_peer_presences`'s mtime gate, before it ever reaches
+//! this module. This module's own leniency is limited to "don't choke on a
+//! malformed line" (`Presence::parse`), not "cross-check membership".
 //!
 //! Ordering is a single source of truth shared by `badge()` (what's shown)
 //! and `cycle()` (what Alt+[/] steps through): current session first, then
@@ -11,13 +19,16 @@
 
 use crate::presence::Presence;
 use crate::radar_state::Direction;
-use std::collections::HashSet;
 
-/// A live session as reported by Zellij's session list, reduced to what this
-/// module needs. `lib.rs` maps the host's `SessionInfo` into this.
-pub(crate) struct SessionLite {
-    pub name: String,
-    pub is_current: bool,
+/// A row in the shared ordering: a [`Presence`] (own or peer) plus whether
+/// it's the current session. `own` contributes at most one of these (via
+/// `set_own`); every peer in `peers` contributes one. Combines what used to
+/// be a separate `SessionLite` (identity) + a `presence_for` lookup (counts)
+/// into a single reference, now that a `Presence` IS the identity (its
+/// `session_name`) as well as the counts.
+struct OrderedEntry<'a> {
+    presence: &'a Presence,
+    is_current: bool,
 }
 
 /// One row of the cross-session badge, in display order.
@@ -56,39 +67,30 @@ struct SelectionState {
 
 #[derive(Default)]
 pub(crate) struct Sessions {
-    live: Vec<SessionLite>,
     peers: Vec<Presence>,
     own: Option<Presence>,
     selection: Option<SelectionState>,
 }
 
 impl Sessions {
-    /// Replace the live session list (from Zellij's session list). Returns
-    /// whether the derived badge actually changed, so the runtime only
-    /// repaints on real content change.
-    pub(crate) fn update_live(&mut self, live: Vec<SessionLite>) -> bool {
-        let before = self.badge();
-        self.live = live;
-        self.badge() != before
-    }
-
-    /// Parse peer presence JSON (one string per peer session) and keep only
-    /// the ones naming a currently-live session — a corrupt file (handled by
-    /// `Presence::parse`'s leniency) or a session that has since closed must
-    /// never leave a stale/bogus badge entry lying around.
+    /// Replace the peer set with a fresh read of every OTHER session's
+    /// presence file — these entries ARE the live peers now (see the module
+    /// doc): `session_files::read_peer_presences` has already dropped
+    /// anything stale before this is called, so the only filtering left
+    /// here is `Presence::parse`'s leniency (skip a malformed line, don't
+    /// crash on it). Returns whether the derived badge actually changed, so
+    /// the runtime only repaints on real content change.
     pub(crate) fn update_presences(&mut self, raw: Vec<String>) -> bool {
         let before = self.badge();
-        let live_names: HashSet<&str> = self.live.iter().map(|s| s.name.as_str()).collect();
-        self.peers = raw
-            .iter()
-            .filter_map(|s| Presence::parse(s))
-            .filter(|p| live_names.contains(p.session_name.as_str()))
-            .collect();
+        self.peers = raw.iter().filter_map(|s| Presence::parse(s)).collect();
         self.badge() != before
     }
 
     /// Record this session's own counts (never read from a peer file — the
-    /// current session knows its own state directly).
+    /// current session knows its own state directly). The single path for
+    /// own counts into the badge — the runtime calls this every time it
+    /// recomputes `own_presence()`, not just on a name change, so the own
+    /// row stays live as running/attention move.
     pub(crate) fn set_own(&mut self, p: Presence) -> bool {
         let before = self.badge();
         self.own = Some(p);
@@ -108,25 +110,27 @@ impl Sessions {
         // order (its session closed) is treated the same as "nothing
         // selected" — restart below rather than advance from a position it
         // no longer occupies.
-        let current_position =
-            self.selection.as_ref().and_then(|sel| order.iter().position(|s| s.name == sel.name));
+        let current_position = self
+            .selection
+            .as_ref()
+            .and_then(|sel| order.iter().position(|s| s.presence.session_name == sel.name));
         self.selection = match (current_position, order.len()) {
             (_, 0) => None,
             (None, _) => {
                 // Nothing selected yet (or the selection vanished): start at
                 // the first non-current entry (index 0 is the current
-                // session, when live includes one).
-                order
-                    .iter()
-                    .position(|s| !s.is_current)
-                    .map(|index| SelectionState { name: order[index].name.clone(), last_tap_tick: now_tick })
+                // session, when own is known).
+                order.iter().position(|s| !s.is_current).map(|index| SelectionState {
+                    name: order[index].presence.session_name.clone(),
+                    last_tap_tick: now_tick,
+                })
             }
             (Some(index), len) => {
                 let next = match dir {
                     Direction::Next => (index + 1) % len,
                     Direction::Prev => (index + len - 1) % len,
                 };
-                Some(SelectionState { name: order[next].name.clone(), last_tap_tick: now_tick })
+                Some(SelectionState { name: order[next].presence.session_name.clone(), last_tap_tick: now_tick })
             }
         };
         self.badge() != before
@@ -148,34 +152,31 @@ impl Sessions {
         let name = sel.name.clone();
         self.selection = None; // committing, cancelling, or dropping a vanished selection all clear
         let order = self.ordered();
-        let entry = order.iter().find(|s| s.name == name)?; // vanished session: nothing to commit
+        let entry = order.iter().find(|s| s.presence.session_name == name)?; // vanished session: nothing to commit
         if entry.is_current {
             return None; // cancel gesture: landing back on the current session
         }
         Some(CommitTarget {
-            name: entry.name.clone(),
-            attention_tab_position: self.presence_for(&entry.name).and_then(|p| p.attention_tab_position),
+            name: entry.presence.session_name.clone(),
+            attention_tab_position: entry.presence.attention_tab_position,
         })
     }
 
     /// The ordered badge: current session first, then attention>0 sessions by
-    /// name, then the rest by name. Derived fresh from `live`/`peers`/`own`
-    /// every call — never cached — so it can never drift from its inputs.
+    /// name, then the rest by name. Derived fresh from `peers`/`own` every
+    /// call — never cached — so it can never drift from its inputs.
     pub(crate) fn badge(&self) -> Vec<BadgeEntry> {
         let order = self.ordered();
         let selected_name = self.selection.as_ref().map(|sel| sel.name.as_str());
         order
             .into_iter()
-            .map(|s| {
-                let p = self.presence_for(&s.name);
-                BadgeEntry {
-                    name: s.name.clone(),
-                    running: p.map_or(0, |p| p.running),
-                    attention: p.map_or(0, |p| p.attention),
-                    attention_tab_position: p.and_then(|p| p.attention_tab_position),
-                    is_current: s.is_current,
-                    selected: selected_name == Some(s.name.as_str()),
-                }
+            .map(|s| BadgeEntry {
+                name: s.presence.session_name.clone(),
+                running: s.presence.running,
+                attention: s.presence.attention,
+                attention_tab_position: s.presence.attention_tab_position,
+                is_current: s.is_current,
+                selected: selected_name == Some(s.presence.session_name.as_str()),
             })
             .collect()
     }
@@ -190,35 +191,25 @@ impl Sessions {
         self.selection.is_some()
     }
 
-    /// The shared ordering: current session(s) first, then attention>0
-    /// sessions by name, then the rest by name. Both `badge()` and `cycle()`
-    /// go through this so "what's shown" and "what Alt+[/] steps through"
-    /// can never disagree.
-    fn ordered(&self) -> Vec<&SessionLite> {
-        let mut current: Vec<&SessionLite> = Vec::new();
-        let mut attention: Vec<&SessionLite> = Vec::new();
-        let mut rest: Vec<&SessionLite> = Vec::new();
-        for s in &self.live {
-            if s.is_current {
-                current.push(s);
-            } else if self.presence_for(&s.name).map_or(0, |p| p.attention) > 0 {
-                attention.push(s);
+    /// The shared ordering: the current session first (at most one — `own`,
+    /// once known), then attention>0 peers by name, then the rest by name.
+    /// Both `badge()` and `cycle()` go through this so "what's shown" and
+    /// "what Alt+[/] steps through" can never disagree.
+    fn ordered(&self) -> Vec<OrderedEntry<'_>> {
+        let mut attention: Vec<OrderedEntry> = Vec::new();
+        let mut rest: Vec<OrderedEntry> = Vec::new();
+        for p in &self.peers {
+            let entry = OrderedEntry { presence: p, is_current: false };
+            if p.attention > 0 {
+                attention.push(entry);
             } else {
-                rest.push(s);
+                rest.push(entry);
             }
         }
-        attention.sort_by(|a, b| a.name.cmp(&b.name));
-        rest.sort_by(|a, b| a.name.cmp(&b.name));
+        attention.sort_by(|a, b| a.presence.session_name.cmp(&b.presence.session_name));
+        rest.sort_by(|a, b| a.presence.session_name.cmp(&b.presence.session_name));
+        let current = self.own.as_ref().map(|p| OrderedEntry { presence: p, is_current: true });
         current.into_iter().chain(attention).chain(rest).collect()
-    }
-
-    /// This session's own counts if `name` is the current session, else the
-    /// matching peer's presence, else `None` (no data reported yet).
-    fn presence_for(&self, name: &str) -> Option<&Presence> {
-        self.own
-            .as_ref()
-            .filter(|p| p.session_name == name)
-            .or_else(|| self.peers.iter().find(|p| p.session_name == name))
     }
 }
 
@@ -227,8 +218,9 @@ mod tests {
     use super::*;
     use crate::radar_state::Direction;
 
-    fn live(names: &[(&str, bool)]) -> Vec<SessionLite> {
-        names.iter().map(|(n, c)| SessionLite { name: n.to_string(), is_current: *c }).collect()
+    fn own(name: &str) -> Presence {
+        Presence { session_name: name.into(), running: 0, attention: 0,
+                  attention_tab_position: None, updated_epoch_s: 0 }
     }
     fn presence(name: &str, running: usize, attention: usize) -> String {
         format!(r#"{{"session_name":"{name}","running":{running},"attention":{attention}}}"#)
@@ -237,7 +229,6 @@ mod tests {
     #[test]
     fn badge_orders_current_then_attention_then_rest() {
         let mut s = Sessions::default();
-        s.update_live(live(&[("zeta", false), ("work", true), ("alpha", false)]));
         s.update_presences(vec![presence("zeta", 1, 2), presence("alpha", 1, 0)]);
         s.set_own(Presence { session_name: "work".into(), running: 3, attention: 0,
                              attention_tab_position: None, updated_epoch_s: 0 });
@@ -251,17 +242,24 @@ mod tests {
     }
 
     #[test]
-    fn presences_for_dead_sessions_are_dropped() {
+    fn corrupt_presence_lines_are_skipped_leniently() {
+        // Liveness is no longer cross-checked against a separate live list
+        // here — `session_files::read_peer_presences`'s mtime gate now owns
+        // "is this peer still alive?" (see its own tests). What's left for
+        // this module to guard is `Presence::parse`'s leniency actually
+        // getting exercised by its only caller: a malformed line among
+        // otherwise-valid ones must be dropped, not choke the whole batch.
         let mut s = Sessions::default();
-        s.update_live(live(&[("work", true)]));
-        s.update_presences(vec![presence("ghost", 5, 5)]);
-        assert!(s.badge().iter().all(|b| b.name != "ghost"));
+        s.update_presences(vec!["not json".to_string(), presence("alpha", 1, 0)]);
+        let badge = s.badge();
+        let names: Vec<&str> = badge.iter().map(|b| b.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha"]);
     }
 
     #[test]
     fn cycle_advances_and_wraps_and_tick_commits_after_idle() {
         let mut s = Sessions::default();
-        s.update_live(live(&[("work", true), ("beta", false), ("alpha", false)]));
+        s.set_own(own("work"));
         s.update_presences(vec![presence("alpha", 0, 1), presence("beta", 1, 0)]);
         // Order: work(current), alpha(attention), beta.
         s.cycle(Direction::Next, 10);                 // select alpha
@@ -275,7 +273,7 @@ mod tests {
     #[test]
     fn committing_on_current_session_is_a_noop_cancel() {
         let mut s = Sessions::default();
-        s.update_live(live(&[("work", true), ("alpha", false)]));
+        s.set_own(own("work"));
         s.update_presences(vec![presence("alpha", 0, 0)]);
         s.cycle(Direction::Next, 1);                  // alpha
         s.cycle(Direction::Next, 2);                  // wraps to work (current)
@@ -285,7 +283,7 @@ mod tests {
     #[test]
     fn commit_carries_attention_tab_position() {
         let mut s = Sessions::default();
-        s.update_live(live(&[("work", true), ("alpha", false)]));
+        s.set_own(own("work"));
         s.update_presences(vec![
             r#"{"session_name":"alpha","running":0,"attention":1,"attention_tab_position":2}"#.to_string(),
         ]);
@@ -301,7 +299,8 @@ mod tests {
     #[test]
     fn wants_fast_cadence_tracks_pending_selection_through_commit_and_cancel() {
         let mut s = Sessions::default();
-        s.update_live(live(&[("work", true), ("alpha", false), ("beta", false)]));
+        s.set_own(own("work"));
+        s.update_presences(vec![presence("alpha", 1, 0), presence("beta", 1, 0)]);
         assert!(!s.wants_fast_cadence(), "nothing selected initially");
 
         s.cycle(Direction::Next, 1); // selects alpha
@@ -327,16 +326,8 @@ mod tests {
     // noticing, since none of the tests above assert on the return value.
 
     #[test]
-    fn update_live_reports_change_only_on_actual_content_change() {
-        let mut s = Sessions::default();
-        assert!(s.update_live(live(&[("work", true)])), "first population changes the badge");
-        assert!(!s.update_live(live(&[("work", true)])), "identical live list is not a change");
-    }
-
-    #[test]
     fn update_presences_reports_change_only_on_actual_content_change() {
         let mut s = Sessions::default();
-        s.update_live(live(&[("work", true), ("alpha", false)]));
         assert!(s.update_presences(vec![presence("alpha", 1, 0)]), "first presence report changes the badge");
         assert!(!s.update_presences(vec![presence("alpha", 1, 0)]), "identical presence report is not a change");
     }
@@ -344,7 +335,6 @@ mod tests {
     #[test]
     fn set_own_reports_change_only_on_actual_content_change() {
         let mut s = Sessions::default();
-        s.update_live(live(&[("work", true)]));
         let p = Presence { session_name: "work".into(), running: 3, attention: 0,
                            attention_tab_position: None, updated_epoch_s: 0 };
         assert!(s.set_own(p.clone()), "first own-count report changes the badge");
@@ -358,7 +348,8 @@ mod tests {
     #[test]
     fn cycle_reports_change_when_the_highlight_moves() {
         let mut s = Sessions::default();
-        s.update_live(live(&[("work", true), ("alpha", false), ("beta", false)]));
+        s.set_own(own("work"));
+        s.update_presences(vec![presence("alpha", 1, 0), presence("beta", 1, 0)]);
         assert!(s.cycle(Direction::Next, 1), "starting a selection flips a `selected` flag in the badge");
         assert!(s.cycle(Direction::Next, 2), "advancing the selection moves the `selected` flag");
     }
@@ -371,15 +362,17 @@ mod tests {
     #[test]
     fn cycle_selection_survives_reordering_by_name_not_index() {
         let mut s = Sessions::default();
-        s.update_live(live(&[("work", true), ("alpha", false), ("beta", false)]));
+        s.set_own(own("work"));
         s.update_presences(vec![presence("alpha", 1, 0), presence("beta", 1, 0)]);
         // Order: work (current), alpha, beta — both zero-attention, by name.
         s.cycle(Direction::Next, 1); // selects alpha (first non-current)
 
         // "aardvark" joins and sorts ahead of "alpha" in the rest bucket. A
         // positional-index selection (old index 1) would now point at
-        // "aardvark" instead of "alpha".
-        s.update_live(live(&[("work", true), ("aardvark", false), ("alpha", false), ("beta", false)]));
+        // "aardvark" instead of "alpha". `update_presences` REPLACES the
+        // peer set wholesale (same as `update_live` used to for `live`), so
+        // this is the same "membership changed under the selection" shape.
+        s.update_presences(vec![presence("aardvark", 1, 0), presence("alpha", 1, 0), presence("beta", 1, 0)]);
 
         let t = s.tick(2).expect("idle tick commits");
         assert_eq!(t.name, "alpha", "selection must follow the named session, not the reordered index");
@@ -388,9 +381,10 @@ mod tests {
     #[test]
     fn selected_session_vanishing_before_tick_clears_selection_and_commits_nothing() {
         let mut s = Sessions::default();
-        s.update_live(live(&[("work", true), ("alpha", false)]));
+        s.set_own(own("work"));
+        s.update_presences(vec![presence("alpha", 0, 0)]);
         s.cycle(Direction::Next, 1); // selects alpha
-        s.update_live(live(&[("work", true)])); // alpha leaves before the idle tick
+        s.update_presences(vec![]); // alpha's presence vanished before the idle tick
 
         assert_eq!(s.tick(2), None, "a vanished selection must not commit");
         assert!(!s.wants_fast_cadence(), "the cleared selection must not keep fast cadence armed");
@@ -405,14 +399,15 @@ mod tests {
     #[test]
     fn cycle_restarts_fresh_after_selected_session_vanishes() {
         let mut s = Sessions::default();
-        s.update_live(live(&[("work", true), ("alpha", false), ("beta", false), ("gamma", false)]));
+        s.set_own(own("work"));
+        s.update_presences(vec![presence("alpha", 1, 0), presence("beta", 1, 0), presence("gamma", 1, 0)]);
         // No attention: order is work (current), then alpha, beta, gamma by name.
 
         s.cycle(Direction::Next, 1); // selects alpha (first non-current)
 
         // alpha vanishes, leaving a fresh order with *two* non-current entries
         // (beta, gamma) — order: work, beta, gamma.
-        s.update_live(live(&[("work", true), ("beta", false), ("gamma", false)]));
+        s.update_presences(vec![presence("beta", 1, 0), presence("gamma", 1, 0)]);
 
         // Cycling with Prev is what actually discriminates restart-fresh from
         // an index-0 fallback: restart-fresh ignores the stale direction and
@@ -439,7 +434,7 @@ mod tests {
     #[test]
     fn cycle_returns_false_on_noop_with_only_current_session() {
         let mut s = Sessions::default();
-        s.update_live(live(&[("work", true)]));
+        s.set_own(own("work"));
         // No presences, no peers — work is the only session.
 
         let changed = s.cycle(Direction::Next, 1);

--- a/crates/plugin/src/sessions.rs
+++ b/crates/plugin/src/sessions.rs
@@ -405,19 +405,33 @@ mod tests {
     #[test]
     fn cycle_restarts_fresh_after_selected_session_vanishes() {
         let mut s = Sessions::default();
-        s.update_live(live(&[("work", true), ("alpha", false), ("beta", false)]));
-        s.update_presences(vec![presence("alpha", 0, 1), presence("beta", 1, 0)]);
-        // Order: work (current), alpha (attention), beta.
+        s.update_live(live(&[("work", true), ("alpha", false), ("beta", false), ("gamma", false)]));
+        // No attention: order is work (current), then alpha, beta, gamma by name.
 
-        s.cycle(Direction::Next, 1); // selects alpha
+        s.cycle(Direction::Next, 1); // selects alpha (first non-current)
 
-        // alpha vanishes
-        s.update_live(live(&[("work", true), ("beta", false)]));
+        // alpha vanishes, leaving a fresh order with *two* non-current entries
+        // (beta, gamma) — order: work, beta, gamma.
+        s.update_live(live(&[("work", true), ("beta", false), ("gamma", false)]));
 
-        // Next cycle should restart and select beta (first non-current in fresh order).
-        // A regression that defaulted to index 0 (work/current) would fail via
-        // the cancel path returning None when tick() later lands on current.
-        s.cycle(Direction::Next, 2);
+        // Cycling with Prev is what actually discriminates restart-fresh from
+        // an index-0 fallback: restart-fresh ignores the stale direction and
+        // always selects the first non-current entry (beta). A regression
+        // that resolved the vanished name to index 0 ("as if `work`/current
+        // were selected") would instead advance *backward* from there and
+        // land on the last entry (gamma) — the same bug that, under
+        // Direction::Next, would coincidentally land on beta too and pass
+        // silently.
+        s.cycle(Direction::Prev, 2);
+        let badge = s.badge();
+        let selected: Vec<&str> = badge.iter().filter(|b| b.selected).map(|b| b.name.as_str()).collect();
+        assert_eq!(
+            selected,
+            vec!["beta"],
+            "restart-fresh must ignore the stale direction and pick the first \
+             non-current entry, not fall back to advancing from index 0"
+        );
+
         let t = s.tick(3).expect("idle tick commits");
         assert_eq!(t.name, "beta", "after vanished selection, cycle must restart and select the first non-current entry");
     }

--- a/crates/plugin/src/sessions.rs
+++ b/crates/plugin/src/sessions.rs
@@ -39,13 +39,18 @@ pub(crate) struct CommitTarget {
     pub attention_tab_position: Option<usize>,
 }
 
-/// A pending (not yet committed) cycle selection. `index` is into the same
-/// current/attention/rest ordering `badge()` derives; `last_tap_tick` is the
-/// tick of the most recent `cycle()` call, so `tick()` can tell a same-tick
-/// race (the tap and the idle timer landing in the same update) from genuine
-/// idle — only the latter may commit.
+/// A pending (not yet committed) cycle selection. `name` identifies the
+/// selected session directly rather than its position in the derived order —
+/// `update_live`/`update_presences` can reorder that list between the
+/// `cycle()` tap and the commit `tick()` (e.g. a new session sorting ahead of
+/// the selected one), and a positional index would then silently retarget
+/// whatever session ended up at the old index. Re-resolved by name against
+/// the fresh order on every `cycle()`/`tick()` call instead. `last_tap_tick`
+/// is the tick of the most recent `cycle()` call, so `tick()` can tell a
+/// same-tick race (the tap and the idle timer landing in the same update)
+/// from genuine idle — only the latter may commit.
 struct SelectionState {
-    index: usize,
+    name: String,
     last_tap_tick: u64,
 }
 
@@ -93,44 +98,57 @@ impl Sessions {
     /// Advance (or start) the cycle selection and stamp the tick it happened
     /// on. Re-derives the shared ordering fresh each call, so a selection
     /// started before a `update_live`/`update_presences` change always steps
-    /// relative to the current membership, never a stale snapshot.
+    /// relative to the current membership, never a stale snapshot. The
+    /// pending selection's *name* is re-resolved against that fresh order
+    /// (not trusted as a stale index) before advancing from it.
     pub(crate) fn cycle(&mut self, dir: Direction, now_tick: u64) -> bool {
         let before = self.badge();
         let order = self.ordered();
-        self.selection = match (&self.selection, order.len()) {
+        // A previously selected name that no longer appears in the fresh
+        // order (its session closed) is treated the same as "nothing
+        // selected" — restart below rather than advance from a position it
+        // no longer occupies.
+        let current_position =
+            self.selection.as_ref().and_then(|sel| order.iter().position(|s| s.name == sel.name));
+        self.selection = match (current_position, order.len()) {
             (_, 0) => None,
             (None, _) => {
-                // Nothing selected yet: start at the first non-current entry
-                // (index 0 is the current session, when live includes one).
+                // Nothing selected yet (or the selection vanished): start at
+                // the first non-current entry (index 0 is the current
+                // session, when live includes one).
                 order
                     .iter()
                     .position(|s| !s.is_current)
-                    .map(|index| SelectionState { index, last_tap_tick: now_tick })
+                    .map(|index| SelectionState { name: order[index].name.clone(), last_tap_tick: now_tick })
             }
-            (Some(sel), len) => {
-                let index = match dir {
-                    Direction::Next => (sel.index + 1) % len,
-                    Direction::Prev => (sel.index + len - 1) % len,
+            (Some(index), len) => {
+                let next = match dir {
+                    Direction::Next => (index + 1) % len,
+                    Direction::Prev => (index + len - 1) % len,
                 };
-                Some(SelectionState { index, last_tap_tick: now_tick })
+                Some(SelectionState { name: order[next].name.clone(), last_tap_tick: now_tick })
             }
         };
         self.badge() != before
     }
 
     /// Idle-commit: fires when a selection is pending and this tick is not
-    /// the same tick as the tap that created/advanced it. Landing on the
-    /// current session is the cancel gesture (`None`, no effect); either way
-    /// a commit clears the pending selection.
+    /// the same tick as the tap that created/advanced it. The selected
+    /// *name* is re-resolved against a freshly derived order rather than a
+    /// remembered index, so a reorder between the tap and this tick can
+    /// never retarget a different session; if the name is no longer live,
+    /// the selection is dropped and nothing commits. Landing on the current
+    /// session is the cancel gesture (`None`, no effect); either way a
+    /// commit clears the pending selection.
     pub(crate) fn tick(&mut self, now_tick: u64) -> Option<CommitTarget> {
         let sel = self.selection.as_ref()?;
         if now_tick <= sel.last_tap_tick {
             return None; // tap and timer racing in the same tick must not commit
         }
-        let index = sel.index;
-        self.selection = None; // committing (or cancelling) always clears
+        let name = sel.name.clone();
+        self.selection = None; // committing, cancelling, or dropping a vanished selection all clear
         let order = self.ordered();
-        let entry = order.get(index)?;
+        let entry = order.iter().find(|s| s.name == name)?; // vanished session: nothing to commit
         if entry.is_current {
             return None; // cancel gesture: landing back on the current session
         }
@@ -145,11 +163,10 @@ impl Sessions {
     /// every call — never cached — so it can never drift from its inputs.
     pub(crate) fn badge(&self) -> Vec<BadgeEntry> {
         let order = self.ordered();
-        let selected_index = self.selection.as_ref().map(|sel| sel.index);
+        let selected_name = self.selection.as_ref().map(|sel| sel.name.as_str());
         order
             .into_iter()
-            .enumerate()
-            .map(|(i, s)| {
+            .map(|s| {
                 let p = self.presence_for(&s.name);
                 BadgeEntry {
                     name: s.name.clone(),
@@ -157,7 +174,7 @@ impl Sessions {
                     attention: p.map_or(0, |p| p.attention),
                     attention_tab_position: p.and_then(|p| p.attention_tab_position),
                     is_current: s.is_current,
-                    selected: selected_index == Some(i),
+                    selected: selected_name == Some(s.name.as_str()),
                 }
             })
             .collect()
@@ -166,7 +183,8 @@ impl Sessions {
     /// Whether a cycle selection is pending — the runtime keeps the Fast
     /// timer cadence armed while true, so the idle-commit in `tick()` fires
     /// promptly rather than waiting for the next Slow tick. Only the wasm
-    /// runtime (Task 5) reads this; no host test exercises it yet.
+    /// runtime (Task 5) reads this in production; pinned by a host test
+    /// (`wants_fast_cadence_tracks_pending_selection_through_commit_and_cancel`).
     #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
     pub(crate) fn wants_fast_cadence(&self) -> bool {
         self.selection.is_some()
@@ -273,5 +291,108 @@ mod tests {
         ]);
         s.cycle(Direction::Next, 1);
         assert_eq!(s.tick(2).unwrap().attention_tab_position, Some(2));
+    }
+
+    // -- Pinning: wants_fast_cadence() --------------------------------------
+    // No wasm caller exercises this from a host test, so a refactor that
+    // breaks the "armed while a selection is pending" contract would
+    // otherwise go unnoticed until manual testing in Zellij.
+
+    #[test]
+    fn wants_fast_cadence_tracks_pending_selection_through_commit_and_cancel() {
+        let mut s = Sessions::default();
+        s.update_live(live(&[("work", true), ("alpha", false), ("beta", false)]));
+        assert!(!s.wants_fast_cadence(), "nothing selected initially");
+
+        s.cycle(Direction::Next, 1); // selects alpha
+        assert!(s.wants_fast_cadence(), "a cycle tap arms a pending selection");
+
+        s.tick(2); // idle commit to alpha
+        assert!(!s.wants_fast_cadence(), "a commit clears the pending selection");
+
+        s.cycle(Direction::Next, 3); // alpha
+        s.cycle(Direction::Next, 4); // beta
+        s.cycle(Direction::Next, 5); // wraps to work (current)
+        assert!(s.wants_fast_cadence(), "still pending until the idle tick fires");
+
+        s.tick(6); // cancel-commit (lands on current)
+        assert!(!s.wants_fast_cadence(), "a cancel-commit also clears the pending selection");
+    }
+
+    // -- Pinning: content-compare returns ------------------------------------
+    // Each mutator must report `true` only when the derived badge actually
+    // differs, not merely because it was called. A refactor that starts
+    // returning `true` unconditionally (or `false` unconditionally) would
+    // make the runtime over- or under-repaint without any other test
+    // noticing, since none of the tests above assert on the return value.
+
+    #[test]
+    fn update_live_reports_change_only_on_actual_content_change() {
+        let mut s = Sessions::default();
+        assert!(s.update_live(live(&[("work", true)])), "first population changes the badge");
+        assert!(!s.update_live(live(&[("work", true)])), "identical live list is not a change");
+    }
+
+    #[test]
+    fn update_presences_reports_change_only_on_actual_content_change() {
+        let mut s = Sessions::default();
+        s.update_live(live(&[("work", true), ("alpha", false)]));
+        assert!(s.update_presences(vec![presence("alpha", 1, 0)]), "first presence report changes the badge");
+        assert!(!s.update_presences(vec![presence("alpha", 1, 0)]), "identical presence report is not a change");
+    }
+
+    #[test]
+    fn set_own_reports_change_only_on_actual_content_change() {
+        let mut s = Sessions::default();
+        s.update_live(live(&[("work", true)]));
+        let p = Presence { session_name: "work".into(), running: 3, attention: 0,
+                           attention_tab_position: None, updated_epoch_s: 0 };
+        assert!(s.set_own(p.clone()), "first own-count report changes the badge");
+        // Same badge-relevant fields, different updated_epoch_s (not part of
+        // BadgeEntry) — must not register as a change.
+        let p2 = Presence { session_name: "work".into(), running: 3, attention: 0,
+                            attention_tab_position: None, updated_epoch_s: 99 };
+        assert!(!s.set_own(p2), "a report identical in badge-relevant fields is not a change");
+    }
+
+    #[test]
+    fn cycle_reports_change_when_the_highlight_moves() {
+        let mut s = Sessions::default();
+        s.update_live(live(&[("work", true), ("alpha", false), ("beta", false)]));
+        assert!(s.cycle(Direction::Next, 1), "starting a selection flips a `selected` flag in the badge");
+        assert!(s.cycle(Direction::Next, 2), "advancing the selection moves the `selected` flag");
+    }
+
+    // -- Selection identity (not positional index) ---------------------------
+    // `SelectionState` must track the selected session by name, not by its
+    // position in the derived order — a reorder between the cycle() tap and
+    // the commit tick() must never silently retarget a different session.
+
+    #[test]
+    fn cycle_selection_survives_reordering_by_name_not_index() {
+        let mut s = Sessions::default();
+        s.update_live(live(&[("work", true), ("alpha", false), ("beta", false)]));
+        s.update_presences(vec![presence("alpha", 1, 0), presence("beta", 1, 0)]);
+        // Order: work (current), alpha, beta — both zero-attention, by name.
+        s.cycle(Direction::Next, 1); // selects alpha (first non-current)
+
+        // "aardvark" joins and sorts ahead of "alpha" in the rest bucket. A
+        // positional-index selection (old index 1) would now point at
+        // "aardvark" instead of "alpha".
+        s.update_live(live(&[("work", true), ("aardvark", false), ("alpha", false), ("beta", false)]));
+
+        let t = s.tick(2).expect("idle tick commits");
+        assert_eq!(t.name, "alpha", "selection must follow the named session, not the reordered index");
+    }
+
+    #[test]
+    fn selected_session_vanishing_before_tick_clears_selection_and_commits_nothing() {
+        let mut s = Sessions::default();
+        s.update_live(live(&[("work", true), ("alpha", false)]));
+        s.cycle(Direction::Next, 1); // selects alpha
+        s.update_live(live(&[("work", true)])); // alpha leaves before the idle tick
+
+        assert_eq!(s.tick(2), None, "a vanished selection must not commit");
+        assert!(!s.wants_fast_cadence(), "the cleared selection must not keep fast cadence armed");
     }
 }

--- a/crates/plugin/src/sessions.rs
+++ b/crates/plugin/src/sessions.rs
@@ -1,36 +1,63 @@
 //! Cross-session peer state + the Alt+[/] cycle state machine — pure: no
 //! zellij-tile, no filesystem. The runtime feeds this module parsed facts
-//! (peer presence JSON, this session's own counts) and it derives the
-//! ordered badge on demand, mirroring the rows-derived-on-render doctrine
-//! (`CONTEXT.md`) rather than caching a badge that could drift from
-//! `peers`/`own`.
+//! (peer presence JSON + its file's mtime age, this session's own counts)
+//! and it derives the ordered badge on demand, mirroring the
+//! rows-derived-on-render doctrine (`CONTEXT.md`) rather than caching a
+//! badge that could drift from `peers`/`own`.
 //!
-//! Liveness is implicit, not a separately-tracked list (task-8b-brief.md):
-//! there is no `SessionUpdate` peer roster to cross-check against anymore.
-//! Whatever `update_presences` was just handed IS the live peer set — a
-//! stale peer has already been filtered out one layer down, by
-//! `session_files::read_peer_presences`'s mtime gate, before it ever reaches
-//! this module. This module's own leniency is limited to "don't choke on a
-//! malformed line" (`Presence::parse`), not "cross-check membership".
+//! task-14 (user decision): a remembered session must NEVER silently vanish
+//! from the badge. `session_files::read_peer_presences` no longer filters
+//! anything by mtime — every peer file it finds comes back, forever (until
+//! the 6h open-time sweep, the only true forgetting). Liveness is instead a
+//! per-entry *staleness* state this module derives from the mtime age it's
+//! handed: `fresh` while recently heartbeated, `stale` past
+//! [`STALE_AFTER_SECS`] — dimmed on the badge and unreachable via `cycle()`,
+//! but never dropped. This module's other leniency is limited to "don't
+//! choke on a malformed line" (`Presence::parse`), not "cross-check
+//! membership".
 //!
 //! Ordering is a single source of truth shared by `badge()` (what's shown)
 //! and `cycle()` (what Alt+[/] steps through): current session first, then
-//! `attention > 0` sessions by name, then the rest by name.
+//! fresh `attention > 0` sessions by name, then the rest of the fresh
+//! sessions by name, then every stale session by name — stale entries never
+//! jump the queue on attention, since a likely-dead session's last-known
+//! attention count isn't actionable.
 
 use std::collections::HashMap;
 
 use crate::presence::Presence;
 use crate::radar_state::Direction;
 
+/// How long a peer's presence file may sit unrefreshed before its badge row
+/// dims to stale. `runtime.rs`'s timer heartbeats an idle-but-alive
+/// session's own file at least once per Slow (60s) tick, so 90s gives 50%
+/// margin against a single missed beat before flagging it — generous
+/// enough that ordinary scheduler jitter never flickers an entry, but a
+/// session that's genuinely gone quiet reads as such promptly. A missed
+/// beat marks stale, never vanishes (see the module doc).
+pub(crate) const STALE_AFTER_SECS: u64 = 90;
+
+/// A peer's [`Presence`] plus the staleness derived from its presence
+/// file's mtime age at the last read (see the module doc). `stale` is a
+/// snapshot from that read, not re-evaluated against a live clock — like
+/// every other peer fact here, it's only ever as fresh as the last
+/// `update_presences` call.
+struct Peer {
+    presence: Presence,
+    stale: bool,
+}
+
 /// A row in the shared ordering: a [`Presence`] (own or peer) plus whether
-/// it's the current session. `own` contributes at most one of these (via
-/// `set_own`); every peer in `peers` contributes one. Combines what used to
-/// be a separate `SessionLite` (identity) + a `presence_for` lookup (counts)
-/// into a single reference, now that a `Presence` IS the identity (its
-/// `session_name`) as well as the counts.
+/// it's the current session and whether it's stale. `own` contributes at
+/// most one of these (via `set_own`, always fresh — this session knows its
+/// own liveness directly); every peer in `peers` contributes one. Combines
+/// what used to be a separate `SessionLite` (identity) + a `presence_for`
+/// lookup (counts) into a single reference, now that a `Presence` IS the
+/// identity (its `session_name`) as well as the counts.
 struct OrderedEntry<'a> {
     presence: &'a Presence,
     is_current: bool,
+    stale: bool,
 }
 
 /// One row of the cross-session badge, in display order.
@@ -42,6 +69,7 @@ pub(crate) struct BadgeEntry {
     pub attention_tab_position: Option<usize>,
     pub is_current: bool,
     pub selected: bool,
+    pub stale: bool,
 }
 
 /// Where a committed cycle gesture lands — enough for the runtime to switch
@@ -77,38 +105,44 @@ struct SelectionState {
 
 #[derive(Default)]
 pub(crate) struct Sessions {
-    peers: Vec<Presence>,
+    peers: Vec<Peer>,
     own: Option<Presence>,
     selection: Option<SelectionState>,
 }
 
 impl Sessions {
     /// Replace the peer set with a fresh read of every OTHER session's
-    /// presence file — these entries ARE the live peers now (see the module
-    /// doc): `session_files::read_peer_presences` has already dropped
-    /// anything stale before this is called, so the only filtering left
-    /// here is `Presence::parse`'s leniency (skip a malformed line, don't
-    /// crash on it). Returns whether the derived badge actually changed, so
-    /// the runtime only repaints on real content change.
-    pub(crate) fn update_presences(&mut self, raw: Vec<String>) -> bool {
+    /// presence file, each paired with its file's mtime age in seconds
+    /// (`session_files::read_peer_presences`'s `age_secs` — no longer
+    /// filtered by liveness there; see the module doc). The only filtering
+    /// left here is `Presence::parse`'s leniency (skip a malformed line,
+    /// don't crash on it). Returns whether the derived badge actually
+    /// changed, so the runtime only repaints on real content change.
+    pub(crate) fn update_presences(&mut self, raw: Vec<(String, u64)>) -> bool {
         let before = self.badge();
         // WHY: presence files are keyed by server pid on disk, not by
         // session name. A session killed and recreated under the same name
         // gets a fresh presence file at a new pid path, but the old one (a
         // "corpse") isn't unlinked — it just sits there parsing as a second
-        // live peer under the same name until PRESENCE_LIVE_TTL reaps it
-        // (up to 3 minutes). Left undeduped, `badge()` would render that
-        // name twice. Collapse by `session_name` here, keeping the presence
-        // with the greatest `updated_epoch_s` — that's the newest write, i.e.
-        // the live session; the corpse is whatever was on disk before the
-        // kill. On a tie, `>` (not `>=`) below makes the later entry in
-        // `raw` win deterministically, without needing separate tie-break
-        // code.
-        let mut by_name: HashMap<String, Presence> = HashMap::new();
-        for p in raw.iter().filter_map(|s| Presence::parse(s)) {
+        // peer under the same name until the (now much longer) open-time
+        // sweep reaps it. Left undeduped, `badge()` would render that name
+        // twice. Collapse by `session_name` here, keeping the presence with
+        // the greatest `updated_epoch_s` — that's the newest write, i.e. the
+        // live session; the corpse is whatever was on disk before the kill.
+        // On a tie, `>` (not `>=`) below makes the later entry in `raw` win
+        // deterministically, without needing separate tie-break code. The
+        // `stale` flag carried alongside is whichever entry's own mtime age
+        // won this dedup — a corpse losing to a fresh recreation of the same
+        // name also loses its (typically old) staleness along with it.
+        let mut by_name: HashMap<String, Peer> = HashMap::new();
+        for (json, age_secs) in raw {
+            let Some(p) = Presence::parse(&json) else { continue };
             match by_name.get(&p.session_name) {
-                Some(existing) if existing.updated_epoch_s > p.updated_epoch_s => {} // existing is strictly fresher: keep it
-                _ => { by_name.insert(p.session_name.clone(), p); }
+                Some(existing) if existing.presence.updated_epoch_s > p.updated_epoch_s => {} // existing is strictly fresher: keep it
+                _ => {
+                    let stale = age_secs > STALE_AFTER_SECS;
+                    by_name.insert(p.session_name.clone(), Peer { presence: p, stale });
+                }
             }
         }
         self.peers = by_name.into_values().collect();
@@ -133,25 +167,32 @@ impl Sessions {
     /// current membership, never a stale snapshot. The pending selection's
     /// *name* is re-resolved against that fresh order (not trusted as a
     /// stale index) before advancing from it.
+    ///
+    /// Stale entries are excluded from the cycle target set entirely — every
+    /// index/position below is computed against `selectable` (fresh entries
+    /// only), never the full `order`. Alt+[/] must never land on a
+    /// likely-dead session: `switch_session`ing onto one that's actually
+    /// gone would have Zellij resurrect it as an empty zombie (task-14).
     pub(crate) fn cycle(&mut self, dir: Direction) -> bool {
         let before = self.badge();
         let order = self.ordered();
-        // A previously selected name that no longer appears in the fresh
-        // order (its session closed) is treated the same as "nothing
-        // selected" — restart below rather than advance from a position it
-        // no longer occupies.
+        let selectable: Vec<&OrderedEntry> = order.iter().filter(|s| !s.stale).collect();
+        // A previously selected name that no longer appears among the fresh
+        // entries (its session closed, or went stale itself) is treated the
+        // same as "nothing selected" — restart below rather than advance
+        // from a position it no longer occupies.
         let current_position = self
             .selection
             .as_ref()
-            .and_then(|sel| order.iter().position(|s| s.presence.session_name == sel.name));
-        self.selection = match (current_position, order.len()) {
+            .and_then(|sel| selectable.iter().position(|s| s.presence.session_name == sel.name));
+        self.selection = match (current_position, selectable.len()) {
             (_, 0) => None,
             (None, _) => {
                 // Nothing selected yet (or the selection vanished): start at
                 // the first non-current entry (index 0 is the current
                 // session, when own is known).
-                order.iter().position(|s| !s.is_current).map(|index| SelectionState {
-                    name: order[index].presence.session_name.clone(),
+                selectable.iter().position(|s| !s.is_current).map(|index| SelectionState {
+                    name: selectable[index].presence.session_name.clone(),
                     taps_since_last_fire: true,
                 })
             }
@@ -160,7 +201,7 @@ impl Sessions {
                     Direction::Next => (index + 1) % len,
                     Direction::Prev => (index + len - 1) % len,
                 };
-                Some(SelectionState { name: order[next].presence.session_name.clone(), taps_since_last_fire: true })
+                Some(SelectionState { name: selectable[next].presence.session_name.clone(), taps_since_last_fire: true })
             }
         };
         self.badge() != before
@@ -175,8 +216,12 @@ impl Sessions {
     /// between the tap and this tick can never retarget a different
     /// session; if the name is no longer live, the selection is dropped and
     /// nothing commits. Landing on the current session is the cancel
-    /// gesture (`None`, no effect); either way a commit clears the pending
-    /// selection.
+    /// gesture (`None`, no effect); a selection that went stale while
+    /// pending (its heartbeat lapsed between the tap and this fire) is
+    /// dropped the same way — `cycle()` never selects a stale entry, so one
+    /// showing up stale here can only mean it lapsed mid-flight, exactly the
+    /// likely-dead session a commit must not switch onto. Either way a
+    /// commit (or drop) clears the pending selection.
     pub(crate) fn tick(&mut self) -> Option<CommitTarget> {
         let sel = self.selection.as_mut()?;
         if sel.taps_since_last_fire {
@@ -184,11 +229,11 @@ impl Sessions {
             return None;
         }
         let name = sel.name.clone();
-        self.selection = None; // committing, cancelling, or dropping a vanished selection all clear
+        self.selection = None; // committing, cancelling, or dropping a vanished/staled selection all clear
         let order = self.ordered();
         let entry = order.iter().find(|s| s.presence.session_name == name)?; // vanished session: nothing to commit
-        if entry.is_current {
-            return None; // cancel gesture: landing back on the current session
+        if entry.is_current || entry.stale {
+            return None; // cancel gesture, or the selection lapsed into staleness before commit
         }
         Some(CommitTarget {
             name: entry.presence.session_name.clone(),
@@ -196,8 +241,9 @@ impl Sessions {
         })
     }
 
-    /// The ordered badge: current session first, then attention>0 sessions by
-    /// name, then the rest by name. Derived fresh from `peers`/`own` every
+    /// The ordered badge: current session first, then fresh attention>0
+    /// sessions by name, then the rest of the fresh sessions by name, then
+    /// every stale session by name. Derived fresh from `peers`/`own` every
     /// call — never cached — so it can never drift from its inputs.
     pub(crate) fn badge(&self) -> Vec<BadgeEntry> {
         let order = self.ordered();
@@ -211,6 +257,7 @@ impl Sessions {
                 attention_tab_position: s.presence.attention_tab_position,
                 is_current: s.is_current,
                 selected: selected_name == Some(s.presence.session_name.as_str()),
+                stale: s.stale,
             })
             .collect()
     }
@@ -226,14 +273,18 @@ impl Sessions {
     }
 
     /// The shared ordering: the current session first (at most one — `own`,
-    /// once known), then attention>0 peers by name, then the rest by name.
-    /// Both `badge()` and `cycle()` go through this so "what's shown" and
-    /// "what Alt+[/] steps through" can never disagree.
+    /// once known), then fresh attention>0 peers by name, then the rest of
+    /// the fresh peers by name, then every stale peer by name — a stale
+    /// peer's attention count is never actionable (it can't be cycled to),
+    /// so staleness outranks attention for ordering purposes. Both
+    /// `badge()` and `cycle()` go through this so "what's shown" and "what
+    /// Alt+[/] steps through" can never disagree.
     fn ordered(&self) -> Vec<OrderedEntry<'_>> {
         let mut attention: Vec<OrderedEntry> = Vec::new();
         let mut rest: Vec<OrderedEntry> = Vec::new();
+        let mut stale: Vec<OrderedEntry> = Vec::new();
         let own_name = self.own.as_ref().map(|p| p.session_name.as_str());
-        for p in &self.peers {
+        for peer in &self.peers {
             // WHY: a peer presence sharing our own session's name is
             // necessarily either a stale corpse of this very session (pid-
             // keyed presence files: a restarted session under the same name
@@ -243,11 +294,13 @@ impl Sessions {
             // (see its doc comment) — it must always win a name collision,
             // so the colliding peer is dropped outright rather than shown
             // as a second line for the same name.
-            if own_name == Some(p.session_name.as_str()) {
+            if own_name == Some(peer.presence.session_name.as_str()) {
                 continue;
             }
-            let entry = OrderedEntry { presence: p, is_current: false };
-            if p.attention > 0 {
+            let entry = OrderedEntry { presence: &peer.presence, is_current: false, stale: peer.stale };
+            if peer.stale {
+                stale.push(entry);
+            } else if peer.presence.attention > 0 {
                 attention.push(entry);
             } else {
                 rest.push(entry);
@@ -255,8 +308,9 @@ impl Sessions {
         }
         attention.sort_by(|a, b| a.presence.session_name.cmp(&b.presence.session_name));
         rest.sort_by(|a, b| a.presence.session_name.cmp(&b.presence.session_name));
-        let current = self.own.as_ref().map(|p| OrderedEntry { presence: p, is_current: true });
-        current.into_iter().chain(attention).chain(rest).collect()
+        stale.sort_by(|a, b| a.presence.session_name.cmp(&b.presence.session_name));
+        let current = self.own.as_ref().map(|p| OrderedEntry { presence: p, is_current: true, stale: false });
+        current.into_iter().chain(attention).chain(rest).chain(stale).collect()
     }
 }
 
@@ -269,8 +323,14 @@ mod tests {
         Presence { session_name: name.into(), running: 0, attention: 0,
                   attention_tab_position: None, updated_epoch_s: 0 }
     }
-    fn presence(name: &str, running: usize, attention: usize) -> String {
-        format!(r#"{{"session_name":"{name}","running":{running},"attention":{attention}}}"#)
+    /// Fresh (age 0) peer presence, the shape most tests want.
+    fn presence(name: &str, running: usize, attention: usize) -> (String, u64) {
+        presence_aged(name, running, attention, 0)
+    }
+    /// A peer presence paired with an explicit mtime age, for exercising
+    /// the fresh/stale boundary (`STALE_AFTER_SECS`).
+    fn presence_aged(name: &str, running: usize, attention: usize, age_secs: u64) -> (String, u64) {
+        (format!(r#"{{"session_name":"{name}","running":{running},"attention":{attention}}}"#), age_secs)
     }
 
     #[test]
@@ -297,7 +357,7 @@ mod tests {
         // getting exercised by its only caller: a malformed line among
         // otherwise-valid ones must be dropped, not choke the whole batch.
         let mut s = Sessions::default();
-        s.update_presences(vec!["not json".to_string(), presence("alpha", 1, 0)]);
+        s.update_presences(vec![("not json".to_string(), 0), presence("alpha", 1, 0)]);
         let badge = s.badge();
         let names: Vec<&str> = badge.iter().map(|b| b.name.as_str()).collect();
         assert_eq!(names, vec!["alpha"]);
@@ -334,7 +394,7 @@ mod tests {
         let mut s = Sessions::default();
         s.set_own(own("work"));
         s.update_presences(vec![
-            r#"{"session_name":"alpha","running":0,"attention":1,"attention_tab_position":2}"#.to_string(),
+            (r#"{"session_name":"alpha","running":0,"attention":1,"attention_tab_position":2}"#.to_string(), 0),
         ]);
         s.cycle(Direction::Next);
         s.tick(); // the fire covering the tap: skip, clears the flag
@@ -534,16 +594,17 @@ mod tests {
     // -- Pinning: duplicate-name dedup (killed-then-recreated session) ------
     // Presence files are pid-keyed on disk, not name-keyed: a session killed
     // and recreated under the same name leaves its old presence file (a
-    // "corpse") coexisting with the fresh one until PRESENCE_LIVE_TTL reaps
-    // it. Without a dedup, `badge()` would render the same name twice for up
-    // to 3 minutes — exactly the bug the user observed.
+    // "corpse") coexisting with the fresh one until the open-time sweep
+    // reaps it, up to `PRESENCE_MAX_AGE` (6h) later. Without a dedup,
+    // `badge()` would render the same name twice for that whole window —
+    // exactly the bug the user observed.
 
     #[test]
     fn update_presences_dedupes_by_name_keeping_freshest() {
         let mut s = Sessions::default();
-        let stale = r#"{"session_name":"alpha","running":1,"attention":0,"updated_epoch_s":10}"#;
-        let fresh = r#"{"session_name":"alpha","running":5,"attention":2,"updated_epoch_s":20}"#;
-        s.update_presences(vec![stale.to_string(), fresh.to_string()]);
+        let corpse = r#"{"session_name":"alpha","running":1,"attention":0,"updated_epoch_s":10}"#;
+        let live = r#"{"session_name":"alpha","running":5,"attention":2,"updated_epoch_s":20}"#;
+        s.update_presences(vec![(corpse.to_string(), 0), (live.to_string(), 0)]);
         let badge = s.badge();
         let alphas: Vec<&BadgeEntry> = badge.iter().filter(|b| b.name == "alpha").collect();
         assert_eq!(alphas.len(), 1, "two presences for the same name must collapse to one badge entry");
@@ -563,7 +624,7 @@ mod tests {
         s.set_own(Presence { session_name: "work".into(), running: 3, attention: 0,
                              attention_tab_position: None, updated_epoch_s: 50 });
         s.update_presences(vec![
-            r#"{"session_name":"work","running":9,"attention":9,"updated_epoch_s":999}"#.to_string(),
+            (r#"{"session_name":"work","running":9,"attention":9,"updated_epoch_s":999}"#.to_string(), 0),
         ]);
         let badge = s.badge();
         let work_entries: Vec<&BadgeEntry> = badge.iter().filter(|b| b.name == "work").collect();
@@ -571,6 +632,83 @@ mod tests {
         assert!(work_entries[0].is_current, "the surviving line must be the own entry");
         assert_eq!(work_entries[0].running, 3, "own's own-known counts must win over a peer claiming the same name");
         assert_eq!(work_entries[0].attention, 0, "own's own-known counts must win over a peer claiming the same name");
+    }
+
+    // -- Pinning: persistent roster (task-14) --------------------------------
+    // A remembered session must never silently vanish from the badge. Peers
+    // past `STALE_AFTER_SECS` mark stale (dimmed by the renderer, unreachable
+    // via `cycle()`) instead of disappearing; only the open-time
+    // `PRESENCE_MAX_AGE` sweep (6h) actually forgets one.
+
+    #[test]
+    fn stale_peer_is_flagged_and_skipped_by_cycle() {
+        let mut s = Sessions::default();
+        s.set_own(own("work"));
+        s.update_presences(vec![presence_aged("alpha", 1, 0, 400)]); // well past STALE_AFTER_SECS
+        let badge = s.badge();
+        let alpha = badge.iter().find(|b| b.name == "alpha").expect("stale peer still on the badge");
+        assert!(alpha.stale, "a peer whose mtime age exceeds STALE_AFTER_SECS must flag stale");
+
+        // The ONLY peer is stale — cycle() must find nothing selectable and
+        // stay a no-op, never landing on the likely-dead session.
+        let changed = s.cycle(Direction::Next);
+        assert!(!changed, "cycle must not select a stale-only peer set");
+        assert!(!s.wants_fast_cadence(), "no selection is armed when nothing selectable exists");
+    }
+
+    #[test]
+    fn cycle_skips_a_stale_peer_and_lands_on_a_fresh_one_instead() {
+        let mut s = Sessions::default();
+        s.set_own(own("work"));
+        s.update_presences(vec![presence_aged("alpha", 1, 0, 400), presence("beta", 1, 0)]);
+        // Order: work (current), beta (fresh, before the stale bucket), alpha (stale, last).
+        s.cycle(Direction::Next);
+        let badge = s.badge();
+        let selected: Vec<&str> = badge.iter().filter(|b| b.selected).map(|b| b.name.as_str()).collect();
+        assert_eq!(selected, vec!["beta"], "cycle must skip the stale peer entirely and select the fresh one");
+    }
+
+    #[test]
+    fn fresh_to_stale_transition_flips_on_age() {
+        let mut s = Sessions::default();
+        s.set_own(own("work"));
+        s.update_presences(vec![presence_aged("alpha", 1, 0, 10)]); // fresh
+        assert!(!s.badge()[1].stale, "a recently-heartbeated peer must not start stale");
+
+        // The next read finds the same peer with an older mtime age (no
+        // further heartbeat landed) — its badge row must flip to stale.
+        s.update_presences(vec![presence_aged("alpha", 1, 0, 200)]);
+        assert!(s.badge()[1].stale, "a peer whose age crossed STALE_AFTER_SECS must flip to stale");
+    }
+
+    #[test]
+    fn stale_entry_superseded_by_a_fresh_same_name_presence_undims() {
+        // The recreation case: a session dies (its old file ages past
+        // STALE_AFTER_SECS) and gets recreated under the same name — a
+        // fresh presence file, young mtime, higher `updated_epoch_s`. The
+        // corpse and the recreation can even coexist in the SAME read
+        // (different pids, same name); dedup must pick the fresh one AND
+        // its (fresh) staleness, not the corpse's.
+        let mut s = Sessions::default();
+        s.set_own(own("work"));
+        let corpse = r#"{"session_name":"alpha","running":1,"attention":0,"updated_epoch_s":10}"#;
+        let recreated = r#"{"session_name":"alpha","running":0,"attention":0,"updated_epoch_s":20}"#;
+        s.update_presences(vec![(corpse.to_string(), 400), (recreated.to_string(), 0)]);
+        let alpha = s.badge().into_iter().find(|b| b.name == "alpha").expect("alpha present");
+        assert!(!alpha.stale, "the fresher recreation must win the dedup, undimming the entry");
+    }
+
+    #[test]
+    fn roster_survives_beyond_the_old_liveness_ttl() {
+        // The old design would have had `session_files::read_peer_presences`
+        // itself drop a peer at 180s. Task-14: it now returns unconditionally,
+        // and this module marks stale rather than dropping — an entry with
+        // age 400s (well past the old TTL) must still be on the badge.
+        let mut s = Sessions::default();
+        s.set_own(own("work"));
+        s.update_presences(vec![presence_aged("alpha", 1, 0, 400)]);
+        let badge = s.badge();
+        assert!(badge.iter().any(|b| b.name == "alpha"), "a peer must never be dropped for being old — only marked stale");
     }
 
     #[test]

--- a/crates/plugin/src/sessions.rs
+++ b/crates/plugin/src/sessions.rs
@@ -395,4 +395,41 @@ mod tests {
         assert_eq!(s.tick(2), None, "a vanished selection must not commit");
         assert!(!s.wants_fast_cadence(), "the cleared selection must not keep fast cadence armed");
     }
+
+    // -- Pinning: cycle restart after vanish and no-op change report -----------
+    // Cycle selection must restart fresh when the previously-selected session
+    // disappears and a new cycle() call advances the selection. A no-op cycle
+    // (nothing to select) must not set up a pending selection or report a
+    // badge change.
+
+    #[test]
+    fn cycle_restarts_fresh_after_selected_session_vanishes() {
+        let mut s = Sessions::default();
+        s.update_live(live(&[("work", true), ("alpha", false), ("beta", false)]));
+        s.update_presences(vec![presence("alpha", 0, 1), presence("beta", 1, 0)]);
+        // Order: work (current), alpha (attention), beta.
+
+        s.cycle(Direction::Next, 1); // selects alpha
+
+        // alpha vanishes
+        s.update_live(live(&[("work", true), ("beta", false)]));
+
+        // Next cycle should restart and select beta (first non-current in fresh order).
+        // A regression that defaulted to index 0 (work/current) would fail via
+        // the cancel path returning None when tick() later lands on current.
+        s.cycle(Direction::Next, 2);
+        let t = s.tick(3).expect("idle tick commits");
+        assert_eq!(t.name, "beta", "after vanished selection, cycle must restart and select the first non-current entry");
+    }
+
+    #[test]
+    fn cycle_returns_false_on_noop_with_only_current_session() {
+        let mut s = Sessions::default();
+        s.update_live(live(&[("work", true)]));
+        // No presences, no peers — work is the only session.
+
+        let changed = s.cycle(Direction::Next, 1);
+        assert!(!changed, "cycle with nothing to select must return false (no badge change)");
+        assert!(!s.wants_fast_cadence(), "cycle with nothing to select must not set up a pending selection");
+    }
 }

--- a/crates/plugin/src/sessions.rs
+++ b/crates/plugin/src/sessions.rs
@@ -160,6 +160,28 @@ impl Sessions {
         self.badge() != before
     }
 
+    /// Manually forget a peer by name — the in-memory half of the right-click
+    /// dismiss gesture (`PluginRuntime::mouse_right_click`), the user-driven
+    /// complement to the 6h open-time sweep for a session the user already
+    /// knows is dead. Removing the entry here gives instant visual feedback
+    /// (the badge row vanishes on this instance without waiting for the next
+    /// file read); the on-disk half is `Effect::DismissPresence`. Only
+    /// shrinks `peers` — ordering, dedup, and cycle semantics of the
+    /// survivors are untouched, and `own` is never touched (the caller gates
+    /// on staleness, and the own entry is never stale). Safe against a
+    /// misjudged dismiss by construction: if the session is secretly still
+    /// alive, its next heartbeat/edge re-publishes a presence file and the
+    /// next `update_presences` simply brings it back, fresh — dismiss is
+    /// never destructive to a live session
+    /// (`dismissed_but_alive_session_reappears_fresh_on_next_presence_write`).
+    /// Returns whether the derived badge actually changed, same contract as
+    /// the other mutators here.
+    pub(crate) fn dismiss(&mut self, name: &str) -> bool {
+        let before = self.badge();
+        self.peers.retain(|p| p.presence.session_name != name);
+        self.badge() != before
+    }
+
     /// Advance (or start) the cycle selection and arm its tap-since-fire
     /// flag (see `SelectionState`'s doc). Re-derives the shared ordering
     /// fresh each call, so a selection started before a
@@ -509,6 +531,44 @@ mod tests {
         s.update_presences(vec![presence("alpha", 1, 0), presence("beta", 1, 0)]);
         assert!(s.cycle(Direction::Next), "starting a selection flips a `selected` flag in the badge");
         assert!(s.cycle(Direction::Next), "advancing the selection moves the `selected` flag");
+    }
+
+    #[test]
+    fn dismiss_removes_peer_entry() {
+        let mut s = Sessions::default();
+        s.set_own(own("work"));
+        s.update_presences(vec![presence("alpha", 2, 1)]);
+
+        assert!(s.dismiss("alpha"), "dismissing an existing peer changes the badge");
+        assert!(
+            !s.badge().iter().any(|b| b.name == "alpha"),
+            "dismissed peer must no longer appear on the badge"
+        );
+    }
+
+    #[test]
+    fn dismiss_absent_name_is_noop() {
+        let mut s = Sessions::default();
+        s.set_own(own("work"));
+        s.update_presences(vec![presence("alpha", 2, 1)]);
+        let before = s.badge();
+
+        assert!(!s.dismiss("beta"), "dismissing a missing peer must report no badge change");
+        assert_eq!(s.badge(), before, "missing-name dismiss must not disturb the badge");
+    }
+
+    #[test]
+    fn dismissed_but_alive_session_reappears_fresh_on_next_presence_write() {
+        let mut s = Sessions::default();
+        s.set_own(own("work"));
+        s.update_presences(vec![presence_aged("alpha", 2, 1, STALE_AFTER_SECS + 1)]);
+        assert!(s.dismiss("alpha"), "setup: stale peer is dismissed locally");
+        assert!(!s.badge().iter().any(|b| b.name == "alpha"));
+
+        s.update_presences(vec![presence_aged("alpha", 2, 1, 0)]);
+
+        let alpha = s.badge().into_iter().find(|b| b.name == "alpha").expect("fresh write makes alpha reappear");
+        assert!(!alpha.stale, "a live session's fresh write must reappear as fresh, not stale");
     }
 
     // -- Selection identity (not positional index) ---------------------------

--- a/crates/plugin/src/sessions.rs
+++ b/crates/plugin/src/sessions.rs
@@ -1,0 +1,277 @@
+//! Cross-session peer state + the Alt+[/] cycle state machine — pure: no
+//! zellij-tile, no filesystem. The runtime (Task 5) feeds this module parsed
+//! facts (the live session list, peer presence JSON, this session's own
+//! counts) and it derives the ordered badge on demand, mirroring the
+//! rows-derived-on-render doctrine (`CONTEXT.md`) rather than caching a
+//! badge that could drift from `live`/`peers`/`own`.
+//!
+//! Ordering is a single source of truth shared by `badge()` (what's shown)
+//! and `cycle()` (what Alt+[/] steps through): current session first, then
+//! `attention > 0` sessions by name, then the rest by name.
+
+use crate::presence::Presence;
+use crate::radar_state::Direction;
+use std::collections::HashSet;
+
+/// A live session as reported by Zellij's session list, reduced to what this
+/// module needs. `lib.rs` maps the host's `SessionInfo` into this.
+pub(crate) struct SessionLite {
+    pub name: String,
+    pub is_current: bool,
+}
+
+/// One row of the cross-session badge, in display order.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct BadgeEntry {
+    pub name: String,
+    pub running: usize,
+    pub attention: usize,
+    pub attention_tab_position: Option<usize>,
+    pub is_current: bool,
+    pub selected: bool,
+}
+
+/// Where a committed cycle gesture lands — enough for the runtime to switch
+/// sessions and then jump straight to the tab that needs attention there.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct CommitTarget {
+    pub name: String,
+    pub attention_tab_position: Option<usize>,
+}
+
+/// A pending (not yet committed) cycle selection. `index` is into the same
+/// current/attention/rest ordering `badge()` derives; `last_tap_tick` is the
+/// tick of the most recent `cycle()` call, so `tick()` can tell a same-tick
+/// race (the tap and the idle timer landing in the same update) from genuine
+/// idle — only the latter may commit.
+struct SelectionState {
+    index: usize,
+    last_tap_tick: u64,
+}
+
+#[derive(Default)]
+pub(crate) struct Sessions {
+    live: Vec<SessionLite>,
+    peers: Vec<Presence>,
+    own: Option<Presence>,
+    selection: Option<SelectionState>,
+}
+
+impl Sessions {
+    /// Replace the live session list (from Zellij's session list). Returns
+    /// whether the derived badge actually changed, so the runtime only
+    /// repaints on real content change.
+    pub(crate) fn update_live(&mut self, live: Vec<SessionLite>) -> bool {
+        let before = self.badge();
+        self.live = live;
+        self.badge() != before
+    }
+
+    /// Parse peer presence JSON (one string per peer session) and keep only
+    /// the ones naming a currently-live session — a corrupt file (handled by
+    /// `Presence::parse`'s leniency) or a session that has since closed must
+    /// never leave a stale/bogus badge entry lying around.
+    pub(crate) fn update_presences(&mut self, raw: Vec<String>) -> bool {
+        let before = self.badge();
+        let live_names: HashSet<&str> = self.live.iter().map(|s| s.name.as_str()).collect();
+        self.peers = raw
+            .iter()
+            .filter_map(|s| Presence::parse(s))
+            .filter(|p| live_names.contains(p.session_name.as_str()))
+            .collect();
+        self.badge() != before
+    }
+
+    /// Record this session's own counts (never read from a peer file — the
+    /// current session knows its own state directly).
+    pub(crate) fn set_own(&mut self, p: Presence) -> bool {
+        let before = self.badge();
+        self.own = Some(p);
+        self.badge() != before
+    }
+
+    /// Advance (or start) the cycle selection and stamp the tick it happened
+    /// on. Re-derives the shared ordering fresh each call, so a selection
+    /// started before a `update_live`/`update_presences` change always steps
+    /// relative to the current membership, never a stale snapshot.
+    pub(crate) fn cycle(&mut self, dir: Direction, now_tick: u64) -> bool {
+        let before = self.badge();
+        let order = self.ordered();
+        self.selection = match (&self.selection, order.len()) {
+            (_, 0) => None,
+            (None, _) => {
+                // Nothing selected yet: start at the first non-current entry
+                // (index 0 is the current session, when live includes one).
+                order
+                    .iter()
+                    .position(|s| !s.is_current)
+                    .map(|index| SelectionState { index, last_tap_tick: now_tick })
+            }
+            (Some(sel), len) => {
+                let index = match dir {
+                    Direction::Next => (sel.index + 1) % len,
+                    Direction::Prev => (sel.index + len - 1) % len,
+                };
+                Some(SelectionState { index, last_tap_tick: now_tick })
+            }
+        };
+        self.badge() != before
+    }
+
+    /// Idle-commit: fires when a selection is pending and this tick is not
+    /// the same tick as the tap that created/advanced it. Landing on the
+    /// current session is the cancel gesture (`None`, no effect); either way
+    /// a commit clears the pending selection.
+    pub(crate) fn tick(&mut self, now_tick: u64) -> Option<CommitTarget> {
+        let sel = self.selection.as_ref()?;
+        if now_tick <= sel.last_tap_tick {
+            return None; // tap and timer racing in the same tick must not commit
+        }
+        let index = sel.index;
+        self.selection = None; // committing (or cancelling) always clears
+        let order = self.ordered();
+        let entry = order.get(index)?;
+        if entry.is_current {
+            return None; // cancel gesture: landing back on the current session
+        }
+        Some(CommitTarget {
+            name: entry.name.clone(),
+            attention_tab_position: self.presence_for(&entry.name).and_then(|p| p.attention_tab_position),
+        })
+    }
+
+    /// The ordered badge: current session first, then attention>0 sessions by
+    /// name, then the rest by name. Derived fresh from `live`/`peers`/`own`
+    /// every call — never cached — so it can never drift from its inputs.
+    pub(crate) fn badge(&self) -> Vec<BadgeEntry> {
+        let order = self.ordered();
+        let selected_index = self.selection.as_ref().map(|sel| sel.index);
+        order
+            .into_iter()
+            .enumerate()
+            .map(|(i, s)| {
+                let p = self.presence_for(&s.name);
+                BadgeEntry {
+                    name: s.name.clone(),
+                    running: p.map_or(0, |p| p.running),
+                    attention: p.map_or(0, |p| p.attention),
+                    attention_tab_position: p.and_then(|p| p.attention_tab_position),
+                    is_current: s.is_current,
+                    selected: selected_index == Some(i),
+                }
+            })
+            .collect()
+    }
+
+    /// Whether a cycle selection is pending — the runtime keeps the Fast
+    /// timer cadence armed while true, so the idle-commit in `tick()` fires
+    /// promptly rather than waiting for the next Slow tick. Only the wasm
+    /// runtime (Task 5) reads this; no host test exercises it yet.
+    #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+    pub(crate) fn wants_fast_cadence(&self) -> bool {
+        self.selection.is_some()
+    }
+
+    /// The shared ordering: current session(s) first, then attention>0
+    /// sessions by name, then the rest by name. Both `badge()` and `cycle()`
+    /// go through this so "what's shown" and "what Alt+[/] steps through"
+    /// can never disagree.
+    fn ordered(&self) -> Vec<&SessionLite> {
+        let mut current: Vec<&SessionLite> = Vec::new();
+        let mut attention: Vec<&SessionLite> = Vec::new();
+        let mut rest: Vec<&SessionLite> = Vec::new();
+        for s in &self.live {
+            if s.is_current {
+                current.push(s);
+            } else if self.presence_for(&s.name).map_or(0, |p| p.attention) > 0 {
+                attention.push(s);
+            } else {
+                rest.push(s);
+            }
+        }
+        attention.sort_by(|a, b| a.name.cmp(&b.name));
+        rest.sort_by(|a, b| a.name.cmp(&b.name));
+        current.into_iter().chain(attention).chain(rest).collect()
+    }
+
+    /// This session's own counts if `name` is the current session, else the
+    /// matching peer's presence, else `None` (no data reported yet).
+    fn presence_for(&self, name: &str) -> Option<&Presence> {
+        self.own
+            .as_ref()
+            .filter(|p| p.session_name == name)
+            .or_else(|| self.peers.iter().find(|p| p.session_name == name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::radar_state::Direction;
+
+    fn live(names: &[(&str, bool)]) -> Vec<SessionLite> {
+        names.iter().map(|(n, c)| SessionLite { name: n.to_string(), is_current: *c }).collect()
+    }
+    fn presence(name: &str, running: usize, attention: usize) -> String {
+        format!(r#"{{"session_name":"{name}","running":{running},"attention":{attention}}}"#)
+    }
+
+    #[test]
+    fn badge_orders_current_then_attention_then_rest() {
+        let mut s = Sessions::default();
+        s.update_live(live(&[("zeta", false), ("work", true), ("alpha", false)]));
+        s.update_presences(vec![presence("zeta", 1, 2), presence("alpha", 1, 0)]);
+        s.set_own(Presence { session_name: "work".into(), running: 3, attention: 0,
+                             attention_tab_position: None, updated_epoch_s: 0 });
+        // (Bound rather than chained straight off `s.badge()`: the literal
+        // brief snippet borrows from a temporary `Vec<BadgeEntry>` that would
+        // be dropped at the end of the `let` statement — a compile-mechanics
+        // issue, not a semantic change; the assertion is unchanged.)
+        let badge = s.badge();
+        let names: Vec<&str> = badge.iter().map(|b| b.name.as_str()).collect();
+        assert_eq!(names, vec!["work", "zeta", "alpha"]);
+    }
+
+    #[test]
+    fn presences_for_dead_sessions_are_dropped() {
+        let mut s = Sessions::default();
+        s.update_live(live(&[("work", true)]));
+        s.update_presences(vec![presence("ghost", 5, 5)]);
+        assert!(s.badge().iter().all(|b| b.name != "ghost"));
+    }
+
+    #[test]
+    fn cycle_advances_and_wraps_and_tick_commits_after_idle() {
+        let mut s = Sessions::default();
+        s.update_live(live(&[("work", true), ("beta", false), ("alpha", false)]));
+        s.update_presences(vec![presence("alpha", 0, 1), presence("beta", 1, 0)]);
+        // Order: work(current), alpha(attention), beta.
+        s.cycle(Direction::Next, 10);                 // select alpha
+        assert_eq!(s.tick(10), None, "same-tick tap must not commit");
+        s.cycle(Direction::Next, 11);                 // skip to beta
+        let t = s.tick(12).expect("idle tick commits");
+        assert_eq!(t.name, "beta");
+        assert_eq!(s.tick(13), None, "committed selection is cleared");
+    }
+
+    #[test]
+    fn committing_on_current_session_is_a_noop_cancel() {
+        let mut s = Sessions::default();
+        s.update_live(live(&[("work", true), ("alpha", false)]));
+        s.update_presences(vec![presence("alpha", 0, 0)]);
+        s.cycle(Direction::Next, 1);                  // alpha
+        s.cycle(Direction::Next, 2);                  // wraps to work (current)
+        assert_eq!(s.tick(3), None, "landing on the current session cancels");
+    }
+
+    #[test]
+    fn commit_carries_attention_tab_position() {
+        let mut s = Sessions::default();
+        s.update_live(live(&[("work", true), ("alpha", false)]));
+        s.update_presences(vec![
+            r#"{"session_name":"alpha","running":0,"attention":1,"attention_tab_position":2}"#.to_string(),
+        ]);
+        s.cycle(Direction::Next, 1);
+        assert_eq!(s.tick(2).unwrap().attention_tab_position, Some(2));
+    }
+}

--- a/crates/plugin/src/sessions.rs
+++ b/crates/plugin/src/sessions.rs
@@ -58,13 +58,21 @@ pub(crate) struct CommitTarget {
 /// `cycle()` tap and the commit `tick()` (e.g. a new session sorting ahead of
 /// the selected one), and a positional index would then silently retarget
 /// whatever session ended up at the old index. Re-resolved by name against
-/// the fresh order on every `cycle()`/`tick()` call instead. `last_tap_tick`
-/// is the tick of the most recent `cycle()` call, so `tick()` can tell a
-/// same-tick race (the tap and the idle timer landing in the same update)
-/// from genuine idle — only the latter may commit.
+/// the fresh order on every `cycle()`/`tick()` call instead.
+///
+/// `taps_since_last_fire` replaces an earlier tick-counter comparison
+/// (`now_tick > last_tap_tick`) that had two field-observed bugs: (a) a tap
+/// landing just before an already-scheduled fire compared as "idle" and
+/// committed instantly, and (b) taps arriving faster than the 1s tick grain
+/// all shared one tick number, so the deadline never extended past the
+/// FIRST tap in a burst. `cycle()` sets this flag on every tap; `tick()`
+/// clears it and skips (no commit) whenever it's set, so a fire only ever
+/// commits when its entire covered interval was tap-free — guaranteeing at
+/// least one full quiet interval after the LAST tap, at the cost of at most
+/// one extra (skipped) fire.
 struct SelectionState {
     name: String,
-    last_tap_tick: u64,
+    taps_since_last_fire: bool,
 }
 
 #[derive(Default)]
@@ -118,13 +126,14 @@ impl Sessions {
         self.badge() != before
     }
 
-    /// Advance (or start) the cycle selection and stamp the tick it happened
-    /// on. Re-derives the shared ordering fresh each call, so a selection
-    /// started before a `update_live`/`update_presences` change always steps
-    /// relative to the current membership, never a stale snapshot. The
-    /// pending selection's *name* is re-resolved against that fresh order
-    /// (not trusted as a stale index) before advancing from it.
-    pub(crate) fn cycle(&mut self, dir: Direction, now_tick: u64) -> bool {
+    /// Advance (or start) the cycle selection and arm its tap-since-fire
+    /// flag (see `SelectionState`'s doc). Re-derives the shared ordering
+    /// fresh each call, so a selection started before a
+    /// `update_live`/`update_presences` change always steps relative to the
+    /// current membership, never a stale snapshot. The pending selection's
+    /// *name* is re-resolved against that fresh order (not trusted as a
+    /// stale index) before advancing from it.
+    pub(crate) fn cycle(&mut self, dir: Direction) -> bool {
         let before = self.badge();
         let order = self.ordered();
         // A previously selected name that no longer appears in the fresh
@@ -143,7 +152,7 @@ impl Sessions {
                 // session, when own is known).
                 order.iter().position(|s| !s.is_current).map(|index| SelectionState {
                     name: order[index].presence.session_name.clone(),
-                    last_tap_tick: now_tick,
+                    taps_since_last_fire: true,
                 })
             }
             (Some(index), len) => {
@@ -151,24 +160,28 @@ impl Sessions {
                     Direction::Next => (index + 1) % len,
                     Direction::Prev => (index + len - 1) % len,
                 };
-                Some(SelectionState { name: order[next].presence.session_name.clone(), last_tap_tick: now_tick })
+                Some(SelectionState { name: order[next].presence.session_name.clone(), taps_since_last_fire: true })
             }
         };
         self.badge() != before
     }
 
-    /// Idle-commit: fires when a selection is pending and this tick is not
-    /// the same tick as the tap that created/advanced it. The selected
-    /// *name* is re-resolved against a freshly derived order rather than a
-    /// remembered index, so a reorder between the tap and this tick can
-    /// never retarget a different session; if the name is no longer live,
-    /// the selection is dropped and nothing commits. Landing on the current
-    /// session is the cancel gesture (`None`, no effect); either way a
-    /// commit clears the pending selection.
-    pub(crate) fn tick(&mut self, now_tick: u64) -> Option<CommitTarget> {
-        let sel = self.selection.as_ref()?;
-        if now_tick <= sel.last_tap_tick {
-            return None; // tap and timer racing in the same tick must not commit
+    /// Idle-commit: called on every timer fire while a selection is pending.
+    /// A fire whose covered interval saw a tap (`taps_since_last_fire` set —
+    /// by `cycle()`, possibly including THIS very fire's own tap) clears the
+    /// flag and skips: the deadline resets, and only the NEXT, fully quiet
+    /// fire may commit. The selected *name* is re-resolved against a
+    /// freshly derived order rather than a remembered index, so a reorder
+    /// between the tap and this tick can never retarget a different
+    /// session; if the name is no longer live, the selection is dropped and
+    /// nothing commits. Landing on the current session is the cancel
+    /// gesture (`None`, no effect); either way a commit clears the pending
+    /// selection.
+    pub(crate) fn tick(&mut self) -> Option<CommitTarget> {
+        let sel = self.selection.as_mut()?;
+        if sel.taps_since_last_fire {
+            sel.taps_since_last_fire = false;
+            return None;
         }
         let name = sel.name.clone();
         self.selection = None; // committing, cancelling, or dropping a vanished selection all clear
@@ -296,12 +309,13 @@ mod tests {
         s.set_own(own("work"));
         s.update_presences(vec![presence("alpha", 0, 1), presence("beta", 1, 0)]);
         // Order: work(current), alpha(attention), beta.
-        s.cycle(Direction::Next, 10);                 // select alpha
-        assert_eq!(s.tick(10), None, "same-tick tap must not commit");
-        s.cycle(Direction::Next, 11);                 // skip to beta
-        let t = s.tick(12).expect("idle tick commits");
+        s.cycle(Direction::Next);                     // select alpha
+        assert_eq!(s.tick(), None, "the fire covering the tap must not commit — it clears the flag");
+        s.cycle(Direction::Next);                     // skip to beta
+        assert_eq!(s.tick(), None, "the fire covering THIS tap must not commit either");
+        let t = s.tick().expect("a fully quiet fire commits");
         assert_eq!(t.name, "beta");
-        assert_eq!(s.tick(13), None, "committed selection is cleared");
+        assert_eq!(s.tick(), None, "committed selection is cleared");
     }
 
     #[test]
@@ -309,9 +323,10 @@ mod tests {
         let mut s = Sessions::default();
         s.set_own(own("work"));
         s.update_presences(vec![presence("alpha", 0, 0)]);
-        s.cycle(Direction::Next, 1);                  // alpha
-        s.cycle(Direction::Next, 2);                  // wraps to work (current)
-        assert_eq!(s.tick(3), None, "landing on the current session cancels");
+        s.cycle(Direction::Next);                     // alpha
+        s.cycle(Direction::Next);                     // wraps to work (current)
+        s.tick();                                     // the fire covering that tap: skip, clears the flag
+        assert_eq!(s.tick(), None, "a quiet fire landing on the current session cancels");
     }
 
     #[test]
@@ -321,8 +336,52 @@ mod tests {
         s.update_presences(vec![
             r#"{"session_name":"alpha","running":0,"attention":1,"attention_tab_position":2}"#.to_string(),
         ]);
-        s.cycle(Direction::Next, 1);
-        assert_eq!(s.tick(2).unwrap().attention_tab_position, Some(2));
+        s.cycle(Direction::Next);
+        s.tick(); // the fire covering the tap: skip, clears the flag
+        assert_eq!(s.tick().unwrap().attention_tab_position, Some(2));
+    }
+
+    // -- Pinning: field bugs in the old tick-counter commit check ------------
+    // The old `now_tick > last_tap_tick` comparison committed on the very
+    // next fire after a tap (a tap landing just before an already-scheduled
+    // fire compared as "idle" and committed instantly) and never extended
+    // the deadline for taps faster than the 1s tick grain (they all shared
+    // one tick number, so the commit landed ~1s after the FIRST tap, not
+    // the last). The `taps_since_last_fire` flag fixes both.
+
+    #[test]
+    fn tap_then_immediate_fire_does_not_commit() {
+        let mut s = Sessions::default();
+        s.set_own(own("work"));
+        s.update_presences(vec![presence("alpha", 1, 0)]);
+        s.cycle(Direction::Next); // selects alpha
+        // A fire landing right after the tap must not commit instantly —
+        // it covers the tap's interval and must reset the deadline instead.
+        assert_eq!(s.tick(), None, "a fire landing right after the tap must not commit instantly");
+        assert!(s.wants_fast_cadence(), "the selection survives that fire, still pending");
+        let t = s.tick().expect("the next, fully quiet fire commits");
+        assert_eq!(t.name, "alpha");
+    }
+
+    #[test]
+    fn rapid_multi_tap_across_several_fires_commits_only_after_first_quiet_fire() {
+        let mut s = Sessions::default();
+        s.set_own(own("work"));
+        s.update_presences(vec![presence("alpha", 1, 0), presence("beta", 1, 0)]);
+        // Order: work(current), alpha, beta. Several taps land, each one
+        // arriving before the next fire — faster than the old 1-tick grain
+        // could distinguish. Every fire covering a tap must skip, not just
+        // the first.
+        s.cycle(Direction::Next); // alpha
+        assert_eq!(s.tick(), None);
+        s.cycle(Direction::Next); // beta
+        assert_eq!(s.tick(), None);
+        s.cycle(Direction::Next); // wraps to work (current) — still just cycling
+        assert_eq!(s.tick(), None, "a fire covering a tap must skip even on the 3rd consecutive tap");
+        s.cycle(Direction::Prev); // back to beta — the LAST tap in this burst
+        assert_eq!(s.tick(), None, "the fire covering the last tap still must not commit");
+        let t = s.tick().expect("the first fully quiet fire after the burst commits");
+        assert_eq!(t.name, "beta", "must commit to whatever the LAST tap selected, not an earlier one");
     }
 
     // -- Pinning: wants_fast_cadence() --------------------------------------
@@ -337,18 +396,22 @@ mod tests {
         s.update_presences(vec![presence("alpha", 1, 0), presence("beta", 1, 0)]);
         assert!(!s.wants_fast_cadence(), "nothing selected initially");
 
-        s.cycle(Direction::Next, 1); // selects alpha
+        s.cycle(Direction::Next); // selects alpha
         assert!(s.wants_fast_cadence(), "a cycle tap arms a pending selection");
 
-        s.tick(2); // idle commit to alpha
+        s.tick(); // the fire covering the tap: skip, still pending
+        assert!(s.wants_fast_cadence(), "a tap-covering fire must not clear the pending selection");
+        s.tick(); // idle commit to alpha
         assert!(!s.wants_fast_cadence(), "a commit clears the pending selection");
 
-        s.cycle(Direction::Next, 3); // alpha
-        s.cycle(Direction::Next, 4); // beta
-        s.cycle(Direction::Next, 5); // wraps to work (current)
+        s.cycle(Direction::Next); // alpha
+        s.cycle(Direction::Next); // beta
+        s.cycle(Direction::Next); // wraps to work (current)
         assert!(s.wants_fast_cadence(), "still pending until the idle tick fires");
 
-        s.tick(6); // cancel-commit (lands on current)
+        s.tick(); // the fire covering the last tap: skip, still pending
+        assert!(s.wants_fast_cadence());
+        s.tick(); // cancel-commit (lands on current)
         assert!(!s.wants_fast_cadence(), "a cancel-commit also clears the pending selection");
     }
 
@@ -384,8 +447,8 @@ mod tests {
         let mut s = Sessions::default();
         s.set_own(own("work"));
         s.update_presences(vec![presence("alpha", 1, 0), presence("beta", 1, 0)]);
-        assert!(s.cycle(Direction::Next, 1), "starting a selection flips a `selected` flag in the badge");
-        assert!(s.cycle(Direction::Next, 2), "advancing the selection moves the `selected` flag");
+        assert!(s.cycle(Direction::Next), "starting a selection flips a `selected` flag in the badge");
+        assert!(s.cycle(Direction::Next), "advancing the selection moves the `selected` flag");
     }
 
     // -- Selection identity (not positional index) ---------------------------
@@ -399,7 +462,7 @@ mod tests {
         s.set_own(own("work"));
         s.update_presences(vec![presence("alpha", 1, 0), presence("beta", 1, 0)]);
         // Order: work (current), alpha, beta — both zero-attention, by name.
-        s.cycle(Direction::Next, 1); // selects alpha (first non-current)
+        s.cycle(Direction::Next); // selects alpha (first non-current)
 
         // "aardvark" joins and sorts ahead of "alpha" in the rest bucket. A
         // positional-index selection (old index 1) would now point at
@@ -408,7 +471,8 @@ mod tests {
         // this is the same "membership changed under the selection" shape.
         s.update_presences(vec![presence("aardvark", 1, 0), presence("alpha", 1, 0), presence("beta", 1, 0)]);
 
-        let t = s.tick(2).expect("idle tick commits");
+        s.tick(); // the fire covering the tap: skip, clears the flag
+        let t = s.tick().expect("a quiet fire commits");
         assert_eq!(t.name, "alpha", "selection must follow the named session, not the reordered index");
     }
 
@@ -417,10 +481,11 @@ mod tests {
         let mut s = Sessions::default();
         s.set_own(own("work"));
         s.update_presences(vec![presence("alpha", 0, 0)]);
-        s.cycle(Direction::Next, 1); // selects alpha
+        s.cycle(Direction::Next); // selects alpha
         s.update_presences(vec![]); // alpha's presence vanished before the idle tick
 
-        assert_eq!(s.tick(2), None, "a vanished selection must not commit");
+        s.tick(); // the fire covering the tap: skip, clears the flag (selection still pending)
+        assert_eq!(s.tick(), None, "a vanished selection must not commit");
         assert!(!s.wants_fast_cadence(), "the cleared selection must not keep fast cadence armed");
     }
 
@@ -437,7 +502,7 @@ mod tests {
         s.update_presences(vec![presence("alpha", 1, 0), presence("beta", 1, 0), presence("gamma", 1, 0)]);
         // No attention: order is work (current), then alpha, beta, gamma by name.
 
-        s.cycle(Direction::Next, 1); // selects alpha (first non-current)
+        s.cycle(Direction::Next); // selects alpha (first non-current)
 
         // alpha vanishes, leaving a fresh order with *two* non-current entries
         // (beta, gamma) — order: work, beta, gamma.
@@ -451,7 +516,7 @@ mod tests {
         // land on the last entry (gamma) — the same bug that, under
         // Direction::Next, would coincidentally land on beta too and pass
         // silently.
-        s.cycle(Direction::Prev, 2);
+        s.cycle(Direction::Prev);
         let badge = s.badge();
         let selected: Vec<&str> = badge.iter().filter(|b| b.selected).map(|b| b.name.as_str()).collect();
         assert_eq!(
@@ -461,7 +526,8 @@ mod tests {
              non-current entry, not fall back to advancing from index 0"
         );
 
-        let t = s.tick(3).expect("idle tick commits");
+        s.tick(); // the fire covering the last tap: skip, clears the flag
+        let t = s.tick().expect("a quiet fire commits");
         assert_eq!(t.name, "beta", "after vanished selection, cycle must restart and select the first non-current entry");
     }
 
@@ -513,7 +579,7 @@ mod tests {
         s.set_own(own("work"));
         // No presences, no peers — work is the only session.
 
-        let changed = s.cycle(Direction::Next, 1);
+        let changed = s.cycle(Direction::Next);
         assert!(!changed, "cycle with nothing to select must return false (no badge change)");
         assert!(!s.wants_fast_cadence(), "cycle with nothing to select must not set up a pending selection");
     }

--- a/crates/plugin/src/status_store.rs
+++ b/crates/plugin/src/status_store.rs
@@ -103,6 +103,7 @@ impl StatusStore {
                 exit_code: None,
                 completed_epoch_s,
                 pending_epoch_s,
+                acknowledged: p.ack,
             },
         );
         self.evict_over_cap();
@@ -224,6 +225,7 @@ impl StatusStore {
                 exit_code: None,
                 completed_epoch_s: None,
                 pending_epoch_s: None,
+                acknowledged: false,
             },
         );
         Some(old)
@@ -287,6 +289,7 @@ mod tests {
             msg: "m".into(),
             task: String::new(),
             source: "test".into(),
+            ack: false,
         }
     }
 
@@ -558,6 +561,20 @@ mod tests {
             s.get(MAX_TRACKED_PANES as u32 + extra - 1).is_some(),
             "the newest pane is still tracked"
         );
+    }
+
+    #[test]
+    fn apply_stamps_acknowledged_from_the_payload_and_a_fresh_payload_clears_it() {
+        let mut s = StatusStore::default();
+        s.apply(payload(1, Status::Pending), 1, 100);
+        assert!(!s.get(1).unwrap().acknowledged);
+        // The right-click acknowledge echo lands with `ack: true`.
+        s.apply(StatusPayload { ack: true, ..payload(1, Status::Done) }, 2, 200);
+        assert!(s.get(1).unwrap().acknowledged);
+        // The exemption lasts exactly as long as the acknowledged status: the
+        // next real broadcast overwrites it.
+        s.apply(payload(1, Status::Running), 3, 300);
+        assert!(!s.get(1).unwrap().acknowledged);
     }
 
     #[test]

--- a/crates/plugin/src/test_fixtures.rs
+++ b/crates/plugin/src/test_fixtures.rs
@@ -50,6 +50,7 @@ pub(crate) fn payload_in_repo(pane_id: u32, status: Status, repo: &str) -> Statu
         msg: "working".into(),
         task: String::new(),
         source: "claude".into(),
+        ack: false,
     }
 }
 

--- a/crates/plugin/tests/e2e/harness.rs
+++ b/crates/plugin/tests/e2e/harness.rs
@@ -64,9 +64,35 @@ pub struct ZellijSession {
     /// (rows, cols) of the PTY at session start; `screen()` sizes its vt100
     /// parser from this.
     size: Mutex<(u16, u16)>,
-    /// Isolated temp HOME for this session. Kept alive so Zellij's cache dir
-    /// survives for the session duration and is auto-cleaned on Drop.
-    _temp_home: tempfile::TempDir,
+    /// HOME used by this session's Zellij subprocesses. Either an owned temp
+    /// dir (deleted on Drop) or a path borrowed from a sibling's owned dir
+    /// (see `HomeHandle`) — never both, or `start_sibling` and its parent
+    /// would race to delete the same directory.
+    _temp_home: HomeHandle,
+}
+
+/// Who owns the on-disk lifetime of a session's HOME directory.
+///
+/// `start_sibling` needs a second Zellij session to use the SAME HOME as an
+/// existing one (so both resolve to the same Zellij cache dir — and thus the
+/// same plugin `/cache` mount — for presence files to actually cross), but
+/// exactly ONE of the two `ZellijSession`s must delete that directory on
+/// Drop. `Owned` is the original `tempfile::TempDir` (deletes on drop);
+/// `Shared` is just the path, borrowed from the owner and inert on drop.
+#[cfg(feature = "e2e")]
+enum HomeHandle {
+    Owned(tempfile::TempDir),
+    Shared(std::path::PathBuf),
+}
+
+#[cfg(feature = "e2e")]
+impl HomeHandle {
+    fn path(&self) -> &Path {
+        match self {
+            HomeHandle::Owned(t) => t.path(),
+            HomeHandle::Shared(p) => p.as_path(),
+        }
+    }
 }
 
 #[cfg(feature = "e2e")]
@@ -100,8 +126,40 @@ impl ZellijSession {
         rows: u16,
         cols: u16,
     ) -> Self {
+        Self::start_internal(name, layout_kdl, HomeHandle::Owned(temp_home), rows, cols)
+    }
+
+    /// Second session on the SAME server socket dir + cache as `self`, so the
+    /// two servers exchange `SessionUpdate` and share the plugin cache root.
+    ///
+    /// Reuses `self`'s temp HOME path (not `isolated_temp_home()`) — same
+    /// permissions.kdl (no re-prompt) and, critically, the same Zellij cache
+    /// dir, which is where zellij maps each plugin's `/cache` mount. Two
+    /// sessions on DIFFERENT HOMEs get DIFFERENT `/cache` roots and never see
+    /// each other's presence files no matter how long they wait; sharing
+    /// HOME is the one thing that makes the two servers' plugin instances
+    /// agree on where presence lives. (Zellij's own session socket dir turns
+    /// out to be keyed by OS temp dir + uid, not HOME, so `--session
+    /// <name>`-addressed sessions already see each other in `SessionUpdate`
+    /// regardless of HOME — verified empirically against 0.44.3 — but the
+    /// shared `/cache` mount is NOT: that one really does require the same
+    /// HOME, which is what this constructor buys.)
+    ///
+    /// The returned session does NOT own the temp HOME directory — `self`
+    /// does, and must outlive it (drop `self` last).
+    #[allow(dead_code)]
+    pub fn start_sibling(&self, name: &str, layout_kdl: &str) -> ZellijSession {
+        let (rows, cols) = *self.size.lock().unwrap();
+        let shared_home = HomeHandle::Shared(self._temp_home.path().to_path_buf());
+        Self::start_internal(name, layout_kdl, shared_home, rows, cols)
+    }
+
+    /// Shared implementation behind `start_with_size` (owned HOME) and
+    /// `start_sibling` (borrowed HOME) — everything past HOME lifetime is
+    /// identical.
+    fn start_internal(name: &str, layout_kdl: &str, home: HomeHandle, rows: u16, cols: u16) -> Self {
         assert_zellij_version();
-        let temp_home_path = temp_home.path().to_path_buf();
+        let temp_home_path = home.path().to_path_buf();
 
         // Kill any previous session with this name to avoid conflicts.
         let _ = Command::new("zellij")
@@ -175,7 +233,7 @@ impl ZellijSession {
             _reader,
             buf,
             size: Mutex::new((rows, cols)),
-            _temp_home: temp_home,
+            _temp_home: home,
         };
         s.wait_until_ready();
         s

--- a/crates/plugin/tests/e2e/main.rs
+++ b/crates/plugin/tests/e2e/main.rs
@@ -1033,9 +1033,10 @@ fn rail_paints_every_column_of_its_pane() {
 /// the full root-cause dive (this test used to fail with a STOP-CONDITION
 /// panic pointing at exactly that). task-8b-brief.md's amendment drops
 /// `SessionUpdate` from the design entirely: liveness is now the presence
-/// files' own mtimes (`session_files::PRESENCE_LIVE_TTL`), and this session's
-/// own name comes from `ModeUpdate` instead — both push-style, neither
-/// needing any other plugin to be running.
+/// files' own mtimes, turned into a per-entry fresh/stale state
+/// (`sessions::STALE_AFTER_SECS`) rather than a read-time drop (task-14),
+/// and this session's own name comes from `ModeUpdate` instead — both
+/// push-style, neither needing any other plugin to be running.
 #[test]
 #[ignore = "e2e: requires zellij + built wasm; run via `just test-e2e`"]
 fn session_next_switches_to_the_session_with_attention() {
@@ -1106,9 +1107,10 @@ fn session_next_switches_to_the_session_with_attention() {
         "A's badge never showed {needle:?}. Either B never learned its own session name from \
          `Event::ModeUpdate` (so `project` withheld `Effect::PersistPresence`), or B's presence \
          file (written under the shared /cache root) never reached A (A's `Effect::ReadPresences` \
-         is Fast-tick-gated — see the rail above for whether A even looks fast-armed), or the \
-         file crossed but `session_files::PRESENCE_LIVE_TTL`'s read-time mtime gate is somehow \
-         treating it as stale already. See the printed rail above.",
+         is Fast-tick-gated — see the rail above for whether A even looks fast-armed). Since \
+         task-14, a stale peer still renders (dimmed) rather than being dropped, so a bare \
+         name with the wrong (or missing) counts, not an absent line, is the sign of a genuine \
+         presence-plumbing failure here. See the printed rail above.",
     );
     eprintln!("[e2e] PASS: A's badge shows B needing attention (presence crossed /cache)");
 

--- a/crates/plugin/tests/e2e/main.rs
+++ b/crates/plugin/tests/e2e/main.rs
@@ -1011,3 +1011,140 @@ fn rail_paints_every_column_of_its_pane() {
          rendering artifact rather than a plugin under-paint bug."
     );
 }
+
+/// Cross-session e2e: TWO independently-started, real Zellij servers — not
+/// two tabs of one server (that's `command_activity_reaches_background_tab_
+/// instances`) — proving the whole cross-session feature works between
+/// separate processes, WITHOUT any session-manager trigger: B's plugin
+/// learns its own name from `Event::ModeUpdate` (push, automatic on load —
+/// no `get_session_list()` call needed) and persists presence to the shared
+/// `/cache` root; A's plugin reads that back directly off disk on a Fast
+/// tick and renders a badge line for B; A's `session-next` (+ idle-commit
+/// ~1s later) really calls Zellij's `switch_session`, physically
+/// reattaching A's PTY client onto B.
+///
+/// HISTORY: an earlier design had liveness riding on `Event::SessionUpdate`
+/// instead of the presence files themselves. That never worked in a stock
+/// zj-radar session: zellij-server 0.44.3 only repopulates
+/// `SessionUpdate`'s peer list (`peer_sessions_cache`) when some plugin
+/// calls the blocking host fn `get_session_list()`, which only Zellij's own
+/// `session-manager` plugin does — zj-radar's plugin never does, by design
+/// (CLAUDE.md: "push-driven, never poll-driven"). See task-8-report.md for
+/// the full root-cause dive (this test used to fail with a STOP-CONDITION
+/// panic pointing at exactly that). task-8b-brief.md's amendment drops
+/// `SessionUpdate` from the design entirely: liveness is now the presence
+/// files' own mtimes (`session_files::PRESENCE_LIVE_TTL`), and this session's
+/// own name comes from `ModeUpdate` instead — both push-style, neither
+/// needing any other plugin to be running.
+#[test]
+#[ignore = "e2e: requires zellij + built wasm; run via `just test-e2e`"]
+fn session_next_switches_to_the_session_with_attention() {
+    use std::time::Duration;
+    use zj_radar_core::status::GlyphSet;
+    use zj_radar_core::Status;
+
+    let wasm = plugin_wasm_path();
+    assert!(
+        wasm.exists(),
+        "Plugin wasm not found at {wasm:?}. Build it:\n  cargo build --release --target wasm32-wasip1 -p zj-radar-plugin"
+    );
+
+    let temp_home = pre_grant_permissions(&wasm);
+    let pid = std::process::id();
+    let layout = sidebar_layout(&wasm);
+
+    // `a` owns the temp HOME (deletes it on drop); `b` is a sibling on the
+    // SAME server socket dir + cache root (see `start_sibling`'s doc) — the
+    // two servers are otherwise completely independent processes, exactly
+    // like two real terminal windows a user opened separately.
+    let a = ZellijSession::start(&format!("zjr_xsess_a_{pid}"), &layout, &wasm, temp_home);
+    eprintln!("[e2e] session A ({}) loaded", a.name);
+    let b = a.start_sibling(&format!("zjr_xsess_b_{pid}"), &layout);
+    eprintln!("[e2e] session B ({}) loaded (sibling of A, shared HOME)", b.name);
+
+    // Give B a tracked agent needing attention. This is what B's plugin folds
+    // into its own `Presence` (attention=1, running=0) and persists to the
+    // shared /cache root — the fact A's badge assertion below actually needs
+    // to have crossed the wire to pass.
+    let pane_b = b.discover_terminal_pane_id();
+    eprintln!("[e2e] B terminal pane_id={pane_b}");
+    let b_payload = format!(
+        r#"{{"v":1,"source":"claude","pane":{{"type":"terminal","id":{pane_b}}},"status":"pending","repo":"radar-b-repo","msg":"pick one"}}"#
+    );
+    b.pipe_status(&b_payload);
+
+    // `Effect::ReadPresences` (A reading the shared /cache root back) is
+    // gated to Fast timer fires only (runtime.rs `timer`), and A has nothing
+    // of its own yet to arm Fast — it would otherwise idle on the 60s Slow
+    // heartbeat and this test would need up to a minute of real wall time to
+    // stay honest. Piping a `running` status into A's OWN terminal arms A's
+    // Fast cadence indefinitely (an active `Running` row animates every
+    // tick — see `timer_should_continue`/`has_running_work`) without giving A
+    // any attention of its own, so it doesn't interfere with the ordering
+    // assertion below (B is still the only attention>0 peer).
+    let pane_a = a.discover_terminal_pane_id();
+    eprintln!("[e2e] A terminal pane_id={pane_a}");
+    let a_payload = format!(
+        r#"{{"v":1,"source":"claude","pane":{{"type":"terminal","id":{pane_a}}},"status":"running","repo":"radar-a-repo","msg":"keep-fast"}}"#
+    );
+    a.pipe_status(&a_payload);
+
+    // A's badge must show B's name TOGETHER WITH the attention glyph+count —
+    // not just B's bare name. Under the new design, B's presence entry is
+    // ALL A ever learns about B (there is no separate "live session roster"
+    // to have populated a bare-name-only row from) — so this needle also
+    // rules out the degenerate case of a badge line with a name but zero
+    // counts (e.g. a peer file that parsed but was empty).
+    let attention_glyph = Status::Pending.glyph_for(GlyphSet::Plain);
+    let needle = format!("{} 1{attention_glyph}", b.name);
+    let saw_badge = a.wait_until(Duration::from_secs(10), |s| {
+        sidebar_region(&s.screen(), 32).contains(&needle)
+    });
+    eprintln!("[e2e] A's rail (32 cols):\n{}", sidebar_region(&a.screen(), 32));
+    assert!(
+        saw_badge,
+        "A's badge never showed {needle:?}. Either B never learned its own session name from \
+         `Event::ModeUpdate` (so `project` withheld `Effect::PersistPresence`), or B's presence \
+         file (written under the shared /cache root) never reached A (A's `Effect::ReadPresences` \
+         is Fast-tick-gated — see the rail above for whether A even looks fast-armed), or the \
+         file crossed but `session_files::PRESENCE_LIVE_TTL`'s read-time mtime gate is somehow \
+         treating it as stale already. See the printed rail above.",
+    );
+    eprintln!("[e2e] PASS: A's badge shows B needing attention (presence crossed /cache)");
+
+    // Cycle from A. `Sessions::ordered()` puts the current session first,
+    // then attention>0 peers by name, then the rest — B is the only
+    // attention>0 peer, so a single `session-next` tap selects it outright.
+    // The actual switch is a LATER idle-commit (`timer`'s `Sessions::tick`),
+    // firing on the very next Fast tick after the tap (~1s here, since A's
+    // `running` row above keeps Fast armed) — not an immediate effect of the
+    // pipe call itself.
+    a.run_action(&["pipe", "--name", "zj_radar.cmd.v1", "--", "session-next"]);
+
+    // After the idle-commit fires, `Effect::SwitchSession` calls Zellij's
+    // `switch_session_with_focus`, which reattaches A's OWN PTY CLIENT onto
+    // session B — session "radar-a" itself keeps running (headless), so
+    // `a.dump_screen()` (which explicitly targets session A BY NAME through
+    // a fresh `--session radar-a action ...` connection) would keep dumping
+    // A's own terminal FOREVER and could never observe this. Only A's raw
+    // PTY buffer (`pty_text()`) reflects what the physical client is
+    // actually attached to now. The marker `discover_terminal_pane_id`
+    // already echoed into B's terminal (`ZPID=<pane_b>`) is still on B's
+    // screen (nothing since has overwritten it), so it can only show up in
+    // A's PTY stream if that PTY is now rendering B's screen — the same
+    // marker-based external-signal technique `click_on_a_tab_row_switches_
+    // the_active_tab` uses to confirm a real `SwitchTab`, applied here to a
+    // real `SwitchSession`.
+    let marker = format!("ZPID={pane_b}");
+    let switched = a.wait_until(Duration::from_secs(8), |s| s.pty_text().contains(&marker));
+    if !switched {
+        let tail: String = a.pty_text().chars().rev().take(1000).collect::<String>().chars().rev().collect();
+        eprintln!("[e2e] A's PTY tail after failed switch wait:\n{tail}");
+    }
+    assert!(
+        switched,
+        "session-next's idle-commit must switch_session A's client onto B; A's PTY never \
+         showed B's marker {marker:?} (session-next tapped, ~1 Fast tick should commit it)"
+    );
+    eprintln!("[e2e] PASS: session-next committed and A's client switched onto B");
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,6 +129,20 @@ keybinds {
 `attention-next` / `attention-prev` walk the tabs whose agents are *waiting for
 you*, *errored*, or *done* — in tab order, wrapping around — and switch focus to
 each. Tabs that are merely *running* or *idle* are skipped. Repeated presses
-sweep every attention tab and cycle. `session-next` / `session-prev` cycle the
-badge selection across sessions. Like every command pipe, an unknown verb is
-ignored, and the action is inert until the sidebar has been granted permissions.
+sweep every attention tab and cycle.
+
+`session-next` / `session-prev` step the cross-session badge's highlighted
+selection (see [Cross-session badge](../README.md#cross-session-badge)) through
+the same order the badge itself renders in — current session first, then any
+session that needs attention, then the rest — wrapping around, with the
+current session included as a normal stop. Each tap only moves the highlight;
+nothing switches yet. The selection **commits** on the first idle tick after
+about a second with no further tap — landing back on the current session
+cancels instead of switching. A committed switch jumps to the target
+session's attention tab if it has one, otherwise it leaves Zellij to restore
+that session's last focus. The badge — and therefore cycling — only has
+something to step through once a second zj-radar session is live; with just
+one session running, `session-next`/`session-prev` are no-ops.
+
+Like every command pipe, an unknown verb is ignored, and the action is inert
+until the sidebar has been granted permissions.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,6 +115,13 @@ keybinds {
         bind "Alt p" {
             MessagePlugin "radar" { name "zj_radar.cmd.v1"; payload "attention-prev"; }
         }
+        // Cycle the badge selection across sessions; commits ~1s after the last tap.
+        bind "Alt s" {
+            MessagePlugin "radar" { name "zj_radar.cmd.v1"; payload "session-next"; }
+        }
+        bind "Alt Shift s" {
+            MessagePlugin "radar" { name "zj_radar.cmd.v1"; payload "session-prev"; }
+        }
     }
 }
 ```
@@ -122,5 +129,6 @@ keybinds {
 `attention-next` / `attention-prev` walk the tabs whose agents are *waiting for
 you*, *errored*, or *done* — in tab order, wrapping around — and switch focus to
 each. Tabs that are merely *running* or *idle* are skipped. Repeated presses
-sweep every attention tab and cycle. Like every command pipe, an unknown verb is
+sweep every attention tab and cycle. `session-next` / `session-prev` cycle the
+badge selection across sessions. Like every command pipe, an unknown verb is
 ignored, and the action is inert until the sidebar has been granted permissions.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,5 +144,10 @@ that session's last focus. The badge — and therefore cycling — only has
 something to step through once a second zj-radar session is live; with just
 one session running, `session-next`/`session-prev` are no-ops.
 
+Dimmed (stale) badge entries are skipped by cycling, but you can dismiss one
+by right-clicking it directly in the rail — a mouse gesture, not a `cmd.v1`
+verb; a dismissed session that turns out to be alive reappears on its next
+heartbeat.
+
 Like every command pipe, an unknown verb is ignored, and the action is inert
 until the sidebar has been granted permissions.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,5 +149,16 @@ by right-clicking it directly in the rail — a mouse gesture, not a `cmd.v1`
 verb; a dismissed session that turns out to be alive reappears on its next
 heartbeat.
 
+Right-click is the rail's general acknowledge/dismiss gesture, not only a
+badge thing — the rule is **left-click navigates, right-click
+acknowledges** everywhere on the rail. Beyond a stale badge entry (above),
+right-clicking a pane or tab row still flagged `◆ needs you` acknowledges
+it: the row downgrades to `done`, and — because a click lands in exactly one
+plugin instance — it converges by re-broadcasting a `done` update over
+`zj_radar.status.v1`, the same pipe a real agent hook uses, rather than
+mutating this instance's state directly. Every tab's instance (including the
+one you clicked in) picks up the change through the normal status-pipe
+intake. A row with nothing pending is a no-op.
+
 Like every command pipe, an unknown verb is ignored, and the action is inert
 until the sidebar has been granted permissions.

--- a/docs/design.md
+++ b/docs/design.md
@@ -504,23 +504,30 @@ ticking alone on an unchanged session never re-writes the file. Withheld
 entirely while `own_session_name` is empty (see below), since an unnamed
 presence file is useless to a peer.
 
-**Liveness heartbeat + TTL.** Peers never call `SessionUpdate`/
-`get_session_list` to learn who's out there (see "Why not `SessionUpdate`"
-below) — liveness is read from the filesystem, not asked for. Peer sessions
-re-read the shared directory only on Fast (1 Hz) timer fires
-(`Effect::ReadPresences`; never on the Slow heartbeat — one directory scan
-per second, only while Fast is armed), and a presence file whose mtime is
-older than `PRESENCE_LIVE_TTL` (180s) is treated as belonging to a dead
-session: its row is skipped, not deleted — a reader only ever judges a
-peer's file, never mutates it. That TTL only bites a session with nothing to
-report: because `PersistPresence` is content-edge-gated, a session sitting
-fully idle (no Fast-cadence work, no count change) would otherwise let its
-file's mtime age past 180s and silently vanish from every peer's badge while
-still alive. The fix is a **liveness heartbeat**: `timer` unconditionally
-re-emits `PersistPresence` on every Slow (60s) fire, bypassing the edge gate,
-purely to keep the mtime fresh. Separately, a `6h` sweep (`PRESENCE_MAX_AGE`)
-deletes genuinely abandoned presence files at plugin `load()` — debris
-cleanup, unrelated to (and much looser than) the 180s liveness TTL.
+**Liveness heartbeat + staleness (task-14: never a hard drop).** Peers never
+call `SessionUpdate`/`get_session_list` to learn who's out there (see "Why
+not `SessionUpdate`" below) — liveness is read from the filesystem, not
+asked for. Peer sessions re-read the shared directory only on Fast (1 Hz)
+timer fires (`Effect::ReadPresences`; never on the Slow heartbeat — one
+directory scan per second, only while Fast is armed). `read_peer_presences`
+returns every peer file it finds, unconditionally, each paired with its
+file's mtime age; `Sessions::update_presences` turns that age into a
+per-entry fresh/stale state (`STALE_AFTER_SECS`, 90s) rather than dropping
+the entry — a session the badge has ever shown must never silently vanish
+from it (user decision, task-14). A stale entry dims on the badge and is
+unreachable via `session-next`/`session-prev`, but stays visible; nothing is
+ever deleted by a reader, which only ever judges a peer's file, never
+mutates it. Staleness mostly bites a session with nothing to report:
+because `PersistPresence` is content-edge-gated, a session sitting fully
+idle (no Fast-cadence work, no count change) would otherwise let its file's
+mtime age past 90s and dim on every peer's badge while still alive. The fix
+is a **liveness heartbeat**: `timer` unconditionally re-emits
+`PersistPresence` on every Slow (60s) fire, bypassing the edge gate, purely
+to keep the mtime fresh — 60s heartbeat against a 90s stale threshold is
+50% margin against one missed beat. Separately, a `6h` sweep
+(`PRESENCE_MAX_AGE`) deletes genuinely abandoned presence files at plugin
+`load()` — the only true forgetting, unrelated to (and much looser than)
+the 90s stale threshold.
 
 **Own session name.** Zellij's `Event::ModeUpdate` carries
 `ModeInfo.session_name`; the plugin already subscribes to `ModeUpdate` for
@@ -539,35 +546,54 @@ so a sidebar with no session-manager pane running never sees peers via that
 event at all. Polling `get_session_list()` from the plugin to force it would
 reintroduce exactly the blocking-host-query shape the whole plugin exists to
 avoid (`smart-tabs-postmortem.md`). The fix (task-8b) drops `SessionUpdate`
-entirely: liveness is derived purely from the presence files' own mtimes
-(`PRESENCE_LIVE_TTL`), and the session's own name arrives push-style via
-`Event::ModeUpdate` instead of a session-list lookup. Net effect: presence is
-entirely peer-published and liveness is entirely mtime-based — whatever a
-Fast-cadence directory read hands back, filtered only by `PRESENCE_LIVE_TTL`,
-IS the live peer set for that tick. No membership roster to keep in sync with
-a second signal, no `get_session_list` call anywhere in the plugin.
+entirely: liveness is derived purely from the presence files' own mtimes,
+and the session's own name arrives push-style via `Event::ModeUpdate`
+instead of a session-list lookup. Net effect: presence is entirely
+peer-published and liveness is entirely mtime-based — whatever a
+Fast-cadence directory read hands back IS the peer set for that tick, every
+member forever (task-14 dropped the read-time filter too); staleness is a
+display/cycle-eligibility state derived from that same mtime, not a
+membership filter. No membership roster to keep in sync with a second
+signal, no `get_session_list` call anywhere in the plugin.
 
 **Badge.** `Sessions::badge()` (pure, re-derived on every call — never
 cached, so it can't drift from `peers`/`own`) renders **zero lines** while
-only the current session's presence is known; from 2+ sessions on, one line
-per session in a single fixed order shared with cycling: current session
-first, then any peer with `attention > 0` by name, then the rest by name.
-Each line shows the session name plus a running count and an attention count
-when nonzero, using the same glyphs the per-tab rows use for those statuses.
-The current line is marked (dimmed, a small `•`) and carries no click
-target — you can't switch to the session you're already in. A pending cycle
-selection renders bold+accent. Clicking any other line switches to that
-session, landing on its `attention_tab_position` if it has one.
+only the current session's presence is known (a lone fresh own-entry plus
+only stale peers still clears that threshold — task-14: the roster's whole
+point is remembering); from 2+ entries on, one line per session in a single
+fixed order shared with cycling: current session first, then any FRESH peer
+with `attention > 0` by name, then the rest of the fresh peers by name, then
+every STALE peer by name (a stale peer's attention count isn't actionable,
+so staleness outranks attention for ordering). Each line shows the session
+name plus a running count and an attention count when nonzero, using the
+same glyphs the per-tab rows use for those statuses. The current line is
+marked (dimmed, a small `•`) and carries no click target — you can't switch
+to the session you're already in. A pending cycle selection renders
+bold+accent; a stale entry renders one step dimmer than the ordinary muted
+line color, but stays fully clickable — a click on it is a deliberate act.
+Clicking any other line switches to that session, landing on its
+`attention_tab_position` if it has one.
 
 **Cycling.** `session-next`/`session-prev`, delivered on the `zj_radar.cmd.v1`
 pipe (documented for operators in `docs/configuration.md`), advance a
 highlighted selection through that same shared order, wrapping, with the
-current session included as a normal stop. A tap only moves the highlight
-(`Sessions::cycle`) — the actual switch is a later **idle-commit**: the first
-Fast tick after roughly a second with no further tap (`Sessions::tick`,
-re-resolved by the selected session's *name*, never a remembered list
-position, so a peer joining or leaving mid-cycle can't silently retarget the
-selection). Landing the commit back on the current session is the cancel
+current session included as a normal stop and every STALE peer excluded
+entirely (task-14: switching onto a likely-dead session would have Zellij
+resurrect it as an empty zombie pane). A tap only moves the highlight
+(`Sessions::cycle`, which arms a per-selection "a tap landed" flag) — the
+actual switch is a later **idle-commit**: `Sessions::tick` runs on every
+timer fire while a selection is pending, and a fire whose covered interval
+saw a tap (the flag is set) clears it and skips, resetting the deadline;
+only a fire whose entire interval was tap-free commits. This guarantees a
+commit at least one full quiet interval after the LAST tap, at the cost of
+at most one extra (skipped) fire — replacing an earlier tick-counter
+comparison that could commit instantly on a tap landing just before an
+already-scheduled fire, or stall at the first tap in a fast burst instead of
+the last. The commit target is re-resolved by the selected session's *name*,
+never a remembered list position, so a peer joining, leaving, or going
+stale mid-cycle can't silently retarget the selection (a selection that
+lapsed into staleness before its commit is dropped, the same as a vanished
+one). Landing the commit back on the current session is the cancel
 gesture — no effect, selection just clears. A real commit emits
 `Effect::SwitchSession { name, tab_position }`, which switches sessions and,
 when the target had an `attention_tab_position`, jumps straight to it;

--- a/docs/design.md
+++ b/docs/design.md
@@ -453,7 +453,10 @@ v1 = through Phase 3. Phase 1 alone is already a usable sidebar.
 
 ## 12. Out of scope (follow-ups)
 
-- Floating cross-session **dashboard** overlay (`MOD+a`).
+- Floating cross-session **dashboard** overlay (`MOD+a`). Distinct from the
+  inline cross-session **badge** shipped in §13 — the badge is a few
+  additional lines in the existing rail, not a separate panel; the floating
+  dashboard non-goal stands unchanged.
 - **Aider** (and other) adapters; richer **Codex** lifecycle (running/pending) via a wrapper.
 - Collapse-to-strip toggle; per-pane breakdown within a multi-agent tab.
 - Moving notification logic into the plugin. **Update:** the plugin now owns OS desktop
@@ -480,3 +483,99 @@ v1 = through Phase 3. Phase 1 alone is already a usable sidebar.
   pane, approving it there, then starting the per-tab sidebar layout.
 - **Horizontal/compact bar mode** (top-level pane like zjstatus, no nesting, no #3247) — would
   need a from-scratch compact renderer; `render.rs` is vertical/card-per-tab today.
+
+## 13. Cross-session badge & session cycling
+
+Cross-session awareness — one session's rail showing counts for every other
+zj-radar session on the same host, with click/cycle-to-switch — added
+without ever calling Zellij's session list. Pure state in `sessions.rs`
+(`Sessions`/`Presence`), file IO in `session_files.rs`, wiring in
+`runtime.rs`; render in `render.rs::render_session_badge`.
+
+**Presence files.** Each session's plugin writes
+`zj-radar.presence.<zellij_pid>.json` — `{session_name, running, attention,
+attention_tab_position, updated_epoch_s}` — into the same plugin-URL-scoped
+`/cache` root persistence already uses (§5's "Newcomer rehydration"; same
+temp-file + atomic-rename write discipline). Writes are content-edge-gated:
+`project` diffs the freshly computed `Presence` against the last one
+actually published, with `updated_epoch_s` zeroed out of the compare (the
+same "write on edges only" rule `PersistSnapshot` follows) — so the clock
+ticking alone on an unchanged session never re-writes the file. Withheld
+entirely while `own_session_name` is empty (see below), since an unnamed
+presence file is useless to a peer.
+
+**Liveness heartbeat + TTL.** Peers never call `SessionUpdate`/
+`get_session_list` to learn who's out there (see "Why not `SessionUpdate`"
+below) — liveness is read from the filesystem, not asked for. Peer sessions
+re-read the shared directory only on Fast (1 Hz) timer fires
+(`Effect::ReadPresences`; never on the Slow heartbeat — one directory scan
+per second, only while Fast is armed), and a presence file whose mtime is
+older than `PRESENCE_LIVE_TTL` (180s) is treated as belonging to a dead
+session: its row is skipped, not deleted — a reader only ever judges a
+peer's file, never mutates it. That TTL only bites a session with nothing to
+report: because `PersistPresence` is content-edge-gated, a session sitting
+fully idle (no Fast-cadence work, no count change) would otherwise let its
+file's mtime age past 180s and silently vanish from every peer's badge while
+still alive. The fix is a **liveness heartbeat**: `timer` unconditionally
+re-emits `PersistPresence` on every Slow (60s) fire, bypassing the edge gate,
+purely to keep the mtime fresh. Separately, a `6h` sweep (`PRESENCE_MAX_AGE`)
+deletes genuinely abandoned presence files at plugin `load()` — debris
+cleanup, unrelated to (and much looser than) the 180s liveness TTL.
+
+**Own session name.** Zellij's `Event::ModeUpdate` carries
+`ModeInfo.session_name`; the plugin already subscribes to `ModeUpdate` for
+other reasons, and `session_name_changed` threads the field straight into
+`own_session_name`. This is push-style and can legitimately arrive `None`
+before Zellij has assigned the session a name yet — handled as a true no-op,
+not an error.
+
+**Why not `SessionUpdate` (or `get_session_list`).** An earlier iteration of
+this feature subscribed to `Event::SessionUpdate` and cross-checked a peer
+roster against presence files to decide who's live. E2E testing against real
+Zellij 0.44.3 proved the roster idea itself was broken: `SessionUpdate` only
+delivers peers after some plugin has called the blocking `get_session_list()`
+host function (in practice, only the built-in session-manager plugin does) —
+so a sidebar with no session-manager pane running never sees peers via that
+event at all. Polling `get_session_list()` from the plugin to force it would
+reintroduce exactly the blocking-host-query shape the whole plugin exists to
+avoid (`smart-tabs-postmortem.md`). The fix (task-8b) drops `SessionUpdate`
+entirely: liveness is derived purely from the presence files' own mtimes
+(`PRESENCE_LIVE_TTL`), and the session's own name arrives push-style via
+`Event::ModeUpdate` instead of a session-list lookup. Net effect: presence is
+entirely peer-published and liveness is entirely mtime-based — whatever a
+Fast-cadence directory read hands back, filtered only by `PRESENCE_LIVE_TTL`,
+IS the live peer set for that tick. No membership roster to keep in sync with
+a second signal, no `get_session_list` call anywhere in the plugin.
+
+**Badge.** `Sessions::badge()` (pure, re-derived on every call — never
+cached, so it can't drift from `peers`/`own`) renders **zero lines** while
+only the current session's presence is known; from 2+ sessions on, one line
+per session in a single fixed order shared with cycling: current session
+first, then any peer with `attention > 0` by name, then the rest by name.
+Each line shows the session name plus a running count and an attention count
+when nonzero, using the same glyphs the per-tab rows use for those statuses.
+The current line is marked (dimmed, a small `•`) and carries no click
+target — you can't switch to the session you're already in. A pending cycle
+selection renders bold+accent. Clicking any other line switches to that
+session, landing on its `attention_tab_position` if it has one.
+
+**Cycling.** `session-next`/`session-prev`, delivered on the `zj_radar.cmd.v1`
+pipe (documented for operators in `docs/configuration.md`), advance a
+highlighted selection through that same shared order, wrapping, with the
+current session included as a normal stop. A tap only moves the highlight
+(`Sessions::cycle`) — the actual switch is a later **idle-commit**: the first
+Fast tick after roughly a second with no further tap (`Sessions::tick`,
+re-resolved by the selected session's *name*, never a remembered list
+position, so a peer joining or leaving mid-cycle can't silently retarget the
+selection). Landing the commit back on the current session is the cancel
+gesture — no effect, selection just clears. A real commit emits
+`Effect::SwitchSession { name, tab_position }`, which switches sessions and,
+when the target had an `attention_tab_position`, jumps straight to it;
+otherwise it leaves Zellij to restore that session's last focus.
+
+**Degradation.** No writable shared cache root (`SessionFiles` falls back to
+`/tmp/zj-radar`, or disables persistence altogether when neither is
+writable) means no presence file is ever written and no peer reads happen —
+the badge simply never appears. Every other rail behavior (status, ledger,
+naming, notifications) is unaffected, exactly as persistence being
+unavailable degrades only snapshot rehydration, never live rendering (§5).

--- a/docs/producers.md
+++ b/docs/producers.md
@@ -133,6 +133,11 @@ name, never `--plugin`) a `zj_radar.status.v1` message:
 - `task` (optional, sent only on `UserPromptSubmit`): sticky task label —
   empty/absent leaves the stored label unchanged, non-empty replaces it; the
   plugin clears it on idle and on return-to-shell.
+- `ack` (optional, default `false`): "the user has already seen this status" —
+  the plugin converges state as usual but never fires a desktop notification
+  for it. Set by the rail's own right-click acknowledge broadcast; producers
+  reporting real events should leave it absent (an acknowledged `done` would
+  otherwise skip the completion notification the user wanted).
 - Unknown fields are ignored, so it's safe to send extras. (A former `on_focus`
   clear-on-focus hint is no longer used — the plugin clears a finished status when
   the pane returns to its shell prompt instead — but sending it does no harm.)


### PR DESCRIPTION
Implements #4, fixes #5 — cross-session radar: a per-session badge in the rail plus `session-next`/`session-prev` cycling that switches sessions.

## What you get

With two or more radar-running sessions, the rail grows one line per session (current first, then attention-bearing by name, then the rest): name, running count, attention count. Clicking a peer line — or tapping `session-next` (suggested `Alt s`) to cycle the highlight and pausing ~1s — switches to that session, landing on its attention tab when it has one, else last focus. Solo sessions see nothing: zero badge lines, zero behavior change.

## Two deliberate divergences from the issue spec

1. **Liveness is presence-file mtime + heartbeat, not `Event::SessionUpdate`.** During e2e it turned out 0.44.3 only populates SessionUpdate's peer list when a plugin calls the blocking `get_session_list()` — which only the built-in session-manager ever does. Polling it from the rail would be exactly the pattern this repo's postmortem bans, so instead: each session's rail writes `zj-radar.presence.<zellij_pid>.json` into the shared plugin `/cache` (content edges only, timestamp excluded from the edge compare, plus a ≤1/min heartbeat re-write on Slow fires); peers read the directory on Fast fires and treat files older than 180s as dead. Own session name arrives push-style via `ModeUpdate`. No polling anywhere.
2. **Idle-commit is ~1s, not the issue's ~700ms** — the plugin timer floor is `Cadence::Fast` = 1.0s and `TimerChain`'s stale-fire discrimination forbids sub-second cadences; the first Fast tick after the last tap commits.

Known bound worth stating plainly: a rail idling on Slow cadence refreshes its *view* of peers at most once per minute (reads are Fast-gated by design); its own liveness heartbeat continues regardless.

## Wire/compat

New cmd-pipe verbs `session-next`/`session-prev` (documented in configuration.md, guard-tested). `zj_radar.status.v1` untouched. No new permissions. Degrades to invisible when the shared cache root is unavailable, same as snapshots.

## Tests

- 454 host tests (unit/insta/proptest/lockstep/reference), incl. mutation-verified pins for the cycle state machine (identity-tracked selection survives mid-cycle reordering; restart-after-vanish discriminates from index-fallback; presence edge-gating ignores timestamp churn; heartbeat+edge coincidence dedupes to one write).
- e2e: 12/12 including a new two-session test (`start_sibling` harness support) — pending in session B shows in A's badge, `session-next` + idle commit reattaches A's client onto B, verified via ZPID markers. This test is also what caught the SessionUpdate reality.
- `just ci` fully green (host suites, clippy `-D warnings`, wasm build, 60 bats).

Single-session rail output is byte-identical (no insta snapshot or rail-reference changes).


## Post-review additions (live dogfooding on a 5-session setup)

- **Liveness fix:** `desired_cadence` could fully disarm on an idle session, freezing the presence heartbeat — after the 180s mtime TTL an alive-but-idle session vanished from every peer's badge (observed live: 18+ min frozen). Named sessions now hold the Slow (60s) cadence so the heartbeat always runs; full disarm remains only for pre-name and permission-denied rails. Pinned by `saturated_history_with_known_name_keeps_slow_armed_for_the_heartbeat`.
- **UX:** blank separator line between the session badge and the tab rows (Lockstep-clean; single-session output stays byte-identical).

Field notes from the same dogfooding, deliberately NOT in this PR (follow-up issue coming): `start-or-reload-plugin` identity/config matching makes a CLI-driven fleet upgrade path subtle (raw `file:` path vs alias spawns strays), and zellij 0.44.3's reload path both refuses client-less sessions silently and leaves un-cleaned pending state behind (event starvation + orphaned loading animation) — the latter looks like an upstream zellij bug.


## Second dogfooding round (multi-session daily use)

- **Badge dedup:** presence is pid-keyed on disk, so a killed-and-recreated session coexisted with its corpse — same name rendered 2-4×. Entries now dedupe by name, freshest `updated_epoch_s` wins.
- **Cycle commit felt wrong in the hand:** tick-counter deadlines meant a tap landing just before a scheduled fire committed instantly, and rapid taps didn't extend the deadline. Commits now require one fully tap-free timer interval (`taps_since_last_fire`), i.e. ≥1s after the *last* tap.
- **Roster instead of TTL eviction (design change):** silently dropping a session from the badge proved wrong in practice — a stale-but-remembered session read as data loss, and cycling into a just-dead ghost made `switch_session` resurrect it as an empty zombie. Presence entries now *never* vanish on staleness: >90s without a heartbeat dims the entry and removes it from Alt-s cycling (clicks still work, deliberately); only the 6h sweep forgets. Timer-chain re-arming across cadence transitions is additionally pinned by deterministic fire-simulations + a proptest after a suspected stall proved unreproducible host-side.

- **Right-click dismisses a stale entry** — the manual complement to the 6h sweep: deletes every pid-keyed corpse file for that name, no-op on fresh/own entries (staleness re-checked against live state at click time, not render time), and non-destructive by construction — a dismissed-but-actually-alive session republishes on its next heartbeat and simply reappears.

- **Right-click acknowledges a pending pane (fixes #5):** a completed turn ending in a courtesy question no longer pins "need you" forever — right-click the row (or the tab row for all its panes) and the pending downgrades to done via a synthetic status broadcast through the normal pipe intake; no local clears, all instances converge. See #5 for the full design discussion.
