### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "zj-radar"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "assert_cmd",
  "assertables",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "zj-radar-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "proptest",
  "serde",
@@ -3368,7 +3368,7 @@ dependencies = [
 
 [[package]]
 name = "zj-radar-plugin"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "insta",
  "portable-pty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/core", "crates/cli", "crates/plugin"]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/marktoda/zj-radar"
@@ -22,7 +22,7 @@ rust-version = "1.95"
 # would let an older published CLI resolve a newer, incompatible core and stop
 # compiling. Bump this in lockstep with [workspace.package] version — the
 # release checklist (RELEASING.md) walks through it.
-zj-radar-core = { path = "crates/core", version = "=0.2.1" }
+zj-radar-core = { path = "crates/core", version = "=0.2.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 unicode-width = "0.2"

--- a/plugins/zj-radar-claude/.claude-plugin/plugin.json
+++ b/plugins/zj-radar-claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zj-radar-claude",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Broadcast Claude Code agent status to the zj-radar Zellij sidebar (working/waiting/done), with zero settings.json editing.",
   "author": { "name": "Mark Toda" },
   "homepage": "https://github.com/marktoda/zj-radar"


### PR DESCRIPTION
## Summary

- bump the workspace and lockfile package versions to 0.2.2
- keep the CLI's exact core dependency pin in lockstep
- bump the Claude producer plugin metadata to 0.2.2

## Why

Publish the Codex side-conversation status fix merged in #8 as a patch release.

## Impact

This prepares the coordinated crates.io packages, Claude plugin metadata, and tag-driven GitHub artifacts for v0.2.2. There are no additional runtime changes in this PR.

## Validation

- `just ci`
- `cargo publish --dry-run -p zj-radar-core`
- Rust 1.95 MSRV is a required PR check before publish/tag
