### PR TITLE
Fix Codex side conversation status

### DIFF
--- a/crates/cli/src/agents/codex.rs
+++ b/crates/cli/src/agents/codex.rs
@@ -15,6 +15,11 @@ pub fn derive(intake: &Intake) -> Option<AgentUpdate> {
 }
 
 fn derive_hook_update(v: &Value) -> Option<AgentUpdate> {
+    // `/side` (`/btw`) runs in an ephemeral fork in the same terminal pane.
+    // Its hooks have no transcript and must not replace the main turn's status.
+    if v.get("transcript_path").is_some_and(Value::is_null) {
+        return None;
+    }
     let event = v.get("hook_event_name")?.as_str()?;
     let cwd = string_field(v, "cwd");
     let (status, msg) = match event {
@@ -220,6 +225,38 @@ mod tests {
         );
         assert_eq!(u.status, Status::Done);
         assert_eq!(u.msg, "implemented");
+    }
+
+    #[test]
+    fn ephemeral_side_conversation_does_not_replace_main_turn() {
+        let mut latest = update(
+            r#"{
+              "hook_event_name": "UserPromptSubmit",
+              "session_id": "main",
+              "transcript_path": "/tmp/main-rollout.jsonl",
+              "prompt": "implement the feature"
+            }"#,
+        );
+        for raw in [
+            r#"{
+              "hook_event_name": "UserPromptSubmit",
+              "session_id": "side",
+              "transcript_path": null,
+              "prompt": "quick question"
+            }"#,
+            r#"{
+              "hook_event_name": "Stop",
+              "session_id": "side",
+              "transcript_path": null,
+              "last_assistant_message": "answer"
+            }"#,
+        ] {
+            if let Some(update) = derive(&Intake { raw, status_arg: None }) {
+                latest = update;
+            }
+        }
+
+        assert_eq!(latest.status, Status::Running);
     }
 
     #[test]

--- a/docs/design.md
+++ b/docs/design.md
@@ -155,6 +155,7 @@ effects. The real external seam remains the **pipe payload schema** (versioned).
 | Codex `UserPromptSubmit` / tool hooks / subagents | `running` |
 | Codex `PermissionRequest`                     | `pending` |
 | Codex `Stop`                                  | `done`    |
+| Codex ephemeral-fork hooks (`transcript_path: null`) | ignored (the main turn keeps owning the pane) |
 | Codex legacy `agent-turn-complete`            | `done`    |
 | Adapter parse/hook failure (optional)         | `error`   |
 | Agent pane returns to its shell prompt (observed exit) | `idle` (clears a stale pushed status; see §6.2) |


### PR DESCRIPTION
## Summary

- ignore Codex hook events from ephemeral `/side` (`/btw`) forks
- preserve the main turn's pane status when an ephemeral side conversation stops
- add a regression test for the main → side prompt → side stop sequence
- document ephemeral-fork handling in the lifecycle table

## Root cause

Codex runs `/side` and `/btw` in an ephemeral fork inside the same terminal pane. Those hook payloads carry `transcript_path: null`, but the adapter previously treated their `Stop` event as the pane's main turn completing. Returning to the main session emits no restoring lifecycle hook, so the side completion remained visible as `done`.

The adapter now ignores only modern hook payloads with an explicitly null `transcript_path`. Payloads where the field is missing and legacy `agent-turn-complete` notifications keep their existing behavior.

## Claude audit

Claude Code's `/btw` path is a tool-less one-shot side request rather than a normal hooked turn. Claude subagent completion is surfaced as `SubagentStop`, which zj-radar already maps to `running`, so no Claude-specific change is needed.

## Validation

- `just ci`
  - Rust tests
  - clippy with warnings denied
  - wasm build
  - shellcheck
  - 60 bash tests
