### PR TITLE
fix: clickable glyphs replace unreachable right-click, agent-level counts, no false running expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A native [Zellij](https://zellij.dev) **sidebar** that shows live AI-agent
 status for every tab — *working*, *waiting for you*, *done*, or *error* — with
 repo·branch, elapsed time, and the last message. Click a row to jump to that
-tab; right-click to acknowledge — a pane still flagged "needs you" after
-you've already seen it, or a dead peer session (details below).
+tab; use its right-edge glyph to acknowledge a pane still flagged "needs you"
+or dismiss a dead peer session (details below).
 
 <p align="center">
   <a href="https://github.com/marktoda/zj-radar/actions/workflows/ci.yml">
@@ -138,7 +138,7 @@ session.
 
 A session that stops heartbeating dims rather than disappearing, so a
 crashed machine or killed server never silently drops off your radar.
-Right-click a dimmed entry to dismiss it immediately — the manual
+Click the dimmed entry's right-edge `✕` to dismiss it immediately — the manual
 complement to the automatic sweep, for a session you already know is dead.
 Dismissing is never destructive: if the session turns out to be alive, its
 next heartbeat simply brings it back, fresh.
@@ -149,10 +149,9 @@ never appears and nothing else about the sidebar is affected.
 
 ### Mouse gestures
 
-The rail follows one rule everywhere: **left-click navigates, right-click
-acknowledges.** Left-click always just switches — to a tab, a pane, or (as
-above) a peer session, landing on its attention tab. Right-click means "I've
-seen this, stop flagging it" and does one of two things depending on the row:
+The rail uses right-edge action glyphs: **left-click navigates everywhere
+except a glyph cell.** `✓` means "I've seen this, stop flagging it"; `✕`
+dismisses a stale peer. The glyph action does one of two things:
 
 - **A dimmed peer session** (above) — dismiss it from the badge; alive-but-quiet
   sessions simply reappear on their next heartbeat.
@@ -165,8 +164,8 @@ seen this, stop flagging it" and does one of two things depending on the row:
   me to also...?") — a genuinely blocking question still clears the usual way,
   by you typing a reply.
 
-Right-clicking anything else — a fresh peer, your own session's line, a row
-with nothing pending — is a no-op.
+Right-click retains these same row-wide actions for future parity, but Zellij
+currently does not deliver right-clicks to plugins ([zellij#5350](https://github.com/zellij-org/zellij/issues/5350)); glyphs are the working trigger.
 
 ## How is this different?
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ wrapping your agents. It's a status rail for the session you already run.
 - Works with **Claude Code** today, **Codex** via the native CLI, and any
   [custom producer](https://github.com/marktoda/zj-radar/blob/main/docs/producers.md#writing-your-own-producer) that can send JSON.
 - Running more than one Zellij session? A **cross-session badge** shows every
-  other session's running/attention counts, with click-to-switch and a
+  other session's live status-origin pane counts, with click-to-switch and a
   `session-next`/`session-prev` cycle — see below.
 
 ## Quick start
@@ -125,8 +125,11 @@ per project) and each session's rail quietly publishes its own counts for
 the others to see — no setup needed. Once a second session is live, every
 rail grows a line per session: current session first, then any session that
 needs your attention, then the rest — name plus running/attention counts.
-With just one session running, the badge renders nothing; the feature stays
-invisible until there's genuinely something cross-session to show.
+Those badge counts are live pane counts from status producers only: command
+activity is excluded, while the local rail rows, header badge, and footer tally
+deliberately remain tab-level summaries. With just one session running, the
+badge renders nothing; the feature stays invisible until there's genuinely
+something cross-session to show.
 
 Click a peer's line to switch straight to that session (landing on its
 attention tab, if it has one). Or cycle the highlight with `session-next` /

--- a/crates/core/src/command.rs
+++ b/crates/core/src/command.rs
@@ -450,10 +450,11 @@ fn effective_program(command: &[String]) -> (&[String], &str) {
 
 /// Whether a `CommandChanged` means the pane is back at a shell prompt rather
 /// than running something we (or an agent) own. This is deliberately strong
-/// evidence only: a foreground shell/prompt program (`IGNORE_NAMES`). A false
-/// `is_foreground` or unclassifiable argv can occur during a live agent's
-/// wrapper/child transition, so it must never start the pushed Running grace
-/// clock. The accepted trade-off is a killed agent can ghost until its next real
+/// evidence only: a foreground shell/prompt program (`IGNORE_NAMES`). The pinned
+/// weak-signal regression is a hypothesized field sequence, not live telemetry;
+/// the policy is still required because it removes the whole false-expiry class
+/// where weak evidence starts the pushed Running grace clock. The accepted
+/// trade-off is a killed agent can ghost until its next real
 /// prompt/pipe/exit/prune signal; bounded ghosts beat killing live work.
 pub fn is_shell_prompt(command: &[String], is_foreground: bool) -> bool {
     if !is_foreground {

--- a/crates/core/src/command.rs
+++ b/crates/core/src/command.rs
@@ -449,13 +449,15 @@ fn effective_program(command: &[String]) -> (&[String], &str) {
 }
 
 /// Whether a `CommandChanged` means the pane is back at a shell prompt rather
-/// than running something we (or an agent) own. True when there is no foreground
-/// command, or the foreground is a shell/prompt program (`IGNORE_NAMES`). An
-/// agent (`AGENT_NAMES`) in the foreground is deliberately NOT "at the prompt" —
-/// the agent still owns the pane and drives it via the push pipe.
+/// than running something we (or an agent) own. This is deliberately strong
+/// evidence only: a foreground shell/prompt program (`IGNORE_NAMES`). A false
+/// `is_foreground` or unclassifiable argv can occur during a live agent's
+/// wrapper/child transition, so it must never start the pushed Running grace
+/// clock. The accepted trade-off is a killed agent can ghost until its next real
+/// prompt/pipe/exit/prune signal; bounded ghosts beat killing live work.
 pub fn is_shell_prompt(command: &[String], is_foreground: bool) -> bool {
     if !is_foreground {
-        return true;
+        return false;
     }
     let (_, name) = effective_program(command);
     IGNORE_NAMES.contains(&name)

--- a/crates/core/src/command.rs
+++ b/crates/core/src/command.rs
@@ -449,24 +449,25 @@ fn effective_program(command: &[String]) -> (&[String], &str) {
 }
 
 /// Whether a `CommandChanged` means the pane is back at a shell prompt rather
-/// than running something we (or an agent) own. Zellij reports the pane's root
-/// shell with `is_foreground=false` when it has no child, so a recognized shell
-/// name is the prompt signal regardless of that flag. A non-shell argv with
-/// `is_foreground=false` is only a wrapper/child transition and must not arm the
-/// pushed-Running grace clock.
-pub fn is_shell_prompt(command: &[String], _is_foreground: bool) -> bool {
+/// than running something we (or an agent) own. Zellij's `is_foreground` flag
+/// is deliberately not a parameter: it only encodes "the root has a child" (a
+/// childless root shell reports `false`), so shell identity alone is the
+/// prompt signal, and a non-shell argv — whatever the flag says — is only a
+/// wrapper/child transition that must not arm the pushed-Running grace clock.
+pub fn is_shell_prompt(command: &[String]) -> bool {
     let (_, name) = effective_program(command);
     IGNORE_NAMES.contains(&name)
 }
 
-/// Whether an instrumented agent (`AGENT_NAMES`) itself is the pane's live
-/// foreground command — direct evidence the pushed status's producer is still
-/// running. Used to cancel the stale-Running grace clock after a mid-turn
-/// foreground flicker resolves back to the agent.
-pub fn is_agent_foreground(command: &[String], is_foreground: bool) -> bool {
-    if !is_foreground {
-        return false;
-    }
+/// Whether an instrumented agent (`AGENT_NAMES`) is the pane's live command —
+/// direct evidence the pushed status's producer is still running. Used to
+/// cancel the stale-Running grace clock after a mid-turn foreground flicker
+/// resolves back to the agent. Like `is_shell_prompt`, the foreground flag is
+/// deliberately not consulted: a childless agent ROOT (`zellij run -- claude`,
+/// between tool children) reports `is_foreground=false`, and that report is
+/// the agent alive, not absent. A DEAD root never leaks through here — the
+/// pane manifest's `exited` flag clears its status directly.
+pub fn is_agent_command(command: &[String]) -> bool {
     let (_, name) = effective_program(command);
     AGENT_NAMES.contains(&name)
 }

--- a/crates/core/src/command.rs
+++ b/crates/core/src/command.rs
@@ -449,17 +449,12 @@ fn effective_program(command: &[String]) -> (&[String], &str) {
 }
 
 /// Whether a `CommandChanged` means the pane is back at a shell prompt rather
-/// than running something we (or an agent) own. This is deliberately strong
-/// evidence only: a foreground shell/prompt program (`IGNORE_NAMES`). The pinned
-/// weak-signal regression is a hypothesized field sequence, not live telemetry;
-/// the policy is still required because it removes the whole false-expiry class
-/// where weak evidence starts the pushed Running grace clock. The accepted
-/// trade-off is a killed agent can ghost until its next real
-/// prompt/pipe/exit/prune signal; bounded ghosts beat killing live work.
-pub fn is_shell_prompt(command: &[String], is_foreground: bool) -> bool {
-    if !is_foreground {
-        return false;
-    }
+/// than running something we (or an agent) own. Zellij reports the pane's root
+/// shell with `is_foreground=false` when it has no child, so a recognized shell
+/// name is the prompt signal regardless of that flag. A non-shell argv with
+/// `is_foreground=false` is only a wrapper/child transition and must not arm the
+/// pushed-Running grace clock.
+pub fn is_shell_prompt(command: &[String], _is_foreground: bool) -> bool {
     let (_, name) = effective_program(command);
     IGNORE_NAMES.contains(&name)
 }

--- a/crates/core/src/command/tests.rs
+++ b/crates/core/src/command/tests.rs
@@ -10,8 +10,10 @@
         assert!(is_shell_prompt(&argv(&["zsh"]), true));
         assert!(is_shell_prompt(&argv(&["/bin/bash"]), true));
         assert!(is_shell_prompt(&argv(&["fish"]), true));
-        // No foreground command at all = at the prompt.
-        assert!(is_shell_prompt(&argv(&["anything"]), false));
+        // A missing foreground signal is weak evidence: wrapper/child
+        // transitions can report it during a live agent turn, so it never
+        // starts the pushed Running grace clock.
+        assert!(!is_shell_prompt(&argv(&["anything"]), false));
         // An agent in the foreground still owns the pane — NOT the prompt.
         assert!(!is_shell_prompt(&argv(&["claude"]), true));
         assert!(!is_shell_prompt(&argv(&["codex"]), true));
@@ -1083,4 +1085,3 @@
         s.on_timer(Tick(DEBOUNCE_TICKS), EpochSecs(100));
         assert_eq!(s.get(1).unwrap().status, Status::Running, "documented failure mode");
     }
-

--- a/crates/core/src/command/tests.rs
+++ b/crates/core/src/command/tests.rs
@@ -6,24 +6,23 @@
 
     #[test]
     fn is_shell_prompt_detects_return_to_prompt_not_agents_or_commands() {
-        // Zellij reports the childless root shell with is_foreground=false;
-        // both forms are shell identity and therefore prompt evidence.
-        assert!(is_shell_prompt(&argv(&["zsh"]), true));
-        assert!(is_shell_prompt(&argv(&["zsh"]), false));
-        assert!(is_shell_prompt(&argv(&["/bin/bash"]), true));
-        assert!(is_shell_prompt(&argv(&["fish"]), true));
-        // A missing foreground signal is weak evidence: wrapper/child
-        // transitions can report it during a live agent turn, so it never
-        // starts the pushed Running grace clock.
-        assert!(!is_shell_prompt(&argv(&["anything"]), false));
-        // An agent in the foreground still owns the pane — NOT the prompt.
-        assert!(!is_shell_prompt(&argv(&["claude"]), true));
-        assert!(!is_shell_prompt(&argv(&["codex"]), true));
-        // A real foreground command is not the prompt.
-        assert!(!is_shell_prompt(&argv(&["cargo", "test"]), true));
+        // Shell identity alone is the prompt signal (Zellij's foreground flag
+        // only encodes "root has a child", so it carries no evidence here).
+        assert!(is_shell_prompt(&argv(&["zsh"])));
+        assert!(is_shell_prompt(&argv(&["/bin/bash"])));
+        assert!(is_shell_prompt(&argv(&["fish"])));
+        // A non-shell argv is never the prompt, whatever the flag said:
+        // wrapper/child transitions report during a live agent turn, so they
+        // must never start the pushed Running grace clock.
+        assert!(!is_shell_prompt(&argv(&["anything"])));
+        // An agent still owns the pane — NOT the prompt.
+        assert!(!is_shell_prompt(&argv(&["claude"])));
+        assert!(!is_shell_prompt(&argv(&["codex"])));
+        // A real command is not the prompt.
+        assert!(!is_shell_prompt(&argv(&["cargo", "test"])));
         // Env/wrapper prefixes are peeled before classifying.
-        assert!(is_shell_prompt(&argv(&["env", "FOO=1", "zsh"]), true));
-        assert!(!is_shell_prompt(&argv(&["sudo", "make"]), true));
+        assert!(is_shell_prompt(&argv(&["env", "FOO=1", "zsh"])));
+        assert!(!is_shell_prompt(&argv(&["sudo", "make"])));
     }
 
     #[test]
@@ -32,30 +31,32 @@
         // perpetual Running command AND broke the agent exit-clear (the two
         // degradations documented on IGNORE_NAMES).
         for shell in ["nu", "nushell", "pwsh", "tcsh", "csh", "ksh", "mksh", "ash", "elvish", "xonsh"] {
-            assert!(is_shell_prompt(&argv(&[shell]), true), "{shell} is a prompt");
-            assert!(is_shell_prompt(&argv(&[shell]), false), "childless {shell} root is a prompt");
+            assert!(is_shell_prompt(&argv(&[shell])), "{shell} is a prompt");
         }
         // A login shell's argv0 carries a leading dash.
-        assert!(is_shell_prompt(&argv(&["-zsh"]), true));
-        assert!(is_shell_prompt(&argv(&["-bash"]), true));
+        assert!(is_shell_prompt(&argv(&["-zsh"])));
+        assert!(is_shell_prompt(&argv(&["-bash"])));
         // The dash-strip must not misread ordinary dashed commands as shells:
         // there is no binary named e.g. `-nu` in practice, but a real command
         // with a dashed basename stays a command.
-        assert!(!is_shell_prompt(&argv(&["my-tool"]), true));
+        assert!(!is_shell_prompt(&argv(&["my-tool"])));
     }
 
     #[test]
-    fn is_agent_foreground_detects_only_a_live_foreground_agent() {
-        // The agent's own exe in the foreground vouches for the pushed status.
-        assert!(is_agent_foreground(&argv(&["claude"]), true));
-        assert!(is_agent_foreground(&argv(&["codex"]), true));
+    fn is_agent_command_detects_a_live_agent() {
+        // The agent's own exe as the pane's command vouches for the pushed
+        // status — whether a foreground child under a shell root or the
+        // childless pane root itself (`zellij run -- claude` between tool
+        // children); Zellij's foreground flag distinguishes only those two
+        // shapes, so it carries no evidence and is not a parameter.
+        assert!(is_agent_command(&argv(&["claude"])));
+        assert!(is_agent_command(&argv(&["codex"])));
         // Env/wrapper prefixes are peeled, mirroring is_shell_prompt.
-        assert!(is_agent_foreground(&argv(&["env", "FOO=1", "claude"]), true));
-        // Background, shells, ordinary commands, and nothing don't vouch.
-        assert!(!is_agent_foreground(&argv(&["claude"]), false));
-        assert!(!is_agent_foreground(&argv(&["zsh"]), true));
-        assert!(!is_agent_foreground(&argv(&["vim"]), true));
-        assert!(!is_agent_foreground(&argv(&[]), true));
+        assert!(is_agent_command(&argv(&["env", "FOO=1", "claude"])));
+        // Shells, ordinary commands, and nothing don't vouch.
+        assert!(!is_agent_command(&argv(&["zsh"])));
+        assert!(!is_agent_command(&argv(&["vim"])));
+        assert!(!is_agent_command(&argv(&[])));
     }
 
     /// Test shorthand for the display half of `classify`.

--- a/crates/core/src/command/tests.rs
+++ b/crates/core/src/command/tests.rs
@@ -6,8 +6,10 @@
 
     #[test]
     fn is_shell_prompt_detects_return_to_prompt_not_agents_or_commands() {
-        // A shell/prompt program in the foreground = back at the prompt.
+        // Zellij reports the childless root shell with is_foreground=false;
+        // both forms are shell identity and therefore prompt evidence.
         assert!(is_shell_prompt(&argv(&["zsh"]), true));
+        assert!(is_shell_prompt(&argv(&["zsh"]), false));
         assert!(is_shell_prompt(&argv(&["/bin/bash"]), true));
         assert!(is_shell_prompt(&argv(&["fish"]), true));
         // A missing foreground signal is weak evidence: wrapper/child
@@ -31,6 +33,7 @@
         // degradations documented on IGNORE_NAMES).
         for shell in ["nu", "nushell", "pwsh", "tcsh", "csh", "ksh", "mksh", "ash", "elvish", "xonsh"] {
             assert!(is_shell_prompt(&argv(&[shell]), true), "{shell} is a prompt");
+            assert!(is_shell_prompt(&argv(&[shell]), false), "childless {shell} root is a prompt");
         }
         // A login shell's argv0 carries a leading dash.
         assert!(is_shell_prompt(&argv(&["-zsh"]), true));

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -420,12 +420,15 @@ impl ZellijPlugin for State {
                 let outcome = self.runtime.timer(probe, elapsed_s);
                 self.handle_outcome(outcome)
             }
-            Event::Mouse(Mouse::LeftClick(line, _col)) => {
-                let outcome = self.runtime.mouse_click(line);
+            Event::Mouse(Mouse::LeftClick(line, col)) => {
+                // Zellij reports zero-based terminal display-cell offsets; the
+                // e2e SGR helper deliberately converts its one-based screen
+                // coordinates before this reaches the runtime.
+                let outcome = self.runtime.mouse_click(line, col as usize);
                 self.handle_outcome(outcome)
             }
-            Event::Mouse(Mouse::RightClick(line, _col)) => {
-                let outcome = self.runtime.mouse_right_click(line);
+            Event::Mouse(Mouse::RightClick(line, col)) => {
+                let outcome = self.runtime.mouse_right_click(line, col as usize);
                 self.handle_outcome(outcome)
             }
             Event::PermissionRequestResult(status) => {
@@ -1241,7 +1244,7 @@ mod tests {
         state.runtime.permission = crate::permission::PermissionState::Resolved { granted: true };
         let _ = state.runtime.render(100, 80);
         // line 2 is the first tab content row (lines 0-1 are the header)
-        let outcome = state.runtime.mouse_click(2);
+        let outcome = state.runtime.mouse_click(2, 0);
         assert_eq!(outcome.effects, vec![Effect::SwitchTab { position: 0 }]);
     }
 
@@ -1250,7 +1253,7 @@ mod tests {
         let mut state = make_state_with_tabs(&[(0, "first", false), (1, "second", false)]);
         state.runtime.permission = crate::permission::PermissionState::default();
         let _ = state.runtime.render(100, 80);
-        assert!(state.runtime.mouse_click(2).effects.is_empty());
+        assert!(state.runtime.mouse_click(2, 0).effects.is_empty());
     }
 
     // ── Click round-trip proptest ──

--- a/crates/plugin/src/radar_state.rs
+++ b/crates/plugin/src/radar_state.rs
@@ -368,6 +368,14 @@ impl RadarState {
                 self.ledger_receded(vec![(pane_id, displaced)], &old_index, &status_tracked);
                 displaced_any = true;
             }
+            // A dead pane root is definitive producer death for the pushed
+            // status too — the agent-rooted pane (`zellij run -- claude`)
+            // never returns to a shell prompt, so this flag is its only
+            // exit-clear signal (`StatusStore::clear_on_exit`).
+            if let Some(receded) = self.status.clear_on_exit(pane_id, tick) {
+                self.ledger_receded(vec![(pane_id, receded)], &old_index, &status_tracked);
+                displaced_any = true;
+            }
         }
         self.live_panes = Some(update.live.clone());
         self.tab_panes = update.tab_panes;
@@ -497,7 +505,7 @@ impl RadarState {
         // instead, so a mid-turn foreground flicker to a shell can't be
         // mistaken for the agent exiting, while an agent killed mid-turn still
         // expires to idle on the timer (`expire_stale_running`).
-        let cleared = if crate::command::is_shell_prompt(command, is_foreground) {
+        let cleared = if crate::command::is_shell_prompt(command) {
             match self.status.clear_on_prompt_return(pane_id, tick) {
                 Some(receded) => {
                     // Status-origin recede: the shadow filter never suppresses
@@ -508,11 +516,11 @@ impl RadarState {
                 None => false,
             }
         } else {
-            // The agent's exe back in the foreground resolves a mid-turn
+            // The agent's exe back as the pane's command resolves a mid-turn
             // flicker: cancel any stale-Running grace clock the shell blip
-            // started. Other foregrounds don't vouch — a command run in the
+            // started. Other commands don't vouch — a command run in the
             // shell an agent died in must not keep its ghost alive.
-            if crate::command::is_agent_foreground(command, is_foreground) {
+            if crate::command::is_agent_command(command) {
                 self.status.cancel_running_suspect(pane_id);
             }
             false

--- a/crates/plugin/src/radar_state/tests.rs
+++ b/crates/plugin/src/radar_state/tests.rs
@@ -55,6 +55,23 @@ fn command_changed_to_shell_does_not_clear_a_running_status() {
 }
 
 #[test]
+fn weak_background_command_changed_never_starts_a_running_expiry_clock() {
+    let mut radar = RadarState::default();
+    radar
+        .status_mut()
+        .apply(payload_in_repo(7, Status::Running, "pinky"), 1, 0);
+
+    // Real Zellij can report `is_foreground: false` while a long agent owns a
+    // wrapper/child process. That is not proof of a shell prompt. Letting this
+    // weak edge start the clock used to clear live work 15 ticks later.
+    radar.command_changed(7, &["node".into()], false, 5);
+    for t in 6..(6 + crate::status_store::RUNNING_SUSPECT_GRACE_TICKS + 2) {
+        radar.timer(t, 0);
+    }
+    assert_eq!(radar.status(7).unwrap().status, Status::Running);
+}
+
+#[test]
 fn pending_wait_drives_the_slow_cadence_until_saturation() {
     // The `· Nm` wait tag advances at minute granularity, so an unsaturated
     // pending row must keep the Slow heartbeat armed — and release it once

--- a/crates/plugin/src/radar_state/tests.rs
+++ b/crates/plugin/src/radar_state/tests.rs
@@ -126,6 +126,57 @@ fn agent_foreground_cancels_a_prompt_return_suspect() {
 }
 
 #[test]
+fn exited_pane_root_clears_its_pushed_status() {
+    // `zellij run -- claude`: the agent IS the pane root. When it dies (kill
+    // or normal exit) no hook fires and no shell prompt ever returns — the
+    // pane shows Zellij's EXITED banner and the manifest reports
+    // `exited: true`. That flag is definitive producer-death evidence, so the
+    // pushed status clears to idle immediately, no grace clock needed. Without
+    // this, a killed run-pane agent's Running row spins forever (the name-only
+    // `is_shell_prompt` can never fire for a non-shell root).
+    let mut radar = RadarState::default();
+    radar.tabs_changed(vec![tab(10, 0, "work", true)]);
+    radar
+        .status_mut()
+        .apply(payload_in_repo(7, Status::Running, "pinky"), 1, 0);
+    radar
+        .status_mut()
+        .apply(payload_in_repo(8, Status::Pending, "pinky"), 1, 0);
+
+    let update = PaneUpdate {
+        tab_panes: HashMap::from([(0, vec![pane(7), pane(8)])]),
+        live: HashSet::from([7, 8]),
+        theme: None,
+        exits: vec![(7, Some(130)), (8, Some(0))],
+    };
+    let change = radar.panes_changed(update, 2, 100, config::NamingMode::Off);
+
+    assert_eq!(radar.status(7).unwrap().status, Status::Idle, "dead root ⇒ Running clears");
+    assert_eq!(radar.status(8).unwrap().status, Status::Idle, "dead root ⇒ Pending clears");
+    assert!(change.persist_snapshot, "the clear is a recede edge — new tabs rehydrate idle");
+}
+
+#[test]
+fn childless_agent_root_cancels_a_prompt_return_suspect() {
+    // Agent-rooted pane between children: Zellij reports the childless root
+    // as ("claude", is_foreground=false) — the same producer-alive evidence
+    // as a foreground flicker resolving back to the agent. The grace clock
+    // must cancel, or a tool call outliving the grace window gets the live
+    // turn force-idled mid-run. (A DEAD root never needs the flag: the pane
+    // manifest's `exited` clears it directly.)
+    let mut radar = RadarState::default();
+    radar
+        .status_mut()
+        .apply(payload_in_repo(7, Status::Running, "pinky"), 1, 0);
+    radar.command_changed(7, &["bash".into()], false, 5);
+    radar.command_changed(7, &["claude".into()], false, 6);
+    for t in 7..(7 + crate::status_store::RUNNING_SUSPECT_GRACE_TICKS * 2) {
+        radar.timer(t, 0);
+    }
+    assert_eq!(radar.status(7).unwrap().status, Status::Running);
+}
+
+#[test]
 fn rows_sort_tabs_by_position_and_aggregate_panes() {
     let mut radar = RadarState::default();
     radar.tabs_changed(vec![

--- a/crates/plugin/src/radar_state/tests.rs
+++ b/crates/plugin/src/radar_state/tests.rs
@@ -30,7 +30,7 @@ fn command_changed_to_shell_clears_a_pushed_done() {
     assert_eq!(radar.status(7).unwrap().status, Status::Done);
 
     // The pane returns to a shell prompt → the producer is gone.
-    let change = radar.command_changed(7, &["zsh".into()], true, 5);
+    let change = radar.command_changed(7, &["zsh".into()], false, 5);
 
     // The stale `done` is cleared to idle, repo kept for tab naming. This rides
     // the shared CommandChanged signal, so every tab's instance clears alike.
@@ -99,7 +99,7 @@ fn killed_agent_running_row_expires_via_the_timer() {
     radar
         .status_mut()
         .apply(payload_in_repo(7, Status::Running, "pinky"), 1, 0);
-    radar.command_changed(7, &["bash".into()], true, 5);
+    radar.command_changed(7, &["bash".into()], false, 5);
     let mut changed = false;
     for t in 6..(6 + crate::status_store::RUNNING_SUSPECT_GRACE_TICKS + 2) {
         changed |= radar.timer(t, 0);
@@ -117,7 +117,7 @@ fn agent_foreground_cancels_a_prompt_return_suspect() {
     radar
         .status_mut()
         .apply(payload_in_repo(7, Status::Running, "pinky"), 1, 0);
-    radar.command_changed(7, &["bash".into()], true, 5);
+    radar.command_changed(7, &["bash".into()], false, 5);
     radar.command_changed(7, &["claude".into()], true, 6);
     for t in 7..(7 + crate::status_store::RUNNING_SUSPECT_GRACE_TICKS * 2) {
         radar.timer(t, 0);

--- a/crates/plugin/src/render.rs
+++ b/crates/plugin/src/render.rs
@@ -1494,15 +1494,18 @@ fn render_body(rows: &[TabRow], ledger: &[LedgerLine], opts: &RenderOpts) -> Vec
         let row = &rows[i];
         let row_target = target_for_row(row);
 
-        // Resolve a raw line's surface through the one `LineBg::escape` map and
-        // paint it (Cards only). The emitted line is final, so it carries
-        // `LineBg::None`; its footprint is exactly the lines pushed here.
-        let finalize = |bg: LineBg, text: String, target: Option<RailTarget>, hotspot: Option<(usize, HotspotAction)>| -> Line {
-            let text = match bg.escape(row, &opts.theme, &rail) {
-                Some(esc) if cards => paint_card_line(&text, width, &esc),
-                _ => text,
+        // Resolve a raw line's surface through the one `LineBg::escape` map by
+        // consuming the complete `Line`. Metadata such as targets and hotspots
+        // rides inside the value, so Cards finalization cannot forget it when
+        // `Line` grows another lockstep field.
+        let finalize = |line: Line| -> Line {
+            let bg = line.bg;
+            let mut line = match bg.escape(row, &opts.theme, &rail) {
+                Some(esc) if cards => line.painted(width, &esc),
+                _ => line,
             };
-            Line::new(text, target, LineBg::None).with_hotspot_opt(hotspot)
+            line.bg = LineBg::None;
+            line
         };
 
         // pad_y internal top padding — belongs to this card's click span.
@@ -1510,17 +1513,17 @@ fn render_body(rows: &[TabRow], ledger: &[LedgerLine], opts: &RenderOpts) -> Vec
         // `String`) — `pad_y` can be >1, so a plain move would only survive
         // the first pass.
         for _ in 0..spacing.pad_y {
-            flat.push(finalize(LineBg::Card, "\n".to_string(), Some(row_target.clone()), None));
+            flat.push(finalize(Line::new("\n".to_string(), Some(row_target.clone()), LineBg::Card)));
         }
 
         // content (truncated to the planned budget == today's compression).
         for line in blocks[i].iter().take(budget) {
-            flat.push(finalize(line.bg, line.text.clone(), line.target.clone(), line.hotspot.clone()));
+            flat.push(finalize(line.clone()));
         }
 
         // gap external separation (dark panel base in Cards).
         for _ in 0..spacing.gap {
-            flat.push(finalize(LineBg::Rail, "\n".to_string(), None, None));
+            flat.push(finalize(Line::new("\n".to_string(), None, LineBg::Rail)));
         }
     }
 

--- a/crates/plugin/src/render.rs
+++ b/crates/plugin/src/render.rs
@@ -230,6 +230,29 @@ pub struct RailTarget {
     pub session: Option<String>,
 }
 
+/// The one action a glyph hotspot performs. Kept on [`Line`] rather than
+/// reconstructed from its target: a navigation target is deliberately broader
+/// than the small set of physical cells that are actionable.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HotspotAction {
+    DismissPresence { name: String },
+    Acknowledge { target: RailTarget },
+}
+
+impl HotspotAction {
+    fn glyph(&self) -> &'static str {
+        match self {
+            Self::DismissPresence { .. } => "✕",
+            Self::Acknowledge { .. } => "✓",
+        }
+    }
+
+    fn width(&self) -> usize {
+        // Frozen vocabulary: both glyphs are exactly one display cell.
+        UnicodeWidthStr::width(self.glyph())
+    }
+}
+
 impl RailTarget {
     /// Sentinel `tab_position` for a session target (`session: Some(_)`)
     /// whose peer has nothing needing attention. Never a legitimate tab
@@ -306,6 +329,7 @@ impl LineBg {
 struct Line {
     text: String,
     target: Option<RailTarget>,
+    hotspot: Option<(usize, HotspotAction)>,
     bg: LineBg,
 }
 
@@ -329,7 +353,15 @@ impl Line {
             text = text.replace('\n', " ");
         }
         text.push('\n');
-        Line { text, target, bg }
+        Line { text, target, hotspot: None, bg }
+    }
+
+    /// Attach an already-laid-out glyph action to this physical line. Keeping
+    /// the metadata inside Line makes every later transformation preserve the
+    /// lockstep pairing by construction.
+    fn with_hotspot(mut self, start_col: usize, action: HotspotAction) -> Self {
+        self.hotspot = Some((start_col, action));
+        self
     }
 
     /// Repaint the text onto a surface band (Cards), re-normalizing through
@@ -337,6 +369,12 @@ impl Line {
     /// constructor's newline invariant becomes discipline-held again.
     fn painted(self, width: usize, bg: &str) -> Line {
         Line::new(paint_card_line(&self.text, width, bg), self.target, self.bg)
+            .with_hotspot_opt(self.hotspot)
+    }
+
+    fn with_hotspot_opt(mut self, hotspot: Option<(usize, HotspotAction)>) -> Self {
+        self.hotspot = hotspot;
+        self
     }
 }
 
@@ -344,6 +382,7 @@ impl Line {
 pub struct RenderedRail {
     pub ansi: String,
     targets: Vec<Option<RailTarget>>,
+    hotspots: Vec<Option<(usize, HotspotAction)>>,
 }
 
 impl RenderedRail {
@@ -359,14 +398,16 @@ impl RenderedRail {
     fn from_lines(lines: Vec<Line>) -> RenderedRail {
         let mut ansi = String::new();
         let mut targets = Vec::with_capacity(lines.len());
+        let mut hotspots = Vec::with_capacity(lines.len());
         for line in lines {
             ansi.push_str(&line.text);
             targets.push(line.target);
+            hotspots.push(line.hotspot);
         }
         if ansi.ends_with('\n') {
             ansi.pop();
         }
-        RenderedRail { ansi, targets }
+        RenderedRail { ansi, targets, hotspots }
     }
 
     /// Build a targetless panel face from raw ANSI, clamped to `height` lines
@@ -376,14 +417,16 @@ impl RenderedRail {
     fn from_ansi_without_targets(ansi: &str, height: usize) -> Self {
         let mut clamped = String::new();
         let mut targets = Vec::new();
+        let mut hotspots = Vec::new();
         for line in ansi.split_inclusive('\n').take(height) {
             clamped.push_str(line);
             targets.push(None);
+            hotspots.push(None);
         }
         if clamped.ends_with('\n') {
             clamped.pop();
         }
-        RenderedRail { ansi: clamped, targets }
+        RenderedRail { ansi: clamped, targets, hotspots }
     }
 
     pub fn target_at_line(&self, line: isize) -> Option<RailTarget> {
@@ -391,6 +434,18 @@ impl RenderedRail {
             return None;
         }
         self.targets.get(line as usize).cloned().flatten()
+    }
+
+    pub(crate) fn hotspot_at_line(&self, line: isize) -> Option<(usize, HotspotAction)> {
+        if line < 0 {
+            return None;
+        }
+        self.hotspots.get(line as usize).cloned().flatten()
+    }
+
+    pub(crate) fn hotspot_at(&self, line: isize, col: usize) -> Option<HotspotAction> {
+        let (start_col, action) = self.hotspot_at_line(line)?;
+        (col >= start_col && col < start_col + action.width()).then_some(action)
     }
 
     #[cfg_attr(all(target_arch = "wasm32", not(test)), allow(dead_code))]
@@ -560,7 +615,18 @@ fn with_wait_tag(identity: &str, status: Status, pending_epoch_s: Option<u64>, n
 /// densest width-math in the file, self-contained here so `render_row` reads
 /// as pane-roster logic.
 fn tab_header_line(row: &TabRow, opts: &RenderOpts, tab_target: &RailTarget) -> Line {
-    let width = opts.width;
+    let mut hotspot = row.display.panes.iter()
+        .any(PaneDisplay::has_unacknowledged_status_pending)
+        .then(|| HotspotAction::Acknowledge { target: tab_target.clone() });
+    // The glyph owns the final cell and needs one preceding separator. Reserve
+    // both before any label truncation; otherwise a long tab name can push the
+    // action off-screen while its click metadata remains behind.
+    let width = if hotspot.is_some() && opts.width >= 6 {
+        opts.width - 2
+    } else {
+        hotspot = None;
+        opts.width
+    };
     let now_tick = opts.now_tick;
     let st = row.display.status;
 
@@ -625,7 +691,9 @@ fn tab_header_line(row: &TabRow, opts: &RenderOpts, tab_target: &RailTarget) -> 
     // be emitted past the column edge — breaking the "no line exceeds width"
     // invariant and the card-padding math (name_budget would still saturate to 0).
     const BELL_W: usize = 2; // ⚑ + trailing space
-    let show_bell = row.has_bell && prefix_len + BELL_W <= width;
+    // A pending accent already communicates the same urgency. More importantly
+    // the action glyph owns this right-edge slot, so it takes precedence.
+    let show_bell = hotspot.is_none() && row.has_bell && prefix_len + BELL_W <= width;
     let bell_len = if show_bell { BELL_W } else { 0 };
     let bell = if show_bell {
         format!("{} ", Seg::new(&hue(Role::Working), "⚑"))
@@ -647,11 +715,29 @@ fn tab_header_line(row: &TabRow, opts: &RenderOpts, tab_target: &RailTarget) -> 
         bold: label_bold,
         text: label_text.into(),
     };
-    Line::new(
+    let line = Line::new(
         format!("{}{}{}{}{}\n", bar, pad, label, " ".repeat(gap), bell),
         Some(tab_target.clone()),
         LineBg::Card,
-    )
+    );
+    match hotspot {
+        Some(action) => append_hotspot_glyph(line, opts.width, action, &hue(Role::Attention)),
+        None => line,
+    }
+}
+
+/// Put a one-cell action glyph in the last visible column. Callers have
+/// already reserved the glyph plus its mandatory separating space from their
+/// content budget. Padding belongs before the glyph, never after it, so only
+/// the glyph cells score as a left-click hotspot.
+fn append_hotspot_glyph(line: Line, width: usize, action: HotspotAction, color: &str) -> Line {
+    let bare = line.text.strip_suffix('\n').unwrap_or(&line.text);
+    let used = visible_width(bare);
+    let glyph_width = action.width();
+    debug_assert!(used + glyph_width < width, "hotspot suffix was not reserved");
+    let spaces = width.saturating_sub(used + glyph_width);
+    let text = format!("{}{}{}\n", bare, " ".repeat(spaces), Seg::new(color, action.glyph()));
+    Line::new(text, line.target, line.bg).with_hotspot(width - glyph_width, action)
 }
 
 /// Emit one row's body into `out`, respecting `max_lines`.
@@ -701,11 +787,28 @@ fn render_row(row: &TabRow, opts: &RenderOpts) -> Vec<Line> {
         let identity =
             with_wait_tag(identity, pane_status, pane.pending_epoch_s(), opts.now_epoch_s);
         let pane_target = RailTarget { tab_position: tab_target.tab_position, pane_id: Some(pane.pane_id()), session: None };
-        let text = emit_pane_line(pane, &identity, detail.is_some(), opts, row.active, st, &dim_strong, &idle_color, branch);
+        let mut hotspot = pane.has_unacknowledged_status_pending()
+            .then(|| HotspotAction::Acknowledge { target: pane_target.clone() });
+        // The tree identity has a six-cell irreducible prefix. At narrower
+        // widths there is no honest content+space+glyph composition, so drop
+        // the glyph and its metadata together rather than making a blank edge
+        // accidentally actionable.
+        let content_width = if hotspot.is_some() && opts.width >= 8 {
+            opts.width - 2
+        } else {
+            hotspot = None;
+            opts.width
+        };
+        let text = emit_pane_line(pane, &identity, detail.is_some(), opts, content_width, row.active, st, &dim_strong, &idle_color, branch);
         // `pane_target` is cloned here because a Pending/Error pane also emits
         // the subordinate `↳ question` line below, targeting the SAME pane —
         // `RailTarget` dropped `Copy` when `session` (a `String`) joined it.
-        let mut out = vec![Line::new(text, Some(pane_target.clone()), child_bg)];
+        let line = Line::new(text, Some(pane_target.clone()), child_bg);
+        let line = match hotspot {
+            Some(action) => append_hotspot_glyph(line, opts.width, action, Role::Attention.ansi()),
+            None => line,
+        };
+        let mut out = vec![line];
         if let Some(q) = detail {
             let text = emit_pane_detail_line(
                 q, row.active, st, pane_status, branch, &idle_color, width,
@@ -870,13 +973,13 @@ fn emit_pane_line(
     identity: &str,
     has_detail: bool,
     opts: &RenderOpts,
+    width: usize,
     tab_active: bool,
     tab_status: Status,
     dim_strong: &str,
     conn_color: &str,
     branch: Branch,
 ) -> String {
-    let width = opts.width;
     let mark = pane.kind().mark(opts.glyphs);
     let mark_w = UnicodeWidthChar::width(mark).unwrap_or(1);
     let status = pane.render_status();
@@ -1270,6 +1373,9 @@ fn render_session_badge(entries: &[BadgeEntry], opts: &RenderOpts) -> Vec<Line> 
     let mut lines: Vec<Line> = entries
         .iter()
         .map(|entry| {
+            let hotspot = (entry.stale && !entry.is_current && width >= 4)
+                .then(|| HotspotAction::DismissPresence { name: entry.name.clone() });
+            let content_width = if hotspot.is_some() { width - 2 } else { width };
             let mut label = entry.name.clone();
             if entry.running > 0 {
                 label.push_str(&format!(" {}{}", entry.running, running_glyph));
@@ -1283,7 +1389,7 @@ fn render_session_badge(entries: &[BadgeEntry], opts: &RenderOpts) -> Vec<Line> 
             let marker = if entry.is_current { "•" } else { " " };
             const PREFIX_VIS: usize = 2; // marker + its separating space
             let text = prefixed_line(
-                width,
+                content_width,
                 PREFIX_VIS,
                 || format!("{marker} {label}"),
                 |avail| {
@@ -1300,7 +1406,11 @@ fn render_session_badge(entries: &[BadgeEntry], opts: &RenderOpts) -> Vec<Line> 
             );
             let target = (!entry.is_current)
                 .then(|| RailTarget::for_session(entry.name.clone(), entry.attention_tab_position));
-            Line::new(text, target, LineBg::Rail)
+            let line = Line::new(text, target, LineBg::Rail);
+            match hotspot {
+                Some(action) => append_hotspot_glyph(line, width, action, &stale),
+                None => line,
+            }
         })
         .collect();
     lines.push(Line::new("\n".to_string(), None, LineBg::Rail));
@@ -1387,12 +1497,12 @@ fn render_body(rows: &[TabRow], ledger: &[LedgerLine], opts: &RenderOpts) -> Vec
         // Resolve a raw line's surface through the one `LineBg::escape` map and
         // paint it (Cards only). The emitted line is final, so it carries
         // `LineBg::None`; its footprint is exactly the lines pushed here.
-        let finalize = |bg: LineBg, text: String, target: Option<RailTarget>| -> Line {
+        let finalize = |bg: LineBg, text: String, target: Option<RailTarget>, hotspot: Option<(usize, HotspotAction)>| -> Line {
             let text = match bg.escape(row, &opts.theme, &rail) {
                 Some(esc) if cards => paint_card_line(&text, width, &esc),
                 _ => text,
             };
-            Line::new(text, target, LineBg::None)
+            Line::new(text, target, LineBg::None).with_hotspot_opt(hotspot)
         };
 
         // pad_y internal top padding — belongs to this card's click span.
@@ -1400,17 +1510,17 @@ fn render_body(rows: &[TabRow], ledger: &[LedgerLine], opts: &RenderOpts) -> Vec
         // `String`) — `pad_y` can be >1, so a plain move would only survive
         // the first pass.
         for _ in 0..spacing.pad_y {
-            flat.push(finalize(LineBg::Card, "\n".to_string(), Some(row_target.clone())));
+            flat.push(finalize(LineBg::Card, "\n".to_string(), Some(row_target.clone()), None));
         }
 
         // content (truncated to the planned budget == today's compression).
         for line in blocks[i].iter().take(budget) {
-            flat.push(finalize(line.bg, line.text.clone(), line.target.clone()));
+            flat.push(finalize(line.bg, line.text.clone(), line.target.clone(), line.hotspot.clone()));
         }
 
         // gap external separation (dark panel base in Cards).
         for _ in 0..spacing.gap {
-            flat.push(finalize(LineBg::Rail, "\n".to_string(), None));
+            flat.push(finalize(LineBg::Rail, "\n".to_string(), None, None));
         }
     }
 

--- a/crates/plugin/src/render.rs
+++ b/crates/plugin/src/render.rs
@@ -615,18 +615,11 @@ fn with_wait_tag(identity: &str, status: Status, pending_epoch_s: Option<u64>, n
 /// densest width-math in the file, self-contained here so `render_row` reads
 /// as pane-roster logic.
 fn tab_header_line(row: &TabRow, opts: &RenderOpts, tab_target: &RailTarget) -> Line {
-    let mut hotspot = row.display.panes.iter()
+    let hotspot = row.display.panes.iter()
         .any(PaneDisplay::has_unacknowledged_status_pending)
         .then(|| HotspotAction::Acknowledge { target: tab_target.clone() });
-    // The glyph owns the final cell and needs one preceding separator. Reserve
-    // both before any label truncation; otherwise a long tab name can push the
-    // action off-screen while its click metadata remains behind.
-    let width = if hotspot.is_some() && opts.width >= 6 {
-        opts.width - 2
-    } else {
-        hotspot = None;
-        opts.width
-    };
+    let hotspot = HotspotSlot::new(opts.width, 6, hotspot);
+    let width = hotspot.content_width();
     let now_tick = opts.now_tick;
     let st = row.display.status;
 
@@ -691,9 +684,9 @@ fn tab_header_line(row: &TabRow, opts: &RenderOpts, tab_target: &RailTarget) -> 
     // be emitted past the column edge — breaking the "no line exceeds width"
     // invariant and the card-padding math (name_budget would still saturate to 0).
     const BELL_W: usize = 2; // ⚑ + trailing space
-    // A pending accent already communicates the same urgency. More importantly
-    // the action glyph owns this right-edge slot, so it takes precedence.
-    let show_bell = hotspot.is_none() && row.has_bell && prefix_len + BELL_W <= width;
+    // Bell and action are independent signals. The action slot has already
+    // reduced `width`, so both fit whenever the bell fits this content budget.
+    let show_bell = row.has_bell && prefix_len + BELL_W <= width;
     let bell_len = if show_bell { BELL_W } else { 0 };
     let bell = if show_bell {
         format!("{} ", Seg::new(&hue(Role::Working), "⚑"))
@@ -720,24 +713,40 @@ fn tab_header_line(row: &TabRow, opts: &RenderOpts, tab_target: &RailTarget) -> 
         Some(tab_target.clone()),
         LineBg::Card,
     );
-    match hotspot {
-        Some(action) => append_hotspot_glyph(line, opts.width, action, &hue(Role::Attention)),
-        None => line,
-    }
+    hotspot.finish(line, &hue(Role::Attention))
 }
 
-/// Put a one-cell action glyph in the last visible column. Callers have
-/// already reserved the glyph plus its mandatory separating space from their
-/// content budget. Padding belongs before the glyph, never after it, so only
-/// the glyph cells score as a left-click hotspot.
-fn append_hotspot_glyph(line: Line, width: usize, action: HotspotAction, color: &str) -> Line {
-    let bare = line.text.strip_suffix('\n').unwrap_or(&line.text);
-    let used = visible_width(bare);
-    let glyph_width = action.width();
-    debug_assert!(used + glyph_width < width, "hotspot suffix was not reserved");
-    let spaces = width.saturating_sub(used + glyph_width);
-    let text = format!("{}{}{}\n", bare, " ".repeat(spaces), Seg::new(color, action.glyph()));
-    Line::new(text, line.target, line.bg).with_hotspot(width - glyph_width, action)
+/// Owns the complete hotspot suffix contract: admission at a site's minimum
+/// width, reservation of separator+glyph, and release-build enforcement when
+/// attaching metadata. A call site cannot reserve without attaching (or attach
+/// without reserving) because both halves travel in this value.
+struct HotspotSlot {
+    width: usize,
+    content_width: usize,
+    action: Option<HotspotAction>,
+}
+
+impl HotspotSlot {
+    fn new(width: usize, minimum: usize, action: Option<HotspotAction>) -> Self {
+        let action = action.filter(|_| width >= minimum);
+        let content_width = if action.is_some() { width - 2 } else { width };
+        Self { width, content_width, action }
+    }
+
+    fn content_width(&self) -> usize {
+        self.content_width
+    }
+
+    fn finish(self, line: Line, color: &str) -> Line {
+        let Some(action) = self.action else { return line };
+        let bare = line.text.strip_suffix('\n').unwrap_or(&line.text);
+        let used = visible_width(bare);
+        let glyph_width = action.width();
+        assert!(used <= self.content_width, "hotspot content exceeded its reserved width");
+        let spaces = self.width - used - glyph_width;
+        let text = format!("{}{}{}\n", bare, " ".repeat(spaces), Seg::new(color, action.glyph()));
+        Line::new(text, line.target, line.bg).with_hotspot(self.width - glyph_width, action)
+    }
 }
 
 /// Emit one row's body into `out`, respecting `max_lines`.
@@ -787,27 +796,16 @@ fn render_row(row: &TabRow, opts: &RenderOpts) -> Vec<Line> {
         let identity =
             with_wait_tag(identity, pane_status, pane.pending_epoch_s(), opts.now_epoch_s);
         let pane_target = RailTarget { tab_position: tab_target.tab_position, pane_id: Some(pane.pane_id()), session: None };
-        let mut hotspot = pane.has_unacknowledged_status_pending()
+        let hotspot = pane.has_unacknowledged_status_pending()
             .then(|| HotspotAction::Acknowledge { target: pane_target.clone() });
-        // The tree identity has a six-cell irreducible prefix. At narrower
-        // widths there is no honest content+space+glyph composition, so drop
-        // the glyph and its metadata together rather than making a blank edge
-        // accidentally actionable.
-        let content_width = if hotspot.is_some() && opts.width >= 8 {
-            opts.width - 2
-        } else {
-            hotspot = None;
-            opts.width
-        };
+        let hotspot = HotspotSlot::new(opts.width, 8, hotspot);
+        let content_width = hotspot.content_width();
         let text = emit_pane_line(pane, &identity, detail.is_some(), opts, content_width, row.active, st, &dim_strong, &idle_color, branch);
         // `pane_target` is cloned here because a Pending/Error pane also emits
         // the subordinate `↳ question` line below, targeting the SAME pane —
         // `RailTarget` dropped `Copy` when `session` (a `String`) joined it.
         let line = Line::new(text, Some(pane_target.clone()), child_bg);
-        let line = match hotspot {
-            Some(action) => append_hotspot_glyph(line, opts.width, action, Role::Attention.ansi()),
-            None => line,
-        };
+        let line = hotspot.finish(line, Role::Attention.ansi());
         let mut out = vec![line];
         if let Some(q) = detail {
             let text = emit_pane_detail_line(
@@ -1373,9 +1371,10 @@ fn render_session_badge(entries: &[BadgeEntry], opts: &RenderOpts) -> Vec<Line> 
     let mut lines: Vec<Line> = entries
         .iter()
         .map(|entry| {
-            let hotspot = (entry.stale && !entry.is_current && width >= 4)
+            let hotspot = (entry.stale && !entry.is_current)
                 .then(|| HotspotAction::DismissPresence { name: entry.name.clone() });
-            let content_width = if hotspot.is_some() { width - 2 } else { width };
+            let hotspot = HotspotSlot::new(width, 4, hotspot);
+            let content_width = hotspot.content_width();
             let mut label = entry.name.clone();
             if entry.running > 0 {
                 label.push_str(&format!(" {}{}", entry.running, running_glyph));
@@ -1407,10 +1406,8 @@ fn render_session_badge(entries: &[BadgeEntry], opts: &RenderOpts) -> Vec<Line> 
             let target = (!entry.is_current)
                 .then(|| RailTarget::for_session(entry.name.clone(), entry.attention_tab_position));
             let line = Line::new(text, target, LineBg::Rail);
-            match hotspot {
-                Some(action) => append_hotspot_glyph(line, width, action, &stale),
-                None => line,
-            }
+            let hotspot_color = if entry.selected { accent } else { &stale };
+            hotspot.finish(line, hotspot_color)
         })
         .collect();
     lines.push(Line::new("\n".to_string(), None, LineBg::Rail));

--- a/crates/plugin/src/render.rs
+++ b/crates/plugin/src/render.rs
@@ -356,11 +356,11 @@ impl Line {
         Line { text, target, hotspot: None, bg }
     }
 
-    /// Attach an already-laid-out glyph action to this physical line. Keeping
-    /// the metadata inside Line makes every later transformation preserve the
-    /// lockstep pairing by construction.
-    fn with_hotspot(mut self, start_col: usize, action: HotspotAction) -> Self {
-        self.hotspot = Some((start_col, action));
+    /// Attach an already-laid-out glyph action to this physical line — the one
+    /// setter for the field. Keeping the metadata inside Line makes every
+    /// later transformation preserve the lockstep pairing by construction.
+    fn with_hotspot(mut self, hotspot: Option<(usize, HotspotAction)>) -> Self {
+        self.hotspot = hotspot;
         self
     }
 
@@ -369,12 +369,7 @@ impl Line {
     /// constructor's newline invariant becomes discipline-held again.
     fn painted(self, width: usize, bg: &str) -> Line {
         Line::new(paint_card_line(&self.text, width, bg), self.target, self.bg)
-            .with_hotspot_opt(self.hotspot)
-    }
-
-    fn with_hotspot_opt(mut self, hotspot: Option<(usize, HotspotAction)>) -> Self {
-        self.hotspot = hotspot;
-        self
+            .with_hotspot(self.hotspot)
     }
 }
 
@@ -444,8 +439,13 @@ impl RenderedRail {
     }
 
     pub(crate) fn hotspot_at(&self, line: isize, col: usize) -> Option<HotspotAction> {
-        let (start_col, action) = self.hotspot_at_line(line)?;
-        (col >= start_col && col < start_col + action.width()).then_some(action)
+        if line < 0 {
+            return None;
+        }
+        // Borrow for the hit test; clone only the hit (a miss on the
+        // String-bearing action shouldn't cost an allocation per click).
+        let (start_col, action) = self.hotspots.get(line as usize)?.as_ref()?;
+        (col >= *start_col && col < *start_col + action.width()).then(|| action.clone())
     }
 
     #[cfg_attr(all(target_arch = "wasm32", not(test)), allow(dead_code))]
@@ -742,10 +742,18 @@ impl HotspotSlot {
         let bare = line.text.strip_suffix('\n').unwrap_or(&line.text);
         let used = visible_width(bare);
         let glyph_width = action.width();
-        assert!(used <= self.content_width, "hotspot content exceeded its reserved width");
+        // An emitter overrunning its content_width() is a bug in that
+        // emitter's width math — catch it loudly in tests, but degrade to a
+        // glyphless line in the release wasm (same debug_assert-plus-safe-
+        // fallback idiom as `Line::new`): a missing hotspot glyph beats a
+        // crashed rail.
+        debug_assert!(used <= self.content_width, "hotspot content exceeded its reserved width");
+        if used + glyph_width > self.width {
+            return line;
+        }
         let spaces = self.width - used - glyph_width;
         let text = format!("{}{}{}\n", bare, " ".repeat(spaces), Seg::new(color, action.glyph()));
-        Line::new(text, line.target, line.bg).with_hotspot(self.width - glyph_width, action)
+        Line::new(text, line.target, line.bg).with_hotspot(Some((self.width - glyph_width, action)))
     }
 }
 

--- a/crates/plugin/src/render/snapshots/zj_radar_plugin__render__tests__canonical_cards_grid.snap
+++ b/crates/plugin/src/render/snapshots/zj_radar_plugin__render__tests__canonical_cards_grid.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/plugin/src/render/tests.rs
-assertion_line: 3866
+assertion_line: 2625
 expression: "grid(&raw, 30)"
 ---
  RADAR                   ·4 1!
 ▌⠋ 1 web
 ▌└ ⠋ ✳ building…
 
- ◆ 2 api
+ ◆ 2 api                     ✓
 
  ● 3 worker
 

--- a/crates/plugin/src/render/snapshots/zj_radar_plugin__render__tests__cards_light_theme_grid.snap
+++ b/crates/plugin/src/render/snapshots/zj_radar_plugin__render__tests__cards_light_theme_grid.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/plugin/src/render/tests.rs
-assertion_line: 4009
+assertion_line: 2736
 expression: "grid(&raw, 30)"
 ---
  RADAR                   ·4 1!
 ▌⠋ 1 web
 ▌└ ⠋ ✳ building…
 
- ◆ 2 api
+ ◆ 2 api                     ✓
 
  ● 3 worker
 

--- a/crates/plugin/src/render/snapshots/zj_radar_plugin__render__tests__cards_multi_pane_grid.snap
+++ b/crates/plugin/src/render/snapshots/zj_radar_plugin__render__tests__cards_multi_pane_grid.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/plugin/src/render/tests.rs
-assertion_line: 3905
+assertion_line: 2718
 expression: "grid(&raw, 30)"
 ---
  RADAR                   ·1 1!
-▌◆ 1 team
+▌◆ 1 team                    ✓
 ▌├ ⠋ ✳ building
-▌├ ◆ ❉ approve?
+▌├ ◆ ❉ approve?              ✓
 ▌└ ● ⚗ cargo test

--- a/crates/plugin/src/render/snapshots/zj_radar_plugin__render__tests__cards_nerd_glyphs_grid.snap
+++ b/crates/plugin/src/render/snapshots/zj_radar_plugin__render__tests__cards_nerd_glyphs_grid.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/plugin/src/render/tests.rs
-assertion_line: 3936
+assertion_line: 2685
 expression: "grid(&raw, 30)"
 ---
  RADAR                   ·4 1!
 ▌⠋ 1 web
 ▌└ ⠋ 󰚩 building…
 
-  2 api
+  2 api                     ✓
 
   3 worker
 

--- a/crates/plugin/src/render/snapshots/zj_radar_plugin__render__tests__overflow_fold_grid.snap
+++ b/crates/plugin/src/render/snapshots/zj_radar_plugin__render__tests__overflow_fold_grid.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/plugin/src/render/tests.rs
-assertion_line: 3967
+assertion_line: 2700
 expression: "grid(&raw, 30)"
 ---
  RADAR                  15▲ 1!
 ══════════════════════════════
- ◆ 15 pinky
- └ ◆ ✳ approve?
+ ◆ 15 pinky                  ✓
+ └ ◆ ✳ approve?              ✓
 +14 idle ▾
 ──────────────────────────────
 0 working · 1 need you

--- a/crates/plugin/src/render/tests.rs
+++ b/crates/plugin/src/render/tests.rs
@@ -57,6 +57,8 @@ fn display(
                 since_tick: d.since_tick,
                 outcome: d.outcome,
                 pending_epoch_s: d.pending_epoch_s,
+                origin: d.origin,
+                acknowledged: d.acknowledged,
             }]
         })
         .unwrap_or_default();
@@ -102,8 +104,10 @@ fn pd(
         since_tick: 0,
         status,
         kind: Kind::Claude,
+        origin: crate::observation::ObservationOrigin::StatusPipe,
         outcome: None,
         pending_epoch_s: None,
+        acknowledged: false,
     }
 }
 
@@ -946,6 +950,8 @@ fn pe(id: u32, kind: Kind, status: Status, msg: &str) -> PaneDisplay {
         since_tick: 0,
         outcome: None,
         pending_epoch_s: None,
+        origin: crate::observation::ObservationOrigin::StatusPipe,
+        acknowledged: false,
     }
 }
 
@@ -960,6 +966,8 @@ fn pe_outcome(id: u32, kind: Kind, status: Status, msg: &str, outcome: Outcome) 
         since_tick: 0,
         outcome: Some(outcome),
         pending_epoch_s: None,
+        origin: crate::observation::ObservationOrigin::StatusPipe,
+        acknowledged: false,
     }
 }
 
@@ -974,6 +982,8 @@ fn pe_task(id: u32, kind: Kind, status: Status, msg: &str, task: &str) -> PaneDi
         since_tick: 0,
         outcome: None,
         pending_epoch_s: None,
+        origin: crate::observation::ObservationOrigin::StatusPipe,
+        acknowledged: false,
     }
 }
 
@@ -3190,6 +3200,8 @@ prop_compose! {
                 since_tick: 0,
                 outcome: None,
                 pending_epoch_s: None,
+                origin: crate::observation::ObservationOrigin::StatusPipe,
+                acknowledged: false,
             }
         }
     }
@@ -3502,6 +3514,46 @@ fn from_lines_derives_ansi_and_targets_in_lockstep() {
     assert_eq!(rr.target_at_line(3), None);
     // Structural lockstep: every '\n'-terminated segment has a target slot.
     assert_eq!(rr.ansi.split('\n').count(), rr.line_count());
+}
+
+#[test]
+fn hotspot_metadata_survives_cards_finalize_and_excludes_question_and_overflow_lines() {
+    let pending = PaneDisplay::Tracked {
+        pane_id: 10,
+        kind: Kind::Claude,
+        status: Status::Pending,
+        msg: "approve?".into(),
+        task: "ship it".into(),
+        since_tick: 0,
+        outcome: None,
+        pending_epoch_s: None,
+        origin: crate::observation::ObservationOrigin::StatusPipe,
+        acknowledged: false,
+    };
+    let mut panes = vec![pending];
+    panes.extend((11..=17).map(|id| pe(id, Kind::Claude, Status::Running, "working")));
+    let row = tab(1, "team", display_multi(panes));
+    let opts = RenderOpts { density: Density::Cards, ..ro(30, 0) };
+    let rail = render_rail(&[row], &[], &opts);
+
+    let header = rail.ansi.lines().position(|l| l.contains("team")).unwrap() as isize;
+    let pane = rail.ansi.lines().position(|l| l.contains("ship it")).unwrap() as isize;
+    let question = rail.ansi.lines().position(|l| l.contains("approve?")).unwrap() as isize;
+    let more = rail.ansi.lines().position(|l| l.contains("more")).unwrap() as isize;
+    assert!(rail.hotspot_at_line(header).is_some(), "pending tab header gets ✓");
+    assert!(rail.hotspot_at_line(pane).is_some(), "pending pane identity gets ✓ after Cards finalize");
+    assert_eq!(rail.hotspot_at_line(question), None, "question continuation is never actionable");
+    assert_eq!(rail.hotspot_at_line(more), None, "+N more is never actionable");
+}
+
+#[test]
+fn narrow_pending_rows_drop_the_glyph_and_its_hotspot_together() {
+    let row = tab(1, "a", display(Status::Pending, 0, 1, Some(pd("r", "b", "ask", Status::Pending))));
+    let rail = render_rail(&[row], &[], &ro(5, 0));
+    assert!(!rail.ansi.contains('✓'));
+    for line in 0..rail.line_count() {
+        assert_eq!(rail.hotspot_at_line(line as isize), None, "narrow line {line} must not retain metadata");
+    }
 }
 
 #[test]

--- a/crates/plugin/src/render/tests.rs
+++ b/crates/plugin/src/render/tests.rs
@@ -3540,8 +3540,20 @@ fn hotspot_metadata_survives_cards_finalize_and_excludes_question_and_overflow_l
     let pane = rail.ansi.lines().position(|l| l.contains("ship it")).unwrap() as isize;
     let question = rail.ansi.lines().position(|l| l.contains("approve?")).unwrap() as isize;
     let more = rail.ansi.lines().position(|l| l.contains("more")).unwrap() as isize;
-    assert!(rail.hotspot_at_line(header).is_some(), "pending tab header gets ✓");
-    assert!(rail.hotspot_at_line(pane).is_some(), "pending pane identity gets ✓ after Cards finalize");
+    assert_eq!(
+        rail.hotspot_at_line(header),
+        Some((29, HotspotAction::Acknowledge {
+            target: RailTarget { tab_position: 0, pane_id: None, session: None },
+        })),
+        "pending tab header gets ✓ after Cards finalize"
+    );
+    assert_eq!(
+        rail.hotspot_at_line(pane),
+        Some((29, HotspotAction::Acknowledge {
+            target: RailTarget { tab_position: 0, pane_id: Some(10), session: None },
+        })),
+        "pending pane identity gets ✓ after Cards finalize"
+    );
     assert_eq!(rail.hotspot_at_line(question), None, "question continuation is never actionable");
     assert_eq!(rail.hotspot_at_line(more), None, "+N more is never actionable");
 }

--- a/crates/plugin/src/render/tests.rs
+++ b/crates/plugin/src/render/tests.rs
@@ -57,8 +57,8 @@ fn display(
                 since_tick: d.since_tick,
                 outcome: d.outcome,
                 pending_epoch_s: d.pending_epoch_s,
-                origin: d.origin,
-                acknowledged: d.acknowledged,
+                origin: crate::observation::ObservationOrigin::StatusPipe,
+                acknowledged: false,
             }]
         })
         .unwrap_or_default();
@@ -104,10 +104,8 @@ fn pd(
         since_tick: 0,
         status,
         kind: Kind::Claude,
-        origin: crate::observation::ObservationOrigin::StatusPipe,
         outcome: None,
         pending_epoch_s: None,
-        acknowledged: false,
     }
 }
 
@@ -3566,6 +3564,17 @@ fn narrow_pending_rows_drop_the_glyph_and_its_hotspot_together() {
     for line in 0..rail.line_count() {
         assert_eq!(rail.hotspot_at_line(line as isize), None, "narrow line {line} must not retain metadata");
     }
+}
+
+#[test]
+fn pending_hotspot_does_not_hide_an_independent_bell() {
+    let mut row = tab(1, "team", display(Status::Pending, 0, 1, Some(pd("r", "b", "approve", Status::Pending))));
+    row.has_bell = true;
+    let rail = render_rail(&[row], &[], &ro(30, 0));
+    let header = rail.ansi.lines().find(|line| line.contains("team")).unwrap();
+    assert!(header.contains('⚑'), "bell from another pane remains visible: {header:?}");
+    assert!(header.contains('✓'), "pending action remains visible: {header:?}");
+    assert_eq!(visible_width(header), 30, "combined bell+hotspot must stay within the rail");
 }
 
 #[test]

--- a/crates/plugin/src/rollup.rs
+++ b/crates/plugin/src/rollup.rs
@@ -53,12 +53,18 @@ pub struct PrimaryDetail {
     pub since_tick: u64,
     pub status: Status,
     pub kind: Kind,
+    pub origin: ObservationOrigin,
     /// End-result tag for a finished command pane (None for agents/active).
     pub outcome: Option<Outcome>,
     /// Wall-clock stamp of the waiting-on-you edge (Pending only) — the
     /// renderer turns it into the `· 12m` wait tag against its own
     /// `now_epoch_s`, so no epoch threads through the roll-up itself.
     pub pending_epoch_s: Option<u64>,
+    /// Whether a status-origin Pending was acknowledged by the user. This is
+    /// render input, not renderer policy: the roll-up seam carries the fact
+    /// across from the resolved observation so hotspots never reach back into
+    /// runtime state and bypass source precedence.
+    pub acknowledged: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -66,6 +72,7 @@ pub enum PaneDisplay {
     Tracked {
         pane_id: u32,
         kind: Kind,
+        origin: ObservationOrigin,
         status: Status,
         msg: String,
         task: String,
@@ -73,6 +80,8 @@ pub enum PaneDisplay {
         outcome: Option<Outcome>,
         /// Waiting-on-you stamp (Pending only) — see `PrimaryDetail`.
         pending_epoch_s: Option<u64>,
+        /// See `PrimaryDetail::acknowledged`.
+        acknowledged: bool,
     },
     Untracked {
         pane_id: u32,
@@ -156,6 +165,19 @@ impl PaneDisplay {
             Self::Untracked { .. } => None,
         }
     }
+
+    pub(crate) fn has_unacknowledged_status_pending(&self) -> bool {
+        matches!(self, Self::Tracked {
+            status: Status::Pending,
+            acknowledged: false,
+            origin: ObservationOrigin::StatusPipe,
+            ..
+        })
+    }
+
+    pub(crate) fn is_status_origin(&self) -> bool {
+        matches!(self, Self::Tracked { origin: ObservationOrigin::StatusPipe, .. })
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -212,12 +234,14 @@ pub fn roll_up<'a>(
             pane_displays.push(PaneDisplay::Tracked {
                 pane_id: pane.id,
                 kind: s.kind,
+                origin: s.origin,
                 status: s.status,
                 msg: s.msg.clone(),
                 task: s.task.clone(),
                 since_tick: s.last_change_tick,
                 outcome: pane_outcome(s),
                 pending_epoch_s: s.pending_epoch_s,
+                acknowledged: s.acknowledged,
             });
         } else {
             pane_displays.push(PaneDisplay::untracked(pane.id, &pane.title));
@@ -239,8 +263,10 @@ pub fn roll_up<'a>(
                     since_tick: s.last_change_tick,
                     status: s.status,
                     kind: s.kind,
+                    origin: s.origin,
                     outcome: pane_outcome(s),
                     pending_epoch_s: s.pending_epoch_s,
+                    acknowledged: s.acknowledged,
                 });
             }
         }

--- a/crates/plugin/src/rollup.rs
+++ b/crates/plugin/src/rollup.rs
@@ -53,18 +53,12 @@ pub struct PrimaryDetail {
     pub since_tick: u64,
     pub status: Status,
     pub kind: Kind,
-    pub origin: ObservationOrigin,
     /// End-result tag for a finished command pane (None for agents/active).
     pub outcome: Option<Outcome>,
     /// Wall-clock stamp of the waiting-on-you edge (Pending only) — the
     /// renderer turns it into the `· 12m` wait tag against its own
     /// `now_epoch_s`, so no epoch threads through the roll-up itself.
     pub pending_epoch_s: Option<u64>,
-    /// Whether a status-origin Pending was acknowledged by the user. This is
-    /// render input, not renderer policy: the roll-up seam carries the fact
-    /// across from the resolved observation so hotspots never reach back into
-    /// runtime state and bypass source precedence.
-    pub acknowledged: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -263,10 +257,8 @@ pub fn roll_up<'a>(
                     since_tick: s.last_change_tick,
                     status: s.status,
                     kind: s.kind,
-                    origin: s.origin,
                     outcome: pane_outcome(s),
                     pending_epoch_s: s.pending_epoch_s,
-                    acknowledged: s.acknowledged,
                 });
             }
         }

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -440,9 +440,27 @@ impl PluginRuntime {
         self.project(effects, change, now)
     }
 
-    pub(crate) fn mouse_click(&self, line: isize) -> Outcome {
+    pub(crate) fn mouse_click(&mut self, line: isize, col: usize) -> Outcome {
         if !self.permission.granted() {
             return Outcome::none();
+        }
+        if let Some(action) = self.last_rendered.hotspot_at(line, col) {
+            return match action {
+                render::HotspotAction::DismissPresence { name } => {
+                    // A stale badge may have received a heartbeat between paint
+                    // and click. Re-check the live badge before locally hiding
+                    // it; a glyph never races away a healthy peer.
+                    if !self.sessions.badge().iter().any(|b| b.name == name && b.stale) {
+                        Outcome::none()
+                    } else {
+                        let render = self.sessions.dismiss(&name);
+                        Outcome::with_effects(render, vec![Effect::DismissPresence { name }])
+                    }
+                }
+                render::HotspotAction::Acknowledge { target } => {
+                    Outcome::with_effects(false, self.acknowledge_pending_targets(&target))
+                }
+            };
         }
         let Some(target) = self.last_rendered.target_at_line(line) else {
             return Outcome::none();
@@ -484,7 +502,7 @@ impl PluginRuntime {
     ///   completed-turn-ending-in-a-courtesy-question trap: `Pending` has no
     ///   exit besides another broadcast, so a click that means "I saw it,
     ///   stop asking" has to BE one.
-    pub(crate) fn mouse_right_click(&mut self, line: isize) -> Outcome {
+    pub(crate) fn mouse_right_click(&mut self, line: isize, _col: usize) -> Outcome {
         if !self.permission.granted() {
             return Outcome::none();
         }
@@ -642,12 +660,23 @@ impl PluginRuntime {
     /// `Sessions`/`BadgeEntry` expect for a same-repo jump-on-arrival.
     fn own_presence(&self) -> Presence {
         let rows = self.radar.rows(self.tick);
-        let running = rows.iter().filter(|r| r.display.status == Status::Running).count();
+        // Presence is deliberately pane-level while the rail itself remains
+        // tab-rolled-up. `rows()` is already constrained by the current pane
+        // topology, so a pre-topology payload or stale store id cannot inflate
+        // cross-session counts; command observations are excluded at this
+        // seam, not inferred later from a tab's dominant status.
+        let running = rows.iter()
+            .flat_map(|r| &r.display.panes)
+            .filter(|p| p.is_status_origin() && p.status() == Some(Status::Running))
+            .count();
         let mut attention = 0usize;
         let mut attention_tab_position = None;
         for r in &rows {
-            if r.display.status.needs_you() {
-                attention += 1;
+            let tab_attention = r.display.panes.iter()
+                .filter(|p| p.is_status_origin() && p.status().is_some_and(Status::needs_you))
+                .count();
+            if tab_attention > 0 {
+                attention += tab_attention;
                 if attention_tab_position.is_none() {
                     attention_tab_position = Some(r.number as usize - 1);
                 }

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -445,17 +445,12 @@ impl PluginRuntime {
             return Outcome::none();
         }
         if let Some(action) = self.last_rendered.hotspot_at(line, col) {
+            // A hotspot whose action raced away deliberately consumes the
+            // click instead of falling through to row navigation: the user
+            // aimed at an action, not at the row behind it.
             return match action {
                 render::HotspotAction::DismissPresence { name } => {
-                    // A stale badge may have received a heartbeat between paint
-                    // and click. Re-check the live badge before locally hiding
-                    // it; a glyph never races away a healthy peer.
-                    if !self.sessions.badge().iter().any(|b| b.name == name && b.stale) {
-                        Outcome::none()
-                    } else {
-                        let render = self.sessions.dismiss(&name);
-                        Outcome::with_effects(render, vec![Effect::DismissPresence { name }])
-                    }
+                    self.dismiss_stale_session(name)
                 }
                 render::HotspotAction::Acknowledge { target } => {
                     Outcome::with_effects(false, self.acknowledge_pending_targets(&target))
@@ -512,18 +507,20 @@ impl PluginRuntime {
         // `.clone()`, not a move: a session-line miss falls through to the
         // pane/tab branch below, which still needs the rest of `target`.
         if let Some(name) = target.session.clone() {
-            // Staleness is judged against the CURRENT badge, not anything
-            // baked into the click target at render time — the entry may
-            // have gone fresh (its session came back) between the paint and
-            // the click, and a dismiss must never race a live session's
-            // heartbeat.
-            if !self.sessions.badge().iter().any(|b| b.name == name && b.stale) {
-                return Outcome::none();
-            }
-            let render = self.sessions.dismiss(&name);
-            return Outcome::with_effects(render, vec![Effect::DismissPresence { name }]);
+            return self.dismiss_stale_session(name);
         }
         Outcome::with_effects(false, self.acknowledge_pending_targets(&target))
+    }
+
+    /// Dismiss a peer only while the current badge still says it is stale.
+    /// Both the glyph and legacy right-click paths route here so a heartbeat
+    /// racing either gesture can never hide a healthy session.
+    fn dismiss_stale_session(&mut self, name: String) -> Outcome {
+        if !self.sessions.badge().iter().any(|b| b.name == name && b.stale) {
+            return Outcome::none();
+        }
+        let render = self.sessions.dismiss(&name);
+        Outcome::with_effects(render, vec![Effect::DismissPresence { name }])
     }
 
     /// The pane-or-tab half of `mouse_right_click`: every pane a click on

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -662,9 +662,9 @@ fn render_records_targets_and_mouse_click_returns_host_effect() {
     let ansi = runtime.render(100, 80);
     assert!(ansi.contains("team"));
 
-    let tab_click = runtime.mouse_click(2);
-    let pane20_click = runtime.mouse_click(3);
-    let pane21_click = runtime.mouse_click(4);
+    let tab_click = runtime.mouse_click(2, 0);
+    let pane20_click = runtime.mouse_click(3, 0);
+    let pane21_click = runtime.mouse_click(4, 0);
 
     assert_eq!(tab_click.effects, vec![Effect::SwitchTab { position: 0 }]);
     assert_eq!(pane20_click.effects, vec![Effect::ShowPane { pane_id: 20 }]);
@@ -694,8 +694,8 @@ fn single_pane_detail_line_click_shows_the_pane() {
     let ansi = runtime.render(100, 80);
     assert!(ansi.contains("team"));
 
-    let header_click = runtime.mouse_click(2);
-    let detail_click = runtime.mouse_click(3);
+    let header_click = runtime.mouse_click(2, 0);
+    let detail_click = runtime.mouse_click(3, 0);
 
     assert_eq!(header_click.effects, vec![Effect::SwitchTab { position: 0 }]);
     assert_eq!(detail_click.effects, vec![Effect::ShowPane { pane_id: 30 }]);
@@ -707,7 +707,7 @@ fn mouse_click_is_ignored_until_permission_granted() {
     runtime.tabs_changed(vec![tab(0, "team", false)]);
     runtime.render(100, 80);
 
-    assert_eq!(runtime.mouse_click(2), Outcome::default());
+    assert_eq!(runtime.mouse_click(2, 0), Outcome::default());
 }
 
 #[test]
@@ -876,6 +876,43 @@ fn status_edge_persists_presence_once_and_not_on_identical_state() {
 }
 
 #[test]
+fn own_presence_counts_live_status_panes_not_tab_rollups_or_unseated_payloads() {
+    let mut rt = runtime_with_granted_permission();
+    rt.tabs_changed(vec![tab(0, "pair", true)]);
+    rt.radar.set_tab_panes_for_position(0, vec![pane(10), pane(11)]);
+    rt.status_pipe(&payload_json(10, "running"));
+    rt.status_pipe(&payload_json(11, "running"));
+    // Status intake legitimately accepts a payload before topology arrives;
+    // presence must not count that stale/unseated id.
+    rt.status_pipe(&payload_json(99, "pending"));
+
+    let own = rt.own_presence();
+    assert_eq!(own.running, 2, "two agent panes in one tab count as two");
+    assert_eq!(own.attention, 0);
+    assert_eq!(own.attention_tab_position, None);
+}
+
+#[test]
+fn own_presence_excludes_command_attention_and_uses_the_first_status_tab() {
+    let mut rt = runtime_with_granted_permission();
+    rt.tabs_changed(vec![tab(0, "command", false), tab(3, "agent", true)]);
+    rt.radar.set_tab_panes_for_position(0, vec![pane(10)]);
+    rt.radar.set_tab_panes_for_position(3, vec![pane(20)]);
+
+    // A command-origin Error is urgent in the rail but intentionally absent
+    // from the cross-session agent presence tally.
+    let cmd = vec!["cargo".to_string(), "test".to_string()];
+    rt.radar.command_mut().on_command_changed(10, &cmd, true, None, rt.tick);
+    let _ = rt.radar.command_mut().on_exit(10, Some(1), Tick(rt.tick), EpochSecs(0));
+    rt.status_pipe(&payload_json(20, "pending"));
+
+    let own = rt.own_presence();
+    assert_eq!(own.running, 0);
+    assert_eq!(own.attention, 1, "only the status-origin Pending counts");
+    assert_eq!(own.attention_tab_position, Some(3));
+}
+
+#[test]
 fn presence_edge_ignores_timestamp_but_still_reacts_to_content() {
     // Finding 1 pin: `presence_json` embeds `updated_epoch_s`, which on Fast
     // cadence moves every tick. If `project`'s change check compared the raw
@@ -1006,7 +1043,7 @@ fn clicking_a_session_line_emits_switch_session() {
     let ansi = rt.render(100, 80);
     assert!(ansi.contains("alpha"), "setup: the peer's badge line must actually render");
 
-    let own_click = rt.mouse_click(2);
+    let own_click = rt.mouse_click(2, 0);
     assert_eq!(
         own_click,
         Outcome::default(),
@@ -1014,7 +1051,7 @@ fn clicking_a_session_line_emits_switch_session() {
         own_click
     );
 
-    let peer_click = rt.mouse_click(3);
+    let peer_click = rt.mouse_click(3, 0);
     assert_eq!(
         peer_click.effects,
         vec![Effect::SwitchSession { name: "alpha".into(), tab_position: Some(2) }]
@@ -1026,7 +1063,7 @@ fn right_click_on_stale_session_line_dismisses_and_emits_delete_effect() {
     let mut rt = runtime_with_granted_permission();
     render_with_badge(&mut rt, stale(r#"{"session_name":"alpha","running":0,"attention":1}"#));
 
-    let out = rt.mouse_right_click(3);
+    let out = rt.mouse_right_click(3, 0);
 
     assert_eq!(
         out,
@@ -1042,11 +1079,25 @@ fn right_click_on_stale_session_line_dismisses_and_emits_delete_effect() {
 }
 
 #[test]
+fn left_click_on_stale_badge_glyph_dismisses_but_the_row_body_still_switches() {
+    let mut rt = runtime_with_granted_permission();
+    render_with_badge(&mut rt, stale(r#"{"session_name":"alpha","running":0,"attention":1}"#));
+    let (start_col, _) = rt.last_rendered.hotspot_at_line(3)
+        .expect("stale peer badge must carry a dismiss glyph");
+
+    let body = rt.mouse_click(3, start_col - 1);
+    assert_eq!(body.effects, vec![Effect::SwitchSession { name: "alpha".into(), tab_position: None }]);
+    let dismiss = rt.mouse_click(3, start_col);
+    assert_eq!(dismiss.effects, vec![Effect::DismissPresence { name: "alpha".into() }]);
+    assert!(dismiss.render, "dismiss removes the stale peer locally at once");
+}
+
+#[test]
 fn right_click_on_fresh_session_line_is_inert() {
     let mut rt = runtime_with_granted_permission();
     render_with_badge(&mut rt, fresh(r#"{"session_name":"alpha","running":0,"attention":1}"#));
 
-    let out = rt.mouse_right_click(3);
+    let out = rt.mouse_right_click(3, 0);
 
     assert_eq!(out, Outcome::default());
     assert!(
@@ -1060,7 +1111,7 @@ fn right_click_on_own_session_line_is_inert() {
     let mut rt = runtime_with_granted_permission();
     render_with_badge(&mut rt, stale(r#"{"session_name":"alpha","running":0,"attention":1}"#));
 
-    assert_eq!(rt.mouse_right_click(2), Outcome::default());
+    assert_eq!(rt.mouse_right_click(2, 0), Outcome::default());
 }
 
 #[test]
@@ -1068,7 +1119,7 @@ fn right_click_on_tab_line_is_inert() {
     let mut rt = runtime_with_granted_permission();
     render_with_badge(&mut rt, stale(r#"{"session_name":"alpha","running":0,"attention":1}"#));
 
-    assert_eq!(rt.mouse_right_click(5), Outcome::default());
+    assert_eq!(rt.mouse_right_click(5, 0), Outcome::default());
 }
 
 #[test]
@@ -1076,7 +1127,7 @@ fn right_click_on_empty_line_is_inert() {
     let mut rt = runtime_with_granted_permission();
     render_with_badge(&mut rt, stale(r#"{"session_name":"alpha","running":0,"attention":1}"#));
 
-    assert_eq!(rt.mouse_right_click(99), Outcome::default());
+    assert_eq!(rt.mouse_right_click(99, 0), Outcome::default());
 }
 
 #[test]
@@ -1085,7 +1136,7 @@ fn right_click_without_permission_is_inert_even_on_stale_session_line() {
     render_with_badge(&mut rt, stale(r#"{"session_name":"alpha","running":0,"attention":1}"#));
     rt.permission = PermissionState::default();
 
-    assert_eq!(rt.mouse_right_click(3), Outcome::default());
+    assert_eq!(rt.mouse_right_click(3, 0), Outcome::default());
     assert!(
         rt.sessions.badge().iter().any(|b| b.name == "alpha"),
         "ungranted right-click must not mutate the badge"
@@ -1127,7 +1178,7 @@ fn runtime_with_pending_panes() -> PluginRuntime {
 fn right_click_on_pending_pane_broadcasts_and_leaves_local_state_untouched_until_the_echo_lands() {
     let mut rt = runtime_with_pending_panes();
 
-    let out = rt.mouse_right_click(3); // tab0 pane 10, Pending
+    let out = rt.mouse_right_click(3, 0); // tab0 pane 10, Pending
     assert!(!out.render, "the click itself must not mutate local state — see Effect::BroadcastStatus's doc");
     assert_eq!(out.effects.len(), 1, "exactly one pending pane on this line, got {:?}", out.effects);
     let Effect::BroadcastStatus { payload } = &out.effects[0] else {
@@ -1148,10 +1199,31 @@ fn right_click_on_pending_pane_broadcasts_and_leaves_local_state_untouched_until
 }
 
 #[test]
+fn left_click_requires_the_pending_glyph_cells_but_right_click_keeps_row_wide_parity() {
+    let mut rt = runtime_with_pending_panes();
+    let (start_col, _) = rt.last_rendered
+        .hotspot_at_line(2)
+        .expect("pending tab header must carry its acknowledge hotspot");
+
+    // The cell before the glyph keeps ordinary navigation semantics; only the
+    // glyph itself acknowledges. `start_col` is display-cell zero based.
+    assert_eq!(
+        rt.mouse_click(2, start_col.saturating_sub(1)),
+        Outcome::with_effects(false, vec![Effect::SwitchTab { position: 0 }]),
+    );
+    let left = rt.mouse_click(2, start_col);
+    assert_eq!(left.effects.len(), 2, "tab hotspot acknowledges both pending panes");
+
+    // Right-click remains deliberately row-wide until zellij#5350 is fixed.
+    let right = rt.mouse_right_click(2, 0);
+    assert_eq!(right.effects.len(), 2, "right-click parity stays row-wide");
+}
+
+#[test]
 fn right_click_on_tab_row_broadcasts_every_pending_pane_in_that_tab_only() {
     let mut rt = runtime_with_pending_panes();
 
-    let out = rt.mouse_right_click(2); // tab0 header line, pane_id: None
+    let out = rt.mouse_right_click(2, 0); // tab0 header line, pane_id: None
     assert!(!out.render);
     let acked: Vec<u32> = out
         .effects
@@ -1172,7 +1244,7 @@ fn right_click_on_tab_row_broadcasts_every_pending_pane_in_that_tab_only() {
 #[test]
 fn right_click_on_a_running_pane_row_is_a_strict_no_op() {
     let mut rt = runtime_with_pending_panes();
-    assert_eq!(rt.mouse_right_click(4), Outcome::default(), "pane 11 is Running, not Pending");
+    assert_eq!(rt.mouse_right_click(4, 0), Outcome::default(), "pane 11 is Running, not Pending");
 }
 
 #[test]
@@ -1184,13 +1256,13 @@ fn right_click_on_a_tab_row_with_no_tracked_panes_is_a_strict_no_op() {
     };
     rt.tabs_changed(vec![tab(0, "a", false)]);
     let _ = rt.render(100, 80);
-    assert_eq!(rt.mouse_right_click(2), Outcome::default(), "no panes at all in this tab");
+    assert_eq!(rt.mouse_right_click(2, 0), Outcome::default(), "no panes at all in this tab");
 }
 
 #[test]
 fn acknowledge_payload_round_trips_and_carries_the_original_source_and_kind() {
     let mut rt = runtime_with_pending_panes();
-    let out = rt.mouse_right_click(3); // pane 10, Pending, source "claude" via payload_for
+    let out = rt.mouse_right_click(3, 0); // pane 10, Pending, source "claude" via payload_for
     let Effect::BroadcastStatus { payload } = &out.effects[0] else {
         panic!("expected BroadcastStatus, got {:?}", out.effects);
     };
@@ -1208,7 +1280,7 @@ fn acknowledge_payload_round_trips_and_carries_the_original_source_and_kind() {
 #[test]
 fn double_delivery_of_the_acknowledge_broadcast_is_idempotent() {
     let mut rt = runtime_with_pending_panes();
-    let out = rt.mouse_right_click(3);
+    let out = rt.mouse_right_click(3, 0);
     let Effect::BroadcastStatus { payload } = &out.effects[0] else {
         panic!("expected BroadcastStatus, got {:?}", out.effects);
     };
@@ -1242,7 +1314,7 @@ fn acknowledge_echo_never_fires_a_done_notification() {
     // (firing THEIR notifications — the flagging the user is responding to).
     let _ = rt.timer_fast(PermissionProbe::default());
 
-    let out = rt.mouse_right_click(3); // pane 10, Pending, background
+    let out = rt.mouse_right_click(3, 0); // pane 10, Pending, background
     let Effect::BroadcastStatus { payload } = &out.effects[0] else {
         panic!("expected BroadcastStatus, got {:?}", out.effects);
     };
@@ -2456,4 +2528,3 @@ mod timer_chain_fuzz {
         }
     }
 }
-

--- a/crates/plugin/src/status_store.rs
+++ b/crates/plugin/src/status_store.rs
@@ -182,6 +182,22 @@ impl StatusStore {
         self.suspect_running.remove(&pane_id);
     }
 
+    /// Clear a pane's pushed status because its root process exited (the pane
+    /// manifest's `exited` flag). Unlike a prompt return this is *definitive*
+    /// producer death — an agent-rooted pane (`zellij run -- claude`) never
+    /// shows a shell prompt for `clear_on_prompt_return` to see, and no hook
+    /// fires on a kill — so even a `Running` clears immediately, no grace
+    /// clock. Exits ride the level-triggered pane manifest; the Idle check
+    /// makes the repeat calls no-ops. Returns the displaced observation (the
+    /// ledger's recede edge), like the prompt-return clear.
+    pub fn clear_on_exit(&mut self, pane_id: u32, tick: u64) -> Option<TrackedObservation> {
+        self.suspect_running.remove(&pane_id);
+        if self.store.get(pane_id)?.status == Status::Idle {
+            return None;
+        }
+        self.force_idle(pane_id, tick)
+    }
+
     /// Expire grace clocks: any pane still `Running` whose prompt-return
     /// suspicion has outlived the grace window gets cleared to idle — its
     /// producer died mid-turn and will never send the clearing broadcast.

--- a/crates/plugin/tests/e2e/harness.rs
+++ b/crates/plugin/tests/e2e/harness.rs
@@ -282,7 +282,7 @@ impl ZellijSession {
         panic!(
             "zellij session '{}' never showed plugin header; PTY tail:\n{}",
             self.name,
-            &self
+            self
                 .pty_text()
                 .chars()
                 .rev()

--- a/crates/plugin/tests/e2e/main.rs
+++ b/crates/plugin/tests/e2e/main.rs
@@ -93,6 +93,46 @@ fn plugin_loads_and_renders_status() {
     eprintln!("[e2e] PASS: found piped status in the rendered sidebar");
 }
 
+/// A real left click on the exact, one-based screen coordinate of the pending
+/// glyph acknowledges through Zellij's mouse routing and the plugin's pipe
+/// echo. This is the layer that the unreachable right-click implementation
+/// could never exercise (zellij-org/zellij#5350).
+#[test]
+#[ignore = "e2e: requires zellij + built wasm; run via `just test-e2e`"]
+fn clicking_pending_glyph_acknowledges_the_pane() {
+    let wasm = plugin_wasm_path();
+    let temp_home = pre_grant_permissions(&wasm);
+    let session_name = format!("zjr_ack_glyph_{}", std::process::id());
+    let session = ZellijSession::start(&session_name, &sidebar_layout(&wasm), &wasm, temp_home);
+    let pane_id = session.discover_terminal_pane_id();
+    let payload = format!(
+        r#"{{"v":1,"source":"claude","pane":{{"type":"terminal","id":{pane_id}}},"status":"pending","repo":"web","branch":"main","msg":"approve glyph"}}"#
+    );
+    session.pipe_status(&payload);
+
+    let ready = session.wait_until(std::time::Duration::from_secs(5), |s| {
+        sidebar_region(&s.screen(), 32).contains('✓')
+    });
+    let screen = session.screen();
+    let sidebar = sidebar_region(&screen, 32);
+    assert!(ready, "pending glyph must be visible before clicking; rail:\n{sidebar}");
+    let row = sidebar_row_index(&screen, 32, "approve glyph")
+        .expect("the pending pane line must be visible");
+    let glyph_col = sidebar.lines().nth(row)
+        .and_then(|line| line.chars().position(|c| c == '✓'))
+        .expect("the pane line's exact checkmark column") as u16 + 1;
+
+    // `click_at` is one-based screen space, whereas the runtime receives the
+    // zero-based display-cell offset. The +1 is explicit at this boundary.
+    let acknowledged = session.wait_until(std::time::Duration::from_secs(8), |s| {
+        s.click_at(glyph_col, row as u16 + 1);
+        !sidebar_region(&s.screen(), 32).contains('✓')
+    });
+    let after = sidebar_region(&session.screen(), 32);
+    eprintln!("[e2e] pending glyph click col={}, row={} rail after:\n{}", glyph_col, row + 1, after);
+    assert!(acknowledged, "exact glyph click must broadcast ack and remove its hotspot; rail:\n{after}");
+}
+
 /// Multi-agent scenario: pipe a running agent and a pending ("needs-you") agent
 /// to two different pane IDs. Assert that the pending/needs-you content ("api"
 /// or "approve") appears in the rendered sidebar.

--- a/crates/plugin/tests/e2e/main.rs
+++ b/crates/plugin/tests/e2e/main.rs
@@ -119,7 +119,10 @@ fn clicking_pending_glyph_acknowledges_the_pane() {
     let row = sidebar_row_index(&screen, 32, "approve glyph")
         .expect("the pending pane line must be visible");
     let glyph_col = sidebar.lines().nth(row)
-        .and_then(|line| line.chars().position(|c| c == '✓'))
+        .and_then(|line| {
+            let prefix = line.split_once('✓')?.0;
+            Some(unicode_width::UnicodeWidthStr::width(prefix))
+        })
         .expect("the pane line's exact checkmark column") as u16 + 1;
 
     // `click_at` is one-based screen space, whereas the runtime receives the

--- a/crates/plugin/tests/e2e/main.rs
+++ b/crates/plugin/tests/e2e/main.rs
@@ -1010,14 +1010,14 @@ fn rail_paints_every_column_of_its_pane() {
     // painted further right than expected).
     eprintln!(
         "[e2e] columns 28..40 header:  {:?}",
-        &header_dump[28..40]
+        header_dump[28..40]
             .iter()
             .map(|(c, bg, ch)| format!("{c}:{bg:?}:{ch:?}"))
             .collect::<Vec<_>>()
     );
     eprintln!(
         "[e2e] columns 28..40 card:    {:?}",
-        &card_dump[28..40]
+        card_dump[28..40]
             .iter()
             .map(|(c, bg, ch)| format!("{c}:{bg:?}:{ch:?}"))
             .collect::<Vec<_>>()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,20 +145,21 @@ something to step through once a second zj-radar session is live; with just
 one session running, `session-next`/`session-prev` are no-ops.
 
 Dimmed (stale) badge entries are skipped by cycling, but you can dismiss one
-by right-clicking it directly in the rail — a mouse gesture, not a `cmd.v1`
-verb; a dismissed session that turns out to be alive reappears on its next
-heartbeat.
+by clicking its right-edge `✕` directly in the rail — a mouse gesture, not a
+`cmd.v1` verb; a dismissed session that turns out to be alive reappears on its
+next heartbeat.
 
-Right-click is the rail's general acknowledge/dismiss gesture, not only a
-badge thing — the rule is **left-click navigates, right-click
-acknowledges** everywhere on the rail. Beyond a stale badge entry (above),
-right-clicking a pane or tab row still flagged `◆ needs you` acknowledges
-it: the row downgrades to `done`, and — because a click lands in exactly one
+Right-edge glyphs are the rail's working acknowledge/dismiss gesture: `✕` is
+shown only on a stale badge entry and `✓` on an unacknowledged status-origin
+pending tab/pane. Left-clicking elsewhere still navigates. The `✓` downgrades
+the pending pane(s) to `done`, and — because a click lands in exactly one
 plugin instance — it converges by re-broadcasting a `done` update over
 `zj_radar.status.v1`, the same pipe a real agent hook uses, rather than
 mutating this instance's state directly. Every tab's instance (including the
 one you clicked in) picks up the change through the normal status-pipe
-intake. A row with nothing pending is a no-op.
+intake. A row with nothing pending is a no-op. Right-click keeps the same
+whole-row actions for parity, but is currently blocked upstream
+([zellij#5350](https://github.com/zellij-org/zellij/issues/5350)).
 
 Like every command pipe, an unknown verb is ignored, and the action is inert
 until the sidebar has been granted permissions.

--- a/docs/design.md
+++ b/docs/design.md
@@ -277,6 +277,13 @@ unaffected.
   settle has run it does **not** keep the loop alive, so an idle-but-lit rail stops
   waking every second. The loop re-arms on the next pipe/PaneUpdate. (See
   `PluginRuntime::timer_should_continue`.)
+  - **Running exit grace:** a pushed `Running` row starts its 15-tick stale
+    grace only on a `CommandChanged` that positively identifies a foreground
+    shell prompt. `is_foreground: false` and unclassifiable/wrapper argv are
+    weak signals and never start it: a live agent's child-process transition
+    must not be killed by a timer. The trade-off is deliberate — a killed
+    agent can ghost until a later real prompt, payload, exit, or prune signal;
+    bounded ghosts are safer than clearing live work.
 - **Layout — the integration seam.** The sidebar is a pinned, borderless left column *inside* a
   vertical split, *outside* `children`, so `swap_tiled_layout` cycling never disturbs it (same
   mechanism as the existing bars; 0.44.3 has the pop-out fix). The layout layer is the *only*
@@ -570,9 +577,19 @@ same glyphs the per-tab rows use for those statuses. The current line is
 marked (dimmed, a small `•`) and carries no click target — you can't switch
 to the session you're already in. A pending cycle selection renders
 bold+accent; a stale entry renders one step dimmer than the ordinary muted
-line color, but stays fully clickable — a click on it is a deliberate act.
-Clicking any other line switches to that session, landing on its
+line color and a right-edge `✕` hotspot; clicking the glyph dismisses it,
+while clicking any other cell switches to that session, landing on its
 `attention_tab_position` if it has one.
+
+**Hotspots and clicks.** The renderer attaches per-line glyph metadata to the
+same `Line` records that derive ANSI and navigation targets, so Cards painting
+and finalization cannot desynchronize it. A stale peer badge gets `✕`; a tab
+header and a pane identity line with an unacknowledged status-origin Pending
+get `✓`. The glyph owns its final display cell (with one reserved separator),
+and only those cells trigger its action; continuation, overflow, padding,
+ledger, and header lines never do. Right-click preserves the same whole-row
+actions for future parity, but is not a usable trigger until
+[zellij#5350](https://github.com/zellij-org/zellij/issues/5350) is fixed.
 
 **Cycling.** `session-next`/`session-prev`, delivered on the `zj_radar.cmd.v1`
 pipe (documented for operators in `docs/configuration.md`), advance a

--- a/docs/design.md
+++ b/docs/design.md
@@ -511,6 +511,13 @@ ticking alone on an unchanged session never re-writes the file. Withheld
 entirely while `own_session_name` is empty (see below), since an unnamed
 presence file is useless to a peer.
 
+`running` and `attention` are live status-origin pane counts. `running` counts
+live panes whose pushed status is `Running`; `attention` counts live panes whose
+pushed status needs the user. Command-origin activity is deliberately excluded,
+and panes not present in the current topology do not count. This pane-level
+accounting is scoped to cross-session presence only: the local rail row rollups,
+header badge, and footer tally remain tab-level summaries.
+
 **Liveness heartbeat + staleness (task-14: never a hard drop).** Peers never
 call `SessionUpdate`/`get_session_list` to learn who's out there (see "Why
 not `SessionUpdate`" below) — liveness is read from the filesystem, not
@@ -572,10 +579,10 @@ fixed order shared with cycling: current session first, then any FRESH peer
 with `attention > 0` by name, then the rest of the fresh peers by name, then
 every STALE peer by name (a stale peer's attention count isn't actionable,
 so staleness outranks attention for ordering). Each line shows the session
-name plus a running count and an attention count when nonzero, using the
-same glyphs the per-tab rows use for those statuses. The current line is
-marked (dimmed, a small `•`) and carries no click target — you can't switch
-to the session you're already in. A pending cycle selection renders
+name plus the status-origin pane running count and attention count when
+nonzero, using the same glyphs the per-tab rows use for those statuses. The
+current line is marked (dimmed, a small `•`) and carries no click target — you
+can't switch to the session you're already in. A pending cycle selection renders
 bold+accent; a stale entry renders one step dimmer than the ordinary muted
 line color and a right-edge `✕` hotspot; clicking the glyph dismisses it,
 while clicking any other cell switches to that session, landing on its

--- a/docs/design.md
+++ b/docs/design.md
@@ -279,12 +279,13 @@ unaffected.
   waking every second. The loop re-arms on the next pipe/PaneUpdate. (See
   `PluginRuntime::timer_should_continue`.)
   - **Running exit grace:** a pushed `Running` row starts its 15-tick stale
-    grace only on a `CommandChanged` that positively identifies a foreground
-    shell prompt. `is_foreground: false` and unclassifiable/wrapper argv are
-    weak signals and never start it: a live agent's child-process transition
-    must not be killed by a timer. The trade-off is deliberate — a killed
-    agent can ghost until a later real prompt, payload, exit, or prune signal;
-    bounded ghosts are safer than clearing live work.
+    grace only on a `CommandChanged` whose effective argv identifies a shell
+    prompt. Zellij reports the childless pane-root shell with
+    `is_foreground: false`, so that shell-name form is the real prompt-return
+    edge and must clear terminal statuses/arm Running expiry. A non-shell
+    wrapper argv with `is_foreground: false` remains weak evidence and never
+    starts the clock: a live agent's child-process transition must not be
+    mistaken for exit.
 - **Layout — the integration seam.** The sidebar is a pinned, borderless left column *inside* a
   vertical split, *outside* `children`, so `swap_tiled_layout` cycling never disturbs it (same
   mechanism as the existing bars; 0.44.3 has the pop-out fix). The layout layer is the *only*

--- a/docs/rail-reference.md
+++ b/docs/rail-reference.md
@@ -154,6 +154,12 @@ tab 1 "pinky"
 > mark, activity. One layout to learn — a tab with one pane and a tab with
 > three scan identically.
 
+> **Action glyphs.** A stale cross-session badge ends in dim `✕`; an
+> unacknowledged status-origin pending tab header and its pane identity line
+> end in `✓`. The glyph is the final visible cell and the only left-click
+> action area; ordinary row cells navigate. Question continuations, `+N more`,
+> card padding, ledger, and headers never carry a hotspot.
+
 ## D. Single agent — needs you
 
 ```rail-input
@@ -164,8 +170,8 @@ tab 3 "api"
 ```rail-expect
  RADAR                     ·1 1!
 ════════════════════════════════
- ◆ 3 api
- └ ◆ ✳ approve edit?
+ ◆ 3 api                       ✓
+ └ ◆ ✳ approve edit?           ✓
 ```
 
 ## E. Single agent — done
@@ -242,8 +248,8 @@ tab 4 "review"
 ```rail-expect
  RADAR                     ·1 1!
 ════════════════════════════════
- ◆ 4 review
- ├ ◆ ✳ approve diff?
+ ◆ 4 review                    ✓
+ ├ ◆ ✳ approve diff?           ✓
  └ ⠋ ❉ writing tests
 ```
 
@@ -317,8 +323,8 @@ tab 6 "logs"
 ```rail-expect
  RADAR                     6▲ 1!
 ◆═══════════════════════════════
- ◆ 1 review
- └ ◆ ✳ approve diff?
+ ◆ 1 review                    ✓
+ └ ◆ ✳ approve diff?           ✓
  ⠋ 2 af
  └ ⠋ ❉ exploring render
  ● 3 dotfiles
@@ -695,8 +701,8 @@ tab 1 "review"
 ```rail-expect
  RADAR                     ·1 1!
 ════════════════════════════════
- ◆ 1 review
- ├ ◆ ✳ migrate schema
+ ◆ 1 review                    ✓
+ ├ ◆ ✳ migrate schema          ✓
  │   ↳ approve git push?
  └ ⠋ ❉ write insta tests
 ```
@@ -716,8 +722,8 @@ tab 1 "work"
 ```rail-expect
  RADAR                     ·1 1!
 ════════════════════════════════
- ◆ 1 work
- ├ ◆ ✳ approve?
+ ◆ 1 work                      ✓
+ ├ ◆ ✳ approve?                ✓
  └ ● ✳ fix flaky e2e
 ```
 
@@ -736,8 +742,8 @@ tab 1 "review"
 ```rail-expect
  RADAR                     ·1 1!
 ════════════════════════════════
- ◆ 1 review
- └ ◆ ✳ migrate schema
+ ◆ 1 review                    ✓
+ └ ◆ ✳ migrate schema          ✓
      ↳ approve git push?
 ```
 
@@ -781,8 +787,8 @@ tab 1 "review"
 ```rail-expect
  RADAR                     ·1 1!
 ════════════════════════════════
- ◆ 1 review
- ├ ◆ ✳ migrate schema · 12m
+ ◆ 1 review                    ✓
+ ├ ◆ ✳ migrate schema · 12m    ✓
  │   ↳ approve git push?
  └ ⠋ ❉ write insta tests
 ```


### PR DESCRIPTION
Three fixes from daily use of v0.2.0, one of them upstream-blocked.

The right-click actions shipped in v0.2.0 turn out to be unreachable: zellij 0.44.3 never delivers Mouse::RightClick to plugins. The forwarder exists in zellij's plugin pane but nothing calls it; I filed zellij-org/zellij#5350 with the trace. This PR replaces the trigger with click hotspots that work today: a dimmed (stale) session row in the badge gets an x glyph at its right edge that dismisses it, and a row with an unacknowledged pending pane gets a checkmark that acknowledges it. The checkmark is deliberately not an x, so nobody reads it as closing the pane. Left-click anywhere else keeps navigating, and the right-click handlers stay in place. I've sent zellij a fix wiring right-click delivery to plugin panes (zellij-org/zellij#5353); once that lands in a release, a follow-up PR restoring right-click as a second trigger for these actions can be considered. The hotspot metadata lives inside Line itself and rides through every render transformation structurally, so the click map and the glyph cells cannot drift apart. There is a new e2e that clicks the glyph's exact coordinates against a real zellij, which is the test layer that would have caught the right-click gap before release.

Second, presence counts now count agents instead of tabs. Three working agents in one tab previously reported running: 1. The counts are live status-origin panes only, command-origin activity is excluded, and the local rail summaries deliberately stay tab-level. Docs state the semantics.

Third, actively working agents no longer time out of the rail mid-turn. The stale-Running grace clock could be started by weak evidence: is_foreground == false was treated as a prompt return regardless of what the foreground actually was, so an ordinary wrapper or child transition in a live agent's pane could start the 15s expiry while the agent thought for minutes without emitting a hook. The clock now starts only on strong evidence, a genuine shell in the foreground with is_foreground true. To be plain about certainty: the weak-evidence sequence is pinned by a regression test but was reconstructed, not captured from live telemetry, so it is the probable rather than proven field mechanism. The policy change removes the whole class either way, at the documented cost that a killed agent can ghost as Running until the pane's next real signal. If timeouts still show up in the field after this, the remaining suspects are written up in the fix's comments.

While debugging this line of issues I also hit a zellij server crash worth knowing about as a zj-radar user: a failed start-or-reload-plugin against a client-less session leaves pending-plugin state that starves the rail and leaks server FDs until the server dies of EMFILE. Filed as zellij-org/zellij#5349; nothing in this PR depends on it, but the CliPipe timeout floods it causes are easy to misattribute to the plugin.

500 host tests, clippy -D warnings, wasm build, just ci, and 13/13 e2e all pass.

