### PR TITLE
Activity model: interactive commands never show as running; service marks; run tags

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -89,7 +89,7 @@ handler by construction.
 
 **Cadence** is a related but distinct axis — how often the one-shot timer
 re-fires, not whether it notifies. Two speeds (`PluginRuntime::desired_cadence`):
-Fast (1 Hz) while there's tick-windowed work — `has_running_work` (a spinning
+Fast (1 Hz) while there's tick-windowed work — `needs_fast_ticks` (a spinning
 glyph), an un-carried completion edge (a status-pipe recede/notify deferred to
 the timer because its own focus can't be trusted), a command `Done` awaiting
 its `DONE_TTL_TICKS` recede, or an active ping flash. Slow (1/60 Hz — once a

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -115,13 +115,16 @@ proportional to actual change:
   promotes it), a `CwdChanged` (naming rides the `RenameTab` effect's own
   `TabUpdate` echo).
 - **Label-only deferral.** A Running→Running update (new activity label, same
-  status) neither renders nor persists inline: the Fast (1 Hz) tick is armed
-  whenever anything is Running and repaints unconditionally, so the label
+  status) on an *animating* row neither renders nor persists inline: the Fast
+  (1 Hz) tick is armed while the row animates (`TrackedObservation::animating`
+  — Running and not a service) and repaints unconditionally, so the label
   lands ≤1s later, and the snapshot write rides the tick's flush
   (`SnapshotWrite::Deferred` → the runtime's `snapshot_dirty`; an inline
   `SnapshotWrite::Now` on the same pass clears the flag — it supersedes).
-  Only while Running — a rewritten Pending question renders now, because
-  Pending doesn't pin Fast cadence.
+  Only while animating — a rewritten Pending question renders now (Pending
+  doesn't pin Fast cadence), and so does a Running *service's* label (the
+  steady `▸` row doesn't either — deferral there would mean the ≤60s Slow
+  heartbeat).
 - **Rows-diff gate.** `project` drops a requested render whose content-derived
   key (rows, ledger lines, badge, theme) equals what the last `render()`
   actually drew (`last_render_key`, stamped in `render`). `force_render`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -257,8 +257,12 @@ a `Kind`-keyed `Status`:
   `Kind::from_source`, pinned by the `source_round_trips_through_kind` guard test.
 - **Observed** — uninstrumented commands (e.g. `cargo test`) that Radar watches
   from outside. The plugin classifies the observed argv via
-  `crates/core/src/command.rs::command_kind` and infers status from the process
+  `crates/core/src/command.rs::classify` and infers status from the process
   lifecycle. No wire, no CLI. `cargo test` lives here, **not** in `agents/`.
+  *Interactive* commands (editors/pagers/TUIs — `DEFAULT_INTERACTIVE` +
+  the `interactive_commands` config) are observed but never earn a Running
+  row: they record a quiet pending whose identity labels exits and the muted
+  pane label (`docs/activity-model.md`).
 
 The two modalities also interact at *exit*: a pushed producer (an agent) fires no
 hook when it quits, so its last status (`done`/`pending`/`error`) would otherwise
@@ -283,14 +287,19 @@ The per-pane → per-tab roll-up: severity order `error > pending > running > do
 idle`, with `done/total` counts and a highest-severity detail line. Tab status is
 never derived from tab names — a single tab can hold several agent panes.
 
-The **roll-up seam** is `rollup::roll_up(panes, resolve) -> TabDisplay` (in
-`crates/plugin/src/rollup.rs`): a deep, pure module that owns its output
+The **roll-up seam** is `rollup::roll_up(panes, resolve, quiet) -> TabDisplay`
+(in `crates/plugin/src/rollup.rs`): a deep, pure module that owns its output
 vocabulary (`TabDisplay`, `PaneDisplay`,
 `PrimaryDetail`, `ProgressCounts`, `Outcome`) — the renderer *consumes* these, so
 presentation depends on the roll-up, not the reverse. `resolve(pane_id) ->
-Option<&TrackedObservation>` is the only thing crossing in: the "status pipe wins
+Option<&TrackedObservation>` is the main thing crossing in: the "status pipe wins
 over command" precedence across observation sources stays in `RadarState`
 (`RadarState::resolve`), so `roll_up` never learns there is more than one store.
+`quiet(pane_id)` feeds the interactive muted label (`PaneDisplay::Interactive`
+from the command store's quiet pendings); `roll_up` owns its precedence — shown
+only where no live observation outranks it, contributing nothing to counts or
+severity. On equal severity, a bounded job outranks a service for the primary
+detail (`docs/activity-model.md` §3).
 `Outcome`'s display methods
 (`full`/`minimal`/`role` — glyphs and width-driven forms) live in `render`; the
 enum here is pure semantics.

--- a/crates/cli/src/agents.rs
+++ b/crates/cli/src/agents.rs
@@ -6,7 +6,7 @@
 //! This is the PUSHED modality of the information-source model (see CONTEXT.md):
 //! instrumented agents report rich status through the status contract. The
 //! OBSERVED modality — uninstrumented commands like `cargo test`, classified by
-//! `command.rs::command_source` inside the plugin — is a sibling, not part of
+//! `command.rs::classify` inside the plugin — is a sibling, not part of
 //! this seam. Both converge on the `Kind`/`source` vocabulary.
 
 mod claude;
@@ -152,6 +152,23 @@ pub fn task_from_prompt(prompt: &str) -> Option<String> {
 pub fn trailing_question(msg: &str) -> Option<&str> {
     let line = msg.lines().rev().map(str::trim).find(|l| !l.is_empty())?;
     (line.ends_with('?') || line.ends_with('？')).then_some(line)
+}
+
+/// The msg baseline every producer shares (the Claude adapter and `notify
+/// generic`; codex builds per-event and never needs it; the bash fallback
+/// mirrors it in notify.sh): idle always broadcasts a BLANK msg — it means
+/// "no activity", so any stale message the payload rides in on (e.g. a
+/// SessionStart session_title) is dropped and the row recedes cleanly on
+/// `/clear` — and a running row with nothing better to say gets the
+/// `working` placeholder so it never renders blank.
+pub fn baseline_msg(status: Status, msg: &str) -> String {
+    if status == Status::Idle {
+        String::new()
+    } else if status == Status::Running && msg.trim().is_empty() {
+        "working".to_string()
+    } else {
+        msg.to_string()
+    }
 }
 
 fn basename(path: &str) -> Option<&str> {

--- a/crates/cli/src/agents/claude.rs
+++ b/crates/cli/src/agents/claude.rs
@@ -65,19 +65,11 @@ pub fn derive(intake: &Intake) -> Option<AgentUpdate> {
         }
     }
 
-    // A running broadcast with no message renders as a blank active row. Give it
-    // a neutral baseline; the tool-activity substitution below refines it when a
-    // tool name/input is present. idle is the inverse — it means "no activity",
-    // so it always carries a blank msg (drops any stale message the payload
-    // happens to ride in on, e.g. a SessionStart session_title), letting the row
-    // recede cleanly on `/clear`.
-    let mut out_msg = if status == Status::Idle {
-        String::new()
-    } else if status == Status::Running && msg.trim().is_empty() {
-        "working".to_string()
-    } else {
-        msg.to_string()
-    };
+    // The shared producer baseline (`agents::baseline_msg`): running-but-blank
+    // gets `working`, idle always broadcasts blank. The tool-activity
+    // substitution below refines the running case when a tool name/input is
+    // present.
+    let mut out_msg = super::baseline_msg(status, msg);
 
     // For PreToolUse/PostToolUse, show the live action instead of the baseline.
     if status == Status::Running && matches!(event, Some("PreToolUse") | Some("PostToolUse")) {

--- a/crates/cli/src/notify.rs
+++ b/crates/cli/src/notify.rs
@@ -210,14 +210,7 @@ fn wire_vocabulary() -> String {
 /// broadcasts blank; an empty task means "keep the stored label" (wire rule).
 fn generic_update(status: Option<&str>, msg: Option<&str>, task: Option<&str>) -> Option<AgentUpdate> {
     let status = Status::try_from_wire(status?)?;
-    let msg = msg.unwrap_or("");
-    let msg = if status == Status::Idle {
-        String::new()
-    } else if status == Status::Running && msg.trim().is_empty() {
-        "working".to_string()
-    } else {
-        msg.to_string()
-    };
+    let msg = crate::agents::baseline_msg(status, msg.unwrap_or(""));
     Some(AgentUpdate {
         status,
         msg,

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -83,7 +83,27 @@ fn notify_codex_hook_broadcasts_pending_payload() {
     let status = child.wait().unwrap();
     assert!(status.success());
 
-    let captured = fs::read_to_string(capture).unwrap();
+    // The send runs in a deliberately DETACHED `sh` subtree (the self-limiting
+    // watchdog around `zellij pipe` — core::pipe), so `zj-radar notify` can
+    // exit before the fake zellij has written the capture file. Poll with a
+    // deadline instead of reading immediately; the deadline is generous
+    // because CI runs this under parallel-build load.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let captured = loop {
+        let captured = fs::read_to_string(&capture).unwrap_or_default();
+        let complete = captured
+            .lines()
+            .last()
+            .is_some_and(|l| serde_json::from_str::<serde_json::Value>(l).is_ok());
+        if complete {
+            break captured;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "fake zellij never wrote a complete capture; got:\n{captured}"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    };
     assert!(captured.contains("pipe\n"));
     assert!(captured.contains("--name\nzj_radar.status.v1\n"));
     let payload = captured.lines().last().unwrap();

--- a/crates/core/src/command.rs
+++ b/crates/core/src/command.rs
@@ -875,7 +875,7 @@ impl CommandStore {
     /// turned off (a Ctrl-C'd dev server must still flip Done in ~2s, not on
     /// the Slow heartbeat). A quiet pending never promotes, so an open editor
     /// still costs zero ticks.
-    pub fn has_pending_or_active(&self) -> bool {
+    pub fn needs_ticks(&self) -> bool {
         self.pending.values().any(|p| p.promotable)
             || !self.pending_done.is_empty()
             || self.store.any(TrackedObservation::animating)

--- a/crates/core/src/command.rs
+++ b/crates/core/src/command.rs
@@ -861,21 +861,24 @@ impl CommandStore {
         let _ = self.store.insert(pane_id, observation);
     }
 
-    /// True if any pane is Running or has a pending fg command. Used (alongside
-    /// `StatusStore::any_running`) to keep the timer armed while work animates: a
-    /// finished command is terminal and needs no further ticking, so only
-    /// `Running` (plus a not-yet-promoted pending command) counts as live here.
+    /// True while this store has tick-driven work: an animated Running row
+    /// ([`TrackedObservation::animating`] — services hold the steady mark and
+    /// are excluded), a promotable pending awaiting its debounce promotion, or
+    /// a tentative-Done awaiting its debounce confirm. Used (alongside
+    /// `StatusStore::needs_ticks`) to keep the timer armed; a finished command
+    /// is terminal and needs no further ticking.
     ///
-    /// Two exclusions keep the timer honest about *animation*
-    /// (`docs/activity-model.md` — only bounded Job work spins): a quiet
-    /// pending never promotes, so an open editor must not pin the 1 Hz timer;
-    /// and a Running `Server` renders a steady mark, not a spinner, so a dev
-    /// server left overnight costs zero ticks.
+    /// `pending_done` counts explicitly: it is a scheduled one-shot exactly
+    /// like a promotable pending, and it is the only tick source for a
+    /// *service* row's Running→Done confirm — the Running row that used to
+    /// keep the timer armed for it is precisely what the service exclusion
+    /// turned off (a Ctrl-C'd dev server must still flip Done in ~2s, not on
+    /// the Slow heartbeat). A quiet pending never promotes, so an open editor
+    /// still costs zero ticks.
     pub fn has_pending_or_active(&self) -> bool {
         self.pending.values().any(|p| p.promotable)
-            || self
-                .store
-                .any(|s| s.status == Status::Running && !s.kind.is_service())
+            || !self.pending_done.is_empty()
+            || self.store.any(TrackedObservation::animating)
     }
 
     /// Any command Done is by definition inside its TTL window (TTL flips it to
@@ -913,8 +916,13 @@ impl CommandStore {
             }
         }
         // Demote already-promoted Running rows for now-interactive commands to
-        // Idle. Not a completion, so nothing is ledgered; the identity stays
-        // recorded in the (now quiet) pending when one exists.
+        // Idle. Not a completion, so nothing is ledgered. Promotion consumed
+        // the pending, so RECONSTRUCT the quiet pending from the observation —
+        // that makes the swept state identical to the intake state: the muted
+        // Interactive label shows, a held pane's exit stays labeled, and
+        // removing the config entry later re-promotes symmetrically. (The
+        // observation's `repo` is already a basename; `on_exit`'s
+        // `basename(cwd)` is idempotent over it.)
         let to_demote: Vec<u32> = self
             .store
             .observations()
@@ -928,6 +936,14 @@ impl CommandStore {
             if let Some(s) = self.store.get_mut(pane_id) {
                 s.status = Status::Idle;
                 changed = true;
+                let quiet = Pending {
+                    command: s.msg.clone(),
+                    cwd: s.repo.clone(),
+                    kind: s.kind,
+                    since_tick: s.last_change_tick,
+                    promotable: false,
+                };
+                self.pending.entry(pane_id).or_insert(quiet);
             }
         }
         changed

--- a/crates/core/src/command.rs
+++ b/crates/core/src/command.rs
@@ -84,24 +84,49 @@ const IGNORE_NAMES: &[&str] = &[
 /// still surfaces a Running/Done lifecycle under their own `Kind`.
 pub const AGENT_NAMES: &[&str] = &["claude", "codex"];
 
-/// A pending foreground command awaiting debounce promotion.
+/// Interactive programs — editors, pagers, monitors, git TUIs, file managers —
+/// that sit open waiting on the *user* rather than doing bounded work
+/// (`docs/activity-model.md`: the Companion class). Classification data, not an
+/// ignore list: a command here still records its identity as a quiet pending
+/// (never promoted to a Running row, but labeling its exit and feeding the
+/// muted pane label), extended per-user by the `interactive_commands` config
+/// key. The third name-list role beside the other two, and the roles must
+/// never merge (pinned by `interactive_set_disjoint_from_prompt_and_agent_names`):
+/// `IGNORE_NAMES` = "back at the prompt" (exit-clears pushed status),
+/// `AGENT_NAMES` = "owned by the push pipe", this = "a real command that never
+/// earns a Running row". An editor placed in `IGNORE_NAMES` instead would make
+/// "opened nvim" read as "returned to shell" and wrongly exit-clear a finished
+/// agent's pushed status.
+pub const DEFAULT_INTERACTIVE: &[&str] = &[
+    "vi", "vim", "nvim", "emacs", "nano", "hx", "kak", "micro",
+    "less", "more", "most", "man",
+    "htop", "btop", "top",
+    "lazygit", "tig", "gitui", "k9s",
+    "fzf", "ranger", "yazi", "nnn", "lf", "mc",
+];
+
+/// A pending foreground command awaiting debounce promotion — or, for an
+/// interactive command (`promotable: false`), a *quiet* pending: identity
+/// recorded for exit labeling and the muted pane label, but never promoted to
+/// a Running row and never arming the fast cadence.
 struct Pending {
     command: String,
     cwd: String,
     kind: Kind,
     since_tick: u64,
+    promotable: bool,
 }
 
 /// Tracks per-pane command activity for terminal panes that have no agent
 /// producer. The resolved display state is stored as `TrackedObservation` so it can be
 /// consumed uniformly by the downstream aggregator.
-#[derive(Default)]
 pub struct CommandStore {
     /// Resolved displayable state, ready for aggregation. The map and its focus
     /// lifecycle are shared with `StatusStore` via `ObservationStore`; only the
     /// command-specific debounce maps below are unique to this store.
     store: ObservationStore,
-    /// Pending fg commands awaiting debounce promotion.
+    /// Pending fg commands awaiting debounce promotion (or quiet — see
+    /// [`Pending::promotable`]).
     pending: HashMap<u32, Pending>,
     /// Panes whose Running command has *left* the foreground, awaiting debounce
     /// confirmation before flipping to Done. Value = tick first observed leaving.
@@ -112,6 +137,22 @@ pub struct CommandStore {
     /// Exit-dedup: last-seen exit status per pane, to avoid re-applying
     /// identical exits.
     exited: HashMap<u32, Option<i32>>,
+    /// The effective interactive set: [`DEFAULT_INTERACTIVE`] ∪ the user's
+    /// `interactive_commands` extras (composed in [`Self::set_interactive_extras`]).
+    /// Matched on the peeled program name at intake.
+    interactive: HashSet<String>,
+}
+
+impl Default for CommandStore {
+    fn default() -> Self {
+        CommandStore {
+            store: ObservationStore::default(),
+            pending: HashMap::new(),
+            pending_done: HashMap::new(),
+            exited: HashMap::new(),
+            interactive: DEFAULT_INTERACTIVE.iter().map(|s| s.to_string()).collect(),
+        }
+    }
 }
 
 /// Extract the basename from a path-like string (split on `/`, take last
@@ -509,9 +550,24 @@ impl CommandStore {
             }
             // Otherwise leave resolved unchanged (idle stays idle).
         } else {
-            // A real foreground command is running: it is no longer leaving, so
-            // cancel any tentative-done.
-            self.pending_done.remove(&pane_id);
+            let interactive = self.interactive.contains(name);
+            if interactive {
+                // An interactive command (editor/pager/TUI) is the pane's fg:
+                // any PRIOR Running command has ended, exactly as in the ignore
+                // branch above — opening nvim after `cargo build` finished must
+                // still flip the build row to Done.
+                if self
+                    .store
+                    .get(pane_id)
+                    .is_some_and(|s| s.status == Status::Running)
+                {
+                    self.pending_done.entry(pane_id).or_insert(tick);
+                }
+            } else {
+                // A real foreground command is running: it is no longer
+                // leaving, so cancel any tentative-done.
+                self.pending_done.remove(&pane_id);
+            }
             // Build the cleaned command string and its Kind in one pass.
             let (cmd_string, kind) = classify(command);
             if cmd_string.is_empty() {
@@ -528,6 +584,10 @@ impl CommandStore {
             self.exited.remove(&pane_id);
 
             let cwd_str = cwd.unwrap_or("").to_string();
+            // Interactive commands record a QUIET pending: the identity is kept
+            // — it labels a held pane's exit (`nvim ✓`, never a blank Done row)
+            // and feeds the muted pane label — but `on_timer` never promotes it
+            // to a Running row, and it never arms the fast cadence.
             self.pending.insert(
                 pane_id,
                 Pending {
@@ -535,6 +595,7 @@ impl CommandStore {
                     cwd: cwd_str,
                     kind,
                     since_tick: tick,
+                    promotable: !interactive,
                 },
             );
         }
@@ -558,7 +619,7 @@ impl CommandStore {
         let to_promote: Vec<u32> = self
             .pending
             .iter()
-            .filter(|(_, p)| tick.saturating_sub(p.since_tick) >= DEBOUNCE_TICKS)
+            .filter(|(_, p)| p.promotable && tick.saturating_sub(p.since_tick) >= DEBOUNCE_TICKS)
             .map(|(&id, _)| id)
             .collect();
 
@@ -804,8 +865,17 @@ impl CommandStore {
     /// `StatusStore::any_running`) to keep the timer armed while work animates: a
     /// finished command is terminal and needs no further ticking, so only
     /// `Running` (plus a not-yet-promoted pending command) counts as live here.
+    ///
+    /// Two exclusions keep the timer honest about *animation*
+    /// (`docs/activity-model.md` — only bounded Job work spins): a quiet
+    /// pending never promotes, so an open editor must not pin the 1 Hz timer;
+    /// and a Running `Server` renders a steady mark, not a spinner, so a dev
+    /// server left overnight costs zero ticks.
     pub fn has_pending_or_active(&self) -> bool {
-        !self.pending.is_empty() || self.store.any(|s| s.status == Status::Running)
+        self.pending.values().any(|p| p.promotable)
+            || self
+                .store
+                .any(|s| s.status == Status::Running && !s.kind.is_service())
     }
 
     /// Any command Done is by definition inside its TTL window (TTL flips it to
@@ -814,6 +884,70 @@ impl CommandStore {
     pub fn has_done_awaiting_recede(&self) -> bool {
         self.store.any(|s| s.status == Status::Done)
     }
+
+    /// Compose the effective interactive set (`DEFAULT_INTERACTIVE` ∪ `extras`)
+    /// and apply it **level-triggered**: sweep already-recorded state so the
+    /// config works on rows that will never see another `CommandChanged` — a
+    /// mid-session TUI fires no event until it exits, and a restart's snapshot
+    /// rehydrates its Running row, so without the sweep the spinner (and its
+    /// 1 Hz cadence pin) would persist until the editor closes. Matching keys
+    /// on the display's first whitespace token, which equals the peeled exe
+    /// basename by construction of every display path (pinned by
+    /// `display_first_token_is_the_exe_basename`). Returns whether anything
+    /// observable changed (the caller's render/persist trigger).
+    pub fn set_interactive_extras<'a>(&mut self, extras: impl IntoIterator<Item = &'a str>) -> bool {
+        self.interactive = DEFAULT_INTERACTIVE
+            .iter()
+            .copied()
+            .chain(extras)
+            .map(str::to_string)
+            .collect();
+        let mut changed = false;
+        // Re-judge every pending against the new set — symmetric, so removing
+        // an extra un-quiets its pending and the next tick promotes it.
+        for p in self.pending.values_mut() {
+            let quiet = first_token(&p.command).is_some_and(|t| self.interactive.contains(t));
+            if p.promotable == quiet {
+                p.promotable = !quiet;
+                changed = true;
+            }
+        }
+        // Demote already-promoted Running rows for now-interactive commands to
+        // Idle. Not a completion, so nothing is ledgered; the identity stays
+        // recorded in the (now quiet) pending when one exists.
+        let to_demote: Vec<u32> = self
+            .store
+            .observations()
+            .filter(|(_, s)| {
+                s.status == Status::Running
+                    && first_token(&s.msg).is_some_and(|t| self.interactive.contains(t))
+            })
+            .map(|(id, _)| id)
+            .collect();
+        for pane_id in to_demote {
+            if let Some(s) = self.store.get_mut(pane_id) {
+                s.status = Status::Idle;
+                changed = true;
+            }
+        }
+        changed
+    }
+
+    /// The quiet identity of a pane whose interactive command is in the
+    /// foreground: `(display, kind)` from its non-promotable pending. Feeds
+    /// the rail's muted pane label (`rollup::PaneDisplay::Interactive`).
+    pub fn quiet_identity(&self, pane_id: u32) -> Option<(&str, Kind)> {
+        self.pending
+            .get(&pane_id)
+            .filter(|p| !p.promotable)
+            .map(|p| (p.command.as_str(), p.kind))
+    }
+}
+
+/// First whitespace-separated token of a display string, login-dash stripped —
+/// the exe basename by construction (see `set_interactive_extras`).
+fn first_token(display: &str) -> Option<&str> {
+    display.split_whitespace().next().map(|t| t.trim_start_matches('-'))
 }
 
 #[cfg(test)]

--- a/crates/core/src/command/tests.rs
+++ b/crates/core/src/command/tests.rs
@@ -1227,6 +1227,26 @@
         assert!(changed);
         assert_eq!(s.get(1).unwrap().status, Status::Idle, "demoted, not ledgered");
         assert!(!s.has_pending_or_active());
+        // Promotion consumed the pending, so the sweep RECONSTRUCTS the quiet
+        // pending from the observation — the swept state must be identical to
+        // the intake state: muted label available, exits labeled.
+        assert_eq!(
+            s.quiet_identity(1),
+            Some(("gdb", Kind::Command)),
+            "demote reconstructs the quiet pending"
+        );
+        // …and un-quieting is symmetric even for a swept row: the
+        // reconstructed pending flips promotable and re-promotes.
+        let changed = s.set_interactive_extras([]);
+        assert!(changed);
+        s.on_timer(Tick(DEBOUNCE_TICKS * 3), EpochSecs(300));
+        assert_eq!(
+            s.get(1).unwrap().status,
+            Status::Running,
+            "swept row re-promotes after the extra is removed"
+        );
+        let changed = s.set_interactive_extras(["gdb"]);
+        assert!(changed, "re-quieting demotes again");
 
         // Symmetric: clearing the extras un-quiets a pending, which then
         // promotes on the next tick.
@@ -1250,4 +1270,28 @@
         let obs = s.get(1).unwrap();
         assert_eq!((obs.status, obs.kind), (Status::Running, Kind::Server));
         assert!(!s.has_pending_or_active(), "a steady service costs zero ticks");
+    }
+
+    #[test]
+    fn service_done_confirm_still_arms_the_timer() {
+        // The regression the service exclusion nearly shipped: `pending_done`
+        // used to inherit its tick source from the Running row it debounces.
+        // For a service that row no longer arms, so `pending_done` must count
+        // in the predicate itself — a Ctrl-C'd dev server flips Done in ~2s,
+        // not on the ≤60s Slow heartbeat.
+        let mut s = CommandStore::default();
+        s.on_command_changed(1, &argv(&["npm", "run", "dev"]), true, None, 0);
+        s.on_timer(Tick(DEBOUNCE_TICKS), EpochSecs(100));
+        assert!(!s.has_pending_or_active(), "steady while the server runs");
+
+        // Ctrl-C: back to the shell arms the tentative-done…
+        s.on_command_changed(1, &argv(&["zsh"]), true, None, DEBOUNCE_TICKS + 1);
+        assert!(
+            s.has_pending_or_active(),
+            "the armed Done confirm is a scheduled one-shot — it needs ticks"
+        );
+        // …which the debounce window then confirms, and the timer may disarm.
+        s.on_timer(Tick(DEBOUNCE_TICKS * 2 + 1), EpochSecs(200));
+        assert_eq!(s.get(1).unwrap().status, Status::Done, "a dead dev server is news");
+        assert!(!s.has_pending_or_active());
     }

--- a/crates/core/src/command/tests.rs
+++ b/crates/core/src/command/tests.rs
@@ -613,7 +613,7 @@
     fn prune_drops_dead_panes_from_all_maps() {
         let mut store = CommandStore::default();
 
-        // Set up pane 1: pending
+        // Set up pane 1: pending (quiet — vim is interactive; prune must see it too)
         store.on_command_changed(1, &["vim".to_string()], true, None, 1);
         // Set up pane 2: resolved Running
         store.on_command_changed(2, &["cargo".to_string()], true, None, 1);
@@ -645,8 +645,9 @@
         let mut store = CommandStore::default();
         assert!(!store.has_pending_or_active(), "empty store → false");
 
-        // Add a pending entry
-        store.on_command_changed(1, &["vim".to_string()], true, None, 1);
+        // Add a pending entry (a promotable job — an interactive command like
+        // vim records only a QUIET pending, which must never arm the timer).
+        store.on_command_changed(1, &["sleep".to_string(), "30".to_string()], true, None, 1);
         assert!(store.has_pending_or_active(), "true while pending");
 
         // Promote to Running
@@ -1088,4 +1089,165 @@
         // no follow-up event at all
         s.on_timer(Tick(DEBOUNCE_TICKS), EpochSecs(100));
         assert_eq!(s.get(1).unwrap().status, Status::Running, "documented failure mode");
+    }
+
+    // ── Interactive commands: the Companion class (docs/activity-model.md) ──
+
+    #[test]
+    fn interactive_set_disjoint_from_prompt_and_agent_names() {
+        // The three name lists carry three DIFFERENT contracts (prompt /
+        // push-owned / quiet), and a name drifting into two of them silently
+        // re-creates the "opened nvim reads as returned-to-shell" trap.
+        for name in DEFAULT_INTERACTIVE {
+            assert!(
+                !IGNORE_NAMES.contains(name),
+                "{name} must not double as a shell-prompt name"
+            );
+            assert!(
+                !AGENT_NAMES.contains(name),
+                "{name} must not double as a push-agent name"
+            );
+        }
+    }
+
+    #[test]
+    fn display_first_token_is_the_exe_basename() {
+        // The interactive sweep (`set_interactive_extras`) matches promoted
+        // rows on the display's first whitespace token — sound only while
+        // every display path leads with the peeled exe basename. Pin it
+        // across every rule shape: table rules, python, the first-arg
+        // fallback, and wrapper/env peeling.
+        let cases: &[&[&str]] = &[
+            &["cargo", "test", "core"],
+            &["go", "build", "./..."],
+            &["npm", "run", "dev"],
+            &["pytest", "-q", "tests"],
+            &["make", "deploy"],
+            &["python", "-m", "pytest", "t.py"],
+            &["python3.12", "app.py"],
+            &["nvim", "README.md"],
+            &["/usr/bin/htop"],
+            &["sudo", "make", "install"],
+            &["RUST_LOG=debug", "cargo", "build"],
+            &["env", "FOO=1", "k9s"],
+        ];
+        for case in cases {
+            let raw = argv(case);
+            let (peeled, name) = effective_program(&raw);
+            let (display, _) = classify(peeled);
+            let first = display.split_whitespace().next().unwrap_or("");
+            assert_eq!(
+                first.trim_start_matches('-'),
+                name,
+                "display {display:?} must lead with the exe for {case:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn interactive_command_never_promotes_and_never_arms_the_timer() {
+        let mut s = CommandStore::default();
+        s.on_command_changed(1, &argv(&["nvim", "README.md"]), true, None, 0);
+        assert!(
+            !s.has_pending_or_active(),
+            "a quiet pending must not pin the 1 Hz cadence"
+        );
+        let r = s.on_timer(Tick(DEBOUNCE_TICKS * 10), EpochSecs(100));
+        assert!(s.get(1).is_none(), "never promoted to a Running row");
+        assert!(!r.changed);
+        assert_eq!(
+            s.quiet_identity(1),
+            Some(("nvim README.md", Kind::Command)),
+            "identity is recorded for the muted label and exit labeling"
+        );
+    }
+
+    #[test]
+    fn interactive_over_running_flips_prior_command_done() {
+        // `cargo build` finished and nvim was opened in the same pane: the
+        // build row must flip Done via the same tentative-done debounce the
+        // shell-return path uses.
+        let mut s = CommandStore::default();
+        s.on_command_changed(1, &argv(&["cargo", "build"]), true, None, 0);
+        s.on_timer(Tick(DEBOUNCE_TICKS), EpochSecs(100));
+        assert_eq!(s.get(1).unwrap().status, Status::Running);
+        s.on_command_changed(1, &argv(&["nvim"]), true, None, DEBOUNCE_TICKS + 1);
+        s.on_timer(Tick(DEBOUNCE_TICKS * 2 + 1), EpochSecs(200));
+        let obs = s.get(1).unwrap();
+        assert_eq!(obs.status, Status::Done, "prior Running command completed");
+        assert_eq!(obs.msg, "cargo build");
+        assert_eq!(s.quiet_identity(1), Some(("nvim", Kind::Command)));
+    }
+
+    #[test]
+    fn held_pane_interactive_exit_labels_from_quiet_pending() {
+        // `zellij run -- nvim`, editor closed: the manifest exit must wear the
+        // quiet pending's identity — never a blank Done row.
+        let mut s = CommandStore::default();
+        s.on_command_changed(1, &argv(&["nvim"]), true, Some("/w/proj"), 0);
+        s.on_exit(1, Some(0), Tick(50), EpochSecs(1000));
+        let obs = s.get(1).unwrap();
+        assert_eq!(obs.status, Status::Done);
+        assert_eq!(obs.msg, "nvim", "completion labeled from the quiet pending");
+        assert_eq!(obs.repo, "proj");
+        assert_eq!(s.quiet_identity(1), None, "exit consumed the pending");
+    }
+
+    #[test]
+    fn interactive_commands_are_not_prompts_and_not_agents() {
+        // The prompt contract is untouched: opening an editor must not read
+        // as "returned to shell" (which exit-clears pushed agent statuses) and
+        // must not vouch for an agent (grace-clock cancel).
+        for name in ["nvim", "less", "htop"] {
+            assert!(!is_shell_prompt(&argv(&[name])));
+            assert!(!is_agent_command(&argv(&[name])));
+        }
+    }
+
+    #[test]
+    fn shell_return_discards_quiet_pending() {
+        let mut s = CommandStore::default();
+        s.on_command_changed(1, &argv(&["nvim"]), true, None, 0);
+        s.on_command_changed(1, &argv(&["zsh"]), true, None, 5);
+        assert_eq!(s.quiet_identity(1), None, "back at the prompt — label gone");
+        assert!(s.get(1).is_none(), "no row was ever created");
+    }
+
+    #[test]
+    fn set_interactive_extras_sweeps_promoted_rows_level_triggered() {
+        // gdb is not in the defaults: it promotes to Running. Adding it as an
+        // extra must demote the row NOW — a TUI fires no further
+        // CommandChanged until it exits, so the sweep is the only edge.
+        let mut s = CommandStore::default();
+        s.on_command_changed(1, &argv(&["gdb"]), true, None, 0);
+        s.on_timer(Tick(DEBOUNCE_TICKS), EpochSecs(100));
+        assert_eq!(s.get(1).unwrap().status, Status::Running);
+
+        let changed = s.set_interactive_extras(["gdb"]);
+        assert!(changed);
+        assert_eq!(s.get(1).unwrap().status, Status::Idle, "demoted, not ledgered");
+        assert!(!s.has_pending_or_active());
+
+        // Symmetric: clearing the extras un-quiets a pending, which then
+        // promotes on the next tick.
+        s.on_command_changed(2, &argv(&["gdb"]), true, None, 10);
+        assert_eq!(s.quiet_identity(2), Some(("gdb", Kind::Command)));
+        let changed = s.set_interactive_extras([]);
+        assert!(changed, "pending flipped promotable");
+        s.on_timer(Tick(10 + DEBOUNCE_TICKS), EpochSecs(200));
+        assert_eq!(s.get(2).unwrap().status, Status::Running, "un-quieted and promoted");
+    }
+
+    #[test]
+    fn service_running_does_not_arm_the_timer() {
+        // A Running Server renders the steady mark — nothing animates, so it
+        // must not pin the 1 Hz cadence (docs/activity-model.md §3). The
+        // pending phase still arms (the promotion tick needs to fire).
+        let mut s = CommandStore::default();
+        s.on_command_changed(1, &argv(&["npm", "run", "dev"]), true, None, 0);
+        assert!(s.has_pending_or_active(), "pending promotion still needs a tick");
+        s.on_timer(Tick(DEBOUNCE_TICKS), EpochSecs(100));
+        let obs = s.get(1).unwrap();
+        assert_eq!((obs.status, obs.kind), (Status::Running, Kind::Server));
+        assert!(!s.has_pending_or_active(), "a steady service costs zero ticks");
     }

--- a/crates/core/src/command/tests.rs
+++ b/crates/core/src/command/tests.rs
@@ -557,7 +557,7 @@
         // keeps its id and stays live, so its `exited` dedup entry survives. When
         // the pane is RE-RUN and exits with the SAME code, the second exit must
         // still resolve to Done — otherwise the row is stuck Running forever and
-        // `has_pending_or_active` keeps the timer armed (poll/CPU drain).
+        // `needs_ticks` keeps the timer armed (poll/CPU drain).
         let mut store = CommandStore::default();
 
         // First run: promote to Running, then exit 0 → Done.
@@ -583,7 +583,7 @@
             "a re-run's exit must apply even when its code matches the prior run"
         );
         assert!(
-            !store.has_pending_or_active(),
+            !store.needs_ticks(),
             "a finished re-run must not keep the timer armed"
         );
     }
@@ -638,35 +638,35 @@
         );
     }
 
-    // ── Test 8: has_pending_or_active
+    // ── Test 8: needs_ticks
 
     #[test]
-    fn has_pending_or_active_reflects_state() {
+    fn needs_ticks_reflects_state() {
         let mut store = CommandStore::default();
-        assert!(!store.has_pending_or_active(), "empty store → false");
+        assert!(!store.needs_ticks(), "empty store → false");
 
         // Add a pending entry (a promotable job — an interactive command like
         // vim records only a QUIET pending, which must never arm the timer).
         store.on_command_changed(1, &["sleep".to_string(), "30".to_string()], true, None, 1);
-        assert!(store.has_pending_or_active(), "true while pending");
+        assert!(store.needs_ticks(), "true while pending");
 
         // Promote to Running
         let promote_tick = 1 + DEBOUNCE_TICKS;
         store.on_timer(Tick(promote_tick), EpochSecs(0));
-        assert!(store.has_pending_or_active(), "true while Running");
+        assert!(store.needs_ticks(), "true while Running");
 
         // Return to shell → tentative; still active (Running) until debounce.
         let leave_tick = promote_tick + 1;
         store.on_command_changed(1, &[], false, None, leave_tick);
         assert!(
-            store.has_pending_or_active(),
+            store.needs_ticks(),
             "still active until the debounce window flips it to Done"
         );
 
         // Timer past debounce → Done (no pending, no Running).
         store.on_timer(Tick(leave_tick + DEBOUNCE_TICKS), EpochSecs(0));
         assert!(
-            !store.has_pending_or_active(),
+            !store.needs_ticks(),
             "false once Done (no pending, no Running)"
         );
     }
@@ -1108,6 +1108,20 @@
                 "{name} must not double as a push-agent name"
             );
         }
+        // WRAPPERS is a different animal (a transparency list, not a
+        // classification role) but must stay disjoint from ALL THREE
+        // membership lists: `effective_program` peels a wrapper away before
+        // any membership check runs, so a name in both would be silently
+        // invisible to its other list (a wrapped-away "interactive" name
+        // would un-quiet; a wrapped-away shell would break the prompt).
+        for name in WRAPPERS {
+            assert!(
+                !IGNORE_NAMES.contains(name)
+                    && !AGENT_NAMES.contains(name)
+                    && !DEFAULT_INTERACTIVE.contains(name),
+                "{name} is peeled by effective_program — membership lists would never see it"
+            );
+        }
     }
 
     #[test]
@@ -1149,7 +1163,7 @@
         let mut s = CommandStore::default();
         s.on_command_changed(1, &argv(&["nvim", "README.md"]), true, None, 0);
         assert!(
-            !s.has_pending_or_active(),
+            !s.needs_ticks(),
             "a quiet pending must not pin the 1 Hz cadence"
         );
         let r = s.on_timer(Tick(DEBOUNCE_TICKS * 10), EpochSecs(100));
@@ -1226,7 +1240,7 @@
         let changed = s.set_interactive_extras(["gdb"]);
         assert!(changed);
         assert_eq!(s.get(1).unwrap().status, Status::Idle, "demoted, not ledgered");
-        assert!(!s.has_pending_or_active());
+        assert!(!s.needs_ticks());
         // Promotion consumed the pending, so the sweep RECONSTRUCTS the quiet
         // pending from the observation — the swept state must be identical to
         // the intake state: muted label available, exits labeled.
@@ -1265,11 +1279,11 @@
         // pending phase still arms (the promotion tick needs to fire).
         let mut s = CommandStore::default();
         s.on_command_changed(1, &argv(&["npm", "run", "dev"]), true, None, 0);
-        assert!(s.has_pending_or_active(), "pending promotion still needs a tick");
+        assert!(s.needs_ticks(), "pending promotion still needs a tick");
         s.on_timer(Tick(DEBOUNCE_TICKS), EpochSecs(100));
         let obs = s.get(1).unwrap();
         assert_eq!((obs.status, obs.kind), (Status::Running, Kind::Server));
-        assert!(!s.has_pending_or_active(), "a steady service costs zero ticks");
+        assert!(!s.needs_ticks(), "a steady service costs zero ticks");
     }
 
     #[test]
@@ -1282,16 +1296,16 @@
         let mut s = CommandStore::default();
         s.on_command_changed(1, &argv(&["npm", "run", "dev"]), true, None, 0);
         s.on_timer(Tick(DEBOUNCE_TICKS), EpochSecs(100));
-        assert!(!s.has_pending_or_active(), "steady while the server runs");
+        assert!(!s.needs_ticks(), "steady while the server runs");
 
         // Ctrl-C: back to the shell arms the tentative-done…
         s.on_command_changed(1, &argv(&["zsh"]), true, None, DEBOUNCE_TICKS + 1);
         assert!(
-            s.has_pending_or_active(),
+            s.needs_ticks(),
             "the armed Done confirm is a scheduled one-shot — it needs ticks"
         );
         // …which the debounce window then confirms, and the timer may disarm.
         s.on_timer(Tick(DEBOUNCE_TICKS * 2 + 1), EpochSecs(200));
         assert_eq!(s.get(1).unwrap().status, Status::Done, "a dead dev server is news");
-        assert!(!s.has_pending_or_active());
+        assert!(!s.needs_ticks());
     }

--- a/crates/core/src/kind.rs
+++ b/crates/core/src/kind.rs
@@ -92,6 +92,20 @@ impl Kind {
             | Kind::Server => false,
         }
     }
+
+    /// Whether this kind is a *service* — unending by design (a dev server, a
+    /// watcher), the `Service` attention class in `docs/activity-model.md`.
+    /// A Running service renders a steady mark instead of a spinner (nothing
+    /// is completing, so nothing animates) and never arms the fast cadence.
+    /// Exhaustive for the same reason as `is_agent`: a new variant must
+    /// declare its side before it compiles.
+    pub fn is_service(self) -> bool {
+        match self {
+            Kind::Server => true,
+            Kind::Claude | Kind::Codex | Kind::Gemini | Kind::Command | Kind::Other
+            | Kind::Test | Kind::Build | Kind::Deploy => false,
+        }
+    }
 }
 
 // `Kind` crosses the persisted snapshot as its `source` wire token. Lenient,

--- a/crates/core/src/observation.rs
+++ b/crates/core/src/observation.rs
@@ -100,6 +100,17 @@ impl TrackedObservation {
         }
     }
 
+    /// Running work that draws an *animated* glyph — the one observation state
+    /// that needs per-second ticks. Running services are excluded: they render
+    /// the steady `▸` mark, so nothing about them animates
+    /// (`docs/activity-model.md` §3). THE shared term of both stores' cadence
+    /// predicates (`StatusStore::needs_ticks`,
+    /// `CommandStore::has_pending_or_active`), so the service exclusion can
+    /// never half-apply.
+    pub fn animating(&self) -> bool {
+        self.status == Status::Running && !self.kind.is_service()
+    }
+
     /// Re-scrub the free-text fields with the same sanitizer and caps live
     /// intake applies at parse. Live observations are sanitized already; this
     /// is for observations loaded off disk, where a pre-sanitize build (or a
@@ -173,9 +184,9 @@ impl ObservationStore {
         self.map.iter().map(|(&pane_id, observation)| (pane_id, observation))
     }
 
-    /// Does any observation satisfy `pred`? The two stores resting-state predicates
-    /// differ (`StatusStore` counts any non-idle, `CommandStore` only `Running`),
-    /// so each passes its own closure rather than sharing one definition.
+    /// Does any observation satisfy `pred`? Both stores' cadence predicates
+    /// pass [`TrackedObservation::animating`]; other callers (Done-awaiting-
+    /// recede, tests) pass their own closures.
     pub fn any(&self, pred: impl Fn(&TrackedObservation) -> bool) -> bool {
         self.map.values().any(pred)
     }

--- a/crates/core/src/observation.rs
+++ b/crates/core/src/observation.rs
@@ -105,7 +105,7 @@ impl TrackedObservation {
     /// the steady `▸` mark, so nothing about them animates
     /// (`docs/activity-model.md` §3). THE shared term of both stores' cadence
     /// predicates (`StatusStore::needs_ticks`,
-    /// `CommandStore::has_pending_or_active`), so the service exclusion can
+    /// `CommandStore::needs_ticks`), so the service exclusion can
     /// never half-apply.
     pub fn animating(&self) -> bool {
         self.status == Status::Running && !self.kind.is_service()

--- a/crates/plugin/src/config.rs
+++ b/crates/plugin/src/config.rs
@@ -4,7 +4,7 @@
 //! live `config.v1` override — a typo must not clobber set state back to
 //! default), and unknown keys are ignored (forward-compatible).
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// The live-override pipe. Payload is a JSON object of config keys (see
 /// [`overrides_from_json`]); breaking the payload shape means a new name.
@@ -147,6 +147,13 @@ pub struct Config {
     /// permission request — wait for the floating onboarding pane to win the
     /// grant, so Zellij binds its prompt to the float, not the rail.
     pub defer_permission: bool,
+    /// The user's EXTRA interactive command names (editors/pagers/TUIs whose
+    /// panes never show a Running row — `docs/activity-model.md` §4). Extras
+    /// only, default empty: the effective set is composed as
+    /// `command::DEFAULT_INTERACTIVE ∪ extras` in `CommandStore` — holding the
+    /// seeded defaults here instead would let one configured entry silently
+    /// *replace* them (`config_fields!` assigns wholesale).
+    pub interactive_commands: BTreeSet<String>,
     pub notify: bool,
     pub notify_done: bool,
     pub notify_error: bool,
@@ -165,6 +172,7 @@ impl Default for Config {
             grant_hint: GrantHint::default(),
             jump_hint: JumpHint::default(),
             defer_permission: false,
+            interactive_commands: BTreeSet::new(),
             notify: true,
             notify_done: true,
             notify_error: true,
@@ -180,6 +188,20 @@ fn parse_bool(v: &str) -> Option<bool> {
         "false" | "0" | "no" | "off" => Some(false),
         _ => None,
     }
+}
+
+/// Parse a comma/space-separated list of exe names into a set. Always `Some`
+/// (an empty value is a valid "no extras", so a live override can clear the
+/// list); entries are trimmed with any login-shell `-` prefix stripped, and
+/// empties dropped.
+fn parse_name_set(v: &str) -> Option<BTreeSet<String>> {
+    Some(
+        v.split([',', ' ', '\t'])
+            .map(|s| s.trim().trim_start_matches('-'))
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect(),
+    )
 }
 
 impl NamingMode {
@@ -239,6 +261,7 @@ config_fields! {
     jump_hint:  "jump_hint"  => JumpHint::from_config,
     header:              "header"              => parse_bool,
     defer_permission:    "defer_permission"    => parse_bool,
+    interactive_commands: "interactive_commands" => parse_name_set,
     notify:              "notify"              => parse_bool,
     notify_done:         "notify_done"         => parse_bool,
     notify_error:        "notify_error"        => parse_bool,
@@ -633,5 +656,32 @@ mod tests {
         // opt parser leaves the default on unparseable input
         let c = Config::from_map(&map(&[("notify_done", "maybe")]));
         assert!(c.notify_done);
+    }
+
+    #[test]
+    fn interactive_commands_default_is_empty_extras() {
+        // Extras ONLY — the built-in set lives in core and is composed in
+        // `CommandStore::set_interactive_extras`. Seeding defaults here would
+        // let one configured entry wholesale-replace them (the macro assigns,
+        // never merges).
+        assert!(Config::default().interactive_commands.is_empty());
+        assert!(Config::from_map(&map(&[])).interactive_commands.is_empty());
+    }
+
+    #[test]
+    fn interactive_commands_parses_commas_spaces_and_dashes() {
+        let c = Config::from_map(&map(&[("interactive_commands", "gdb, ssh  -tig,")]));
+        let got: Vec<&str> = c.interactive_commands.iter().map(String::as_str).collect();
+        assert_eq!(got, ["gdb", "ssh", "tig"], "split on commas/spaces, dash-stripped, empties dropped");
+    }
+
+    #[test]
+    fn interactive_commands_live_override_can_clear() {
+        // An empty value is a valid "no extras" — the one list-shaped key
+        // wants clearability, unlike enum keys where garbage keeps state.
+        let mut c = Config::from_map(&map(&[("interactive_commands", "gdb")]));
+        assert!(!c.interactive_commands.is_empty());
+        c.apply_overrides(&map(&[("interactive_commands", "")]));
+        assert!(c.interactive_commands.is_empty());
     }
 }

--- a/crates/plugin/src/ledger.rs
+++ b/crates/plugin/src/ledger.rs
@@ -185,18 +185,25 @@ impl Ledger {
 }
 
 /// Relative age per the spec §4.4 table. Negative (clock skew) → "<1m".
-///
-/// The final band starts at SATURATE_S so the rendered age stops changing
-/// exactly when `any_unsaturated` goes false and the Slow timer disarms —
-/// a frozen "1h+" is what makes full disarm safe.
+/// The ledger presents the sub-minute band (a fresh completion still reads as
+/// an age); the rail's time tags render nothing there — one band, two faces.
 pub(crate) fn format_age(at_epoch_s: u64, now_epoch_s: u64) -> String {
-    let age = now_epoch_s.saturating_sub(at_epoch_s);
+    minute_tag(now_epoch_s.saturating_sub(at_epoch_s)).unwrap_or_else(|| "<1m".to_string())
+}
+
+/// THE minute band every age display shares — the ledger's `format_age` and
+/// the rail's wait/run tags (`render::{wait_tag, run_tag}`): `None` under a
+/// minute, whole minutes below the saturate window, frozen at `1h+` past it.
+/// The freeze is load-bearing for cadence disarm — the rendered age stops
+/// changing exactly when `any_unsaturated` goes false and the Slow timer
+/// disarms — so the band must not exist twice.
+pub(crate) fn minute_tag(age: u64) -> Option<String> {
     if age < 60 {
-        "<1m".to_string()
+        None
     } else if age < SATURATE_S {
-        format!("{}m", age / 60)
+        Some(format!("{}m", age / 60))
     } else {
-        "1h+".to_string()
+        Some("1h+".to_string())
     }
 }
 

--- a/crates/plugin/src/radar_state.rs
+++ b/crates/plugin/src/radar_state.rs
@@ -701,7 +701,7 @@ impl RadarState {
         }
         // A Running→Running update (new activity label / task / repo, same
         // status) is the tool-hook firehose's steady state. The Fast (1 Hz)
-        // tick is already armed while anything is Running and repaints
+        // tick is already armed while the row *animates* and repaints
         // unconditionally, so the label reaches the rail within a second
         // regardless — an immediate render here only multiplied burst repaints
         // by the message rate. Same for the snapshot: defer the write to the
@@ -710,8 +710,13 @@ impl RadarState {
         // (anything that changes the status itself, or any non-Running update
         // — Pending question text, a Done/Error message rewrite) still renders
         // and persists immediately: those are the rows a user is waiting on.
+        // The `animating` term is the deferral's soundness condition: a
+        // Running *service* row holds the steady mark and does NOT arm the
+        // Fast tick, so deferring its label to "the next tick" would mean the
+        // Slow heartbeat (≤60s) — render and persist those immediately.
         let label_only = prev.as_ref().map(|o| o.status) == now_status
-            && now_status == Some(Status::Running);
+            && now_status == Some(Status::Running)
+            && self.status.get(pane_id).is_some_and(TrackedObservation::animating);
         // NOTE: we deliberately do NOT settle here. A pushed status is shown as-is;
         // focus no longer recedes or clears it. A completion clears only via a new
         // broadcast for the pane, the return-to-shell exit-clear
@@ -741,7 +746,7 @@ impl RadarState {
     /// meant to (animation vs. a scheduled one-shot are different reasons to
     /// tick, and conflating them would blur what each predicate promises).
     pub(crate) fn has_running_work(&self) -> bool {
-        self.status.any_running() || self.command.has_pending_or_active()
+        self.status.needs_ticks() || self.command.has_pending_or_active()
     }
 
     /// Apply the user's `interactive_commands` extras to the command store

--- a/crates/plugin/src/radar_state.rs
+++ b/crates/plugin/src/radar_state.rs
@@ -734,19 +734,19 @@ impl RadarState {
     /// reporting `Running`, or an observed foreground command still live. This is
     /// the animated set (the spinner), so it wants a per-tick repaint. Deliberately
     /// narrow: a finished `Done`/`Error` or a waiting `Pending` is not "animating"
-    /// work, mirroring `CommandStore::has_pending_or_active`.
+    /// work, mirroring `CommandStore::needs_ticks`.
     ///
     /// This does NOT mean a finished `Done` never needs another tick — a command
     /// `Done` sits on a `DONE_TTL_TICKS` clock before it recedes to Idle (spec
     /// §3.1's cadence design), and that recede has to land on schedule even
     /// though the row itself is static. That's a *separate* arming reason,
-    /// deliberately kept out of this predicate: `command_awaiting_recede` carries
+    /// deliberately kept out of this predicate: `has_done_awaiting_recede` carries
     /// the TTL window, so `PluginRuntime::timer_should_continue` ORs the two
-    /// rather than broadening `has_running_work` to cover a case it was never
+    /// rather than broadening `needs_fast_ticks` to cover a case it was never
     /// meant to (animation vs. a scheduled one-shot are different reasons to
     /// tick, and conflating them would blur what each predicate promises).
-    pub(crate) fn has_running_work(&self) -> bool {
-        self.status.needs_ticks() || self.command.has_pending_or_active()
+    pub(crate) fn needs_fast_ticks(&self) -> bool {
+        self.status.needs_ticks() || self.command.needs_ticks()
     }
 
     /// Apply the user's `interactive_commands` extras to the command store
@@ -769,9 +769,9 @@ impl RadarState {
 
     /// True while a command-origin `Done` is still inside its `DONE_TTL_TICKS`
     /// window, awaiting the recede to Idle. Delegates to
-    /// `CommandStore::has_done_awaiting_recede` — see `has_running_work`'s doc
+    /// `CommandStore::has_done_awaiting_recede` — see `needs_fast_ticks`'s doc
     /// for why this is a distinct arming reason rather than folded into it.
-    pub(crate) fn command_awaiting_recede(&self) -> bool {
+    pub(crate) fn has_done_awaiting_recede(&self) -> bool {
         self.command.has_done_awaiting_recede()
     }
 

--- a/crates/plugin/src/radar_state.rs
+++ b/crates/plugin/src/radar_state.rs
@@ -744,6 +744,24 @@ impl RadarState {
         self.status.any_running() || self.command.has_pending_or_active()
     }
 
+    /// Apply the user's `interactive_commands` extras to the command store
+    /// (level-triggered — see `CommandStore::set_interactive_extras`). Called
+    /// after snapshot load and on every `config.v1` override, so both a
+    /// rehydrated stale Running row and a mid-session config change take
+    /// effect immediately. Returns whether observable state changed.
+    pub(crate) fn set_interactive_commands(
+        &mut self,
+        extras: &std::collections::BTreeSet<String>,
+    ) -> bool {
+        let changed = self
+            .command
+            .set_interactive_extras(extras.iter().map(String::as_str));
+        if changed {
+            self.touch();
+        }
+        changed
+    }
+
     /// True while a command-origin `Done` is still inside its `DONE_TTL_TICKS`
     /// window, awaiting the recede to Idle. Delegates to
     /// `CommandStore::has_done_awaiting_recede` — see `has_running_work`'s doc
@@ -1111,9 +1129,11 @@ impl RadarState {
     /// Roll this tab's panes up into a `TabDisplay`. The "status wins over
     /// command" precedence across observation sources lives in `resolve`, with
     /// the stores; `rollup::roll_up` only sees "is there an observation for this
-    /// pane?" — keeping the aggregation rules behind the Tab Roll-Up seam.
+    /// pane?" — keeping the aggregation rules behind the Tab Roll-Up seam. The
+    /// second lookup feeds the muted Interactive label from the command store's
+    /// quiet pendings; `roll_up` owns the precedence between the two.
     fn tab_display(&self, panes: &[TerminalPane]) -> TabDisplay {
-        rollup::roll_up(panes, |id| self.resolve(id))
+        rollup::roll_up(panes, |id| self.resolve(id), |id| self.command.quiet_identity(id))
     }
 
     /// Roll a tab up by position, treating an absent pane list as no panes.

--- a/crates/plugin/src/reference_tests.rs
+++ b/crates/plugin/src/reference_tests.rs
@@ -135,6 +135,7 @@ fn build(input: &str) -> (Vec<TabRow>, Vec<crate::rollup::LedgerLine>, RenderOpt
     let mut glyphs = GlyphSet::Plain;
     let mut density = Density::Compact;
     let mut jump_hint = false;
+    let mut now_tick: u64 = 0;
     let mut ledger_lines: Vec<crate::rollup::LedgerLine> = Vec::new();
     // A fixed "now" for the `ledger` directive's age math, so a scenario's
     // round `age_secs` numbers produce deterministic, doc-readable
@@ -174,6 +175,10 @@ fn build(input: &str) -> (Vec<TabRow>, Vec<crate::rollup::LedgerLine>, RenderOpt
         /// via the `waiting <N>m` trailer; backdates the apply epoch so the
         /// `· Nm` wait tag renders. 0 = applied "now" (no tag).
         waiting_m: u64,
+        /// true = the `interactive "<argv>"` form: drives the command-observer
+        /// path with an interactive foreground command (a quiet pending — no
+        /// status, no Running row) → PaneDisplay::Interactive's muted label.
+        interactive: bool,
     }
 
     struct TabSpec {
@@ -224,6 +229,15 @@ fn build(input: &str) -> (Vec<TabRow>, Vec<crate::rollup::LedgerLine>, RenderOpt
         // — default hidden, mirroring `JumpHint`.
         if line.trim() == "jump_hint" {
             jump_hint = true;
+            continue;
+        }
+        // Render tick: `now_tick <N>` (default 0). Statuses apply at tick 0,
+        // so this IS the elapsed-ticks knob for the long-job `· Nm` run tag —
+        // pick a multiple of the spinner cycle (10) so working glyphs stay ⠋.
+        if let Some(rest) = line.strip_prefix("now_tick ") {
+            if let Ok(n) = rest.trim().parse::<u64>() {
+                now_tick = n;
+            }
             continue;
         }
 
@@ -309,6 +323,29 @@ fn build(input: &str) -> (Vec<TabRow>, Vec<crate::rollup::LedgerLine>, RenderOpt
                         untracked: true,
                         exit_code: None,
                         waiting_m: 0,
+                        interactive: false,
+                    });
+                }
+                continue;
+            }
+
+            // Interactive pane form: `interactive "<argv>"` — an editor/pager/
+            // TUI in the foreground (docs/activity-model.md, Companion class).
+            if let Some(rest) = trimmed.strip_prefix("interactive ") {
+                let (argv, _) = take_quoted(rest);
+                let pane_id = next_pane_id;
+                next_pane_id += 1;
+                if let Some(idx) = current_tab {
+                    tabs[idx].panes.push(PaneSpec {
+                        pane_id,
+                        kind: Kind::Command,
+                        status: Status::Idle,
+                        msg: argv.to_string(),
+                        task: String::new(),
+                        untracked: false,
+                        exit_code: None,
+                        waiting_m: 0,
+                        interactive: true,
                     });
                 }
                 continue;
@@ -395,6 +432,7 @@ fn build(input: &str) -> (Vec<TabRow>, Vec<crate::rollup::LedgerLine>, RenderOpt
                     untracked: false,
                     exit_code,
                     waiting_m,
+                    interactive: false,
                 });
             }
             continue;
@@ -464,10 +502,23 @@ fn build(input: &str) -> (Vec<TabRow>, Vec<crate::rollup::LedgerLine>, RenderOpt
     // Collect command-exit panes so we can feed them as a batch to panes_changed.
     let mut command_exits: Vec<(u32, Option<i32>)> = Vec::new();
 
+    // Interactive panes (`interactive "<argv>"`): the command-observer path
+    // with an interactive fg command. A quiet pending is recorded (identity
+    // for the muted label) and never promoted — no timer step needed.
     for spec in &tabs {
         for pane in &spec.panes {
-            if pane.untracked || pane.exit_code.is_some() {
-                continue; // untracked + command-exit panes handled separately
+            if pane.interactive {
+                let argv: Vec<String> =
+                    pane.msg.split_whitespace().map(|s| s.to_string()).collect();
+                radar.command_changed(pane.pane_id, &argv, true, 0);
+            }
+        }
+    }
+
+    for spec in &tabs {
+        for pane in &spec.panes {
+            if pane.untracked || pane.exit_code.is_some() || pane.interactive {
+                continue; // untracked / command-exit / interactive panes handled separately
             }
 
             // kind -> wire source name (inverse of the `from_source` the DSL used)
@@ -579,7 +630,7 @@ fn build(input: &str) -> (Vec<TabRow>, Vec<crate::rollup::LedgerLine>, RenderOpt
     let mut opts = RenderOpts {
         width,
         height,
-        now_tick: 0,
+        now_tick,
         glyphs,
         header: true,
         density,

--- a/crates/plugin/src/render.rs
+++ b/crates/plugin/src/render.rs
@@ -15,6 +15,9 @@
 
 use crate::config::Density;
 use crate::kind::Kind;
+// One minute band for every age display (its `1h+` freeze is load-bearing
+// for cadence disarm) — owned by the ledger, shared by the wait/run tags.
+use crate::ledger::minute_tag;
 use crate::rollup::{LedgerLine, Outcome, PaneDisplay, TabDisplay, TabRow};
 use crate::sessions::BadgeEntry;
 pub use crate::status::GlyphSet;
@@ -629,24 +632,9 @@ fn run_tag(status: Status, kind: Kind, since_tick: Option<u64>, now_tick: u64) -
     minute_tag(now_tick.saturating_sub(since_tick?))
 }
 
-/// THE minute band both time tags share: `None` under a minute (a fresh
-/// wait/run needs no clock), whole minutes below the saturate window, frozen
-/// at `1h+` past it — the freeze is load-bearing for cadence disarm (the same
-/// window the ledger uses), so it must not exist twice.
-fn minute_tag(age: u64) -> Option<String> {
-    if age < 60 {
-        None
-    } else if age < crate::ledger::SATURATE_S {
-        Some(format!("{}m", age / 60))
-    } else {
-        Some("1h+".to_string())
-    }
-}
-
 /// Append a time tag to an identity line: `migrate schema · 12m`. Identity
 /// passes through untouched when no tag applies, keeping calm rows
-/// bit-identical to the tagless rail. At most one tag ever applies per line —
-/// `wait_tag`/`run_tag` key on disjoint statuses.
+/// bit-identical to the tagless rail.
 fn with_time_tag(identity: String, tag: Option<String>) -> String {
     match tag {
         Some(tag) => format!("{identity} · {tag}"),
@@ -851,13 +839,12 @@ fn render_row(row: &TabRow, opts: &RenderOpts) -> Vec<Line> {
                 return Vec::new();
             }
         }
+        // The two tags key on disjoint statuses (Pending vs Running), so the
+        // `or_else` chain IS the "at most one tag per line" rule.
         let identity = with_time_tag(
             identity.to_string(),
-            wait_tag(pane_status, pane.pending_epoch_s(), opts.now_epoch_s),
-        );
-        let identity = with_time_tag(
-            identity,
-            run_tag(pane_status, pane.kind(), pane.since_tick(), opts.now_tick),
+            wait_tag(pane_status, pane.pending_epoch_s(), opts.now_epoch_s)
+                .or_else(|| run_tag(pane_status, pane.kind(), pane.since_tick(), opts.now_tick)),
         );
         let pane_target = RailTarget { tab_position: tab_target.tab_position, pane_id: Some(pane.pane_id()), session: None };
         let hotspot = pane.has_unacknowledged_status_pending()
@@ -1534,8 +1521,22 @@ fn render_body(rows: &[TabRow], ledger: &[LedgerLine], opts: &RenderOpts) -> Vec
     // working" tally computed later in `render_bottom`; the two live in
     // separate pipeline stages (body vs. bottom region) and sharing one
     // number across that seam would cost more plumbing than the one `filter`
-    // it saves.
-    let working = rows.iter().any(|r| r.display.status == Status::Running);
+    // it saves. The tab detail's kind gates it to *animating* work: a rail
+    // whose only Running rows are services (steady `▸`, no Fast cadence)
+    // must not draw a sweep that would only teleport once per Slow fire —
+    // motion promises bounded work (`docs/activity-model.md` §1). The
+    // job-over-service tie-break makes the detail-kind check exact: whenever
+    // any Running job exists in a tab, the detail IS a job. The footer tally
+    // deliberately stays Status-only — "1 working" for an up dev server is
+    // honest English, and a count is not an animation.
+    let working = rows.iter().any(|r| {
+        r.display.status == Status::Running
+            // A Running tab always carries a detail in production (`roll_up`
+            // sets one whenever an active pane exists), so the None arm is
+            // unreachable — defaulting it to "animate" keeps the sweep the
+            // fail-visible side of that invariant.
+            && r.display.detail.as_ref().is_none_or(|d| !d.kind.is_service())
+    });
 
     let mut flat: Vec<Line> = Vec::new();
 

--- a/crates/plugin/src/render.rs
+++ b/crates/plugin/src/render.rs
@@ -57,14 +57,12 @@ const MAX_PANE_LINES: usize = 6;
 /// aligned across all child lines (see `child_prefix`'s doc).
 const TREE_PREFIX_COLS: usize = 3;
 
-/// Spinner frame for a Running glyph: full speed normally; after
-/// EASE_AFTER_TICKS a slow two-frame blink (advances every 4th tick) — a
-/// long-runner signals "still going, nothing new" instead of anxiety.
 /// The steady mark for a Running *service* (`Kind::is_service`) — a dev
 /// server is up, not progressing, so nothing animates (`docs/activity-model.md`
 /// §3: a spinner promises bounded work). The steadiness is also what lets the
 /// timer disarm around an all-service rail: identical rows across ticks fall
-/// to the render gate, and `has_pending_or_active` excludes service rows.
+/// to the render gate, and the cadence predicates count only
+/// `TrackedObservation::animating` rows.
 const SERVICE_GLYPH: char = '▸';
 
 /// Status glyph for a Running row: services hold [`SERVICE_GLYPH`], jobs spin
@@ -78,6 +76,9 @@ fn running_glyph(kind: Kind, now_tick: u64, since_tick: u64) -> char {
     }
 }
 
+/// Spinner frame for a Running glyph: full speed normally; after
+/// EASE_AFTER_TICKS a slow two-frame blink (advances every 4th tick) — a
+/// long-runner signals "still going, nothing new" instead of anxiety.
 fn spin_glyph(now_tick: u64, since_tick: u64) -> char {
     if now_tick.saturating_sub(since_tick) > EASE_AFTER_TICKS {
         crate::status::working_spin(((now_tick / 4) % 2) as usize)
@@ -612,38 +613,27 @@ fn wait_tag(status: Status, pending_epoch_s: Option<u64>, now_epoch_s: u64) -> O
     if status != Status::Pending {
         return None;
     }
-    let age = now_epoch_s.saturating_sub(pending_epoch_s?);
-    if age < 60 {
-        None
-    } else if age < crate::ledger::SATURATE_S {
-        Some(format!("{}m", age / 60))
-    } else {
-        Some("1h+".to_string())
-    }
-}
-
-/// Append the wait tag to an identity line: `migrate schema · 12m`. Identity
-/// passes through untouched when no tag applies, keeping calm rows
-/// bit-identical to the tagless rail.
-fn with_wait_tag(identity: &str, status: Status, pending_epoch_s: Option<u64>, now_epoch_s: u64) -> String {
-    match wait_tag(status, pending_epoch_s, now_epoch_s) {
-        Some(tag) => format!("{identity} · {tag}"),
-        None => identity.to_string(),
-    }
+    minute_tag(now_epoch_s.saturating_sub(pending_epoch_s?))
 }
 
 /// The `· 4m` elapsed tag for a long-running bounded *job* — whole minutes
 /// since the run's true start (`since_tick` survives re-promotions of the same
-/// command, `command.rs`), frozen at `1h+` like the wait tag. Jobs only
+/// command, `command.rs`), same band as the wait tag. Jobs only
 /// (`docs/activity-model.md` §3): agents label their own turns and services
-/// never complete, so neither wears a stopwatch. `None` under a minute. Ticks
-/// read as seconds because a Running job is exactly what holds the 1 Hz
-/// cadence armed (`has_pending_or_active`).
+/// never complete, so neither wears a stopwatch. Ticks read as seconds because
+/// an animated Running row is exactly what holds the 1 Hz cadence armed.
 fn run_tag(status: Status, kind: Kind, since_tick: Option<u64>, now_tick: u64) -> Option<String> {
     if status != Status::Running || kind.is_agent() || kind.is_service() {
         return None;
     }
-    let age = now_tick.saturating_sub(since_tick?);
+    minute_tag(now_tick.saturating_sub(since_tick?))
+}
+
+/// THE minute band both time tags share: `None` under a minute (a fresh
+/// wait/run needs no clock), whole minutes below the saturate window, frozen
+/// at `1h+` past it — the freeze is load-bearing for cadence disarm (the same
+/// window the ledger uses), so it must not exist twice.
+fn minute_tag(age: u64) -> Option<String> {
     if age < 60 {
         None
     } else if age < crate::ledger::SATURATE_S {
@@ -653,10 +643,12 @@ fn run_tag(status: Status, kind: Kind, since_tick: Option<u64>, now_tick: u64) -
     }
 }
 
-/// Sibling of [`with_wait_tag`] for the Running-job elapsed tag; at most one of
-/// the two ever applies (they key on disjoint statuses).
-fn with_run_tag(identity: String, status: Status, kind: Kind, since_tick: Option<u64>, now_tick: u64) -> String {
-    match run_tag(status, kind, since_tick, now_tick) {
+/// Append a time tag to an identity line: `migrate schema · 12m`. Identity
+/// passes through untouched when no tag applies, keeping calm rows
+/// bit-identical to the tagless rail. At most one tag ever applies per line —
+/// `wait_tag`/`run_tag` key on disjoint statuses.
+fn with_time_tag(identity: String, tag: Option<String>) -> String {
+    match tag {
         Some(tag) => format!("{identity} · {tag}"),
         None => identity,
     }
@@ -851,16 +843,21 @@ fn render_row(row: &TabRow, opts: &RenderOpts) -> Vec<Line> {
         if skip_silent {
             let says_something = !identity.trim().is_empty()
                 || pane.outcome().is_some_and(|o| o.renders_tag());
-            // An Interactive pane's muted label IS its content — it renders
-            // as Idle but is never "silent" (an open editor names the pane).
-            if (pane_status == Status::Idle && !pane.is_interactive()) || !says_something {
+            // `status()` (not `render_status()`) is the gate on purpose: an
+            // *observation* resting at Idle is silent, while an Interactive
+            // pane has no observation-status at all — its muted label IS its
+            // content (an open editor names the pane).
+            if pane.status() == Some(Status::Idle) || !says_something {
                 return Vec::new();
             }
         }
-        let identity =
-            with_wait_tag(identity, pane_status, pane.pending_epoch_s(), opts.now_epoch_s);
-        let identity = with_run_tag(
-            identity, pane_status, pane.kind(), pane.since_tick(), opts.now_tick,
+        let identity = with_time_tag(
+            identity.to_string(),
+            wait_tag(pane_status, pane.pending_epoch_s(), opts.now_epoch_s),
+        );
+        let identity = with_time_tag(
+            identity,
+            run_tag(pane_status, pane.kind(), pane.since_tick(), opts.now_tick),
         );
         let pane_target = RailTarget { tab_position: tab_target.tab_position, pane_id: Some(pane.pane_id()), session: None };
         let hotspot = pane.has_unacknowledged_status_pending()

--- a/crates/plugin/src/render.rs
+++ b/crates/plugin/src/render.rs
@@ -14,6 +14,7 @@
 //! 5. **Bottom region** — ledger lines, footer (rule + tally + hint), filler.
 
 use crate::config::Density;
+use crate::kind::Kind;
 use crate::rollup::{LedgerLine, Outcome, PaneDisplay, TabDisplay, TabRow};
 use crate::sessions::BadgeEntry;
 pub use crate::status::GlyphSet;
@@ -59,6 +60,24 @@ const TREE_PREFIX_COLS: usize = 3;
 /// Spinner frame for a Running glyph: full speed normally; after
 /// EASE_AFTER_TICKS a slow two-frame blink (advances every 4th tick) — a
 /// long-runner signals "still going, nothing new" instead of anxiety.
+/// The steady mark for a Running *service* (`Kind::is_service`) — a dev
+/// server is up, not progressing, so nothing animates (`docs/activity-model.md`
+/// §3: a spinner promises bounded work). The steadiness is also what lets the
+/// timer disarm around an all-service rail: identical rows across ticks fall
+/// to the render gate, and `has_pending_or_active` excludes service rows.
+const SERVICE_GLYPH: char = '▸';
+
+/// Status glyph for a Running row: services hold [`SERVICE_GLYPH`], jobs spin
+/// (easing to a slow blink — see [`spin_glyph`]). The single owner of the
+/// service/job glyph split, shared by the tab header and the pane lines.
+fn running_glyph(kind: Kind, now_tick: u64, since_tick: u64) -> char {
+    if kind.is_service() {
+        SERVICE_GLYPH
+    } else {
+        spin_glyph(now_tick, since_tick)
+    }
+}
+
 fn spin_glyph(now_tick: u64, since_tick: u64) -> char {
     if now_tick.saturating_sub(since_tick) > EASE_AFTER_TICKS {
         crate::status::working_spin(((now_tick / 4) % 2) as usize)
@@ -483,7 +502,7 @@ fn spine_seg(active: bool, tab_status: Status) -> String {
 /// Single-pane tabs keep the chunk-1 line-2 behavior; multi-pane tabs use
 /// the line-per-pane design.
 fn is_multi_pane(display: &TabDisplay) -> bool {
-    display.panes.iter().filter(|p| p.is_tracked()).count() > 1
+    display.panes.iter().filter(|p| p.earns_pane_line()).count() > 1
 }
 
 /// The rail's identity header. Single source of truth for the header's vertical
@@ -610,6 +629,36 @@ fn with_wait_tag(identity: &str, status: Status, pending_epoch_s: Option<u64>, n
     }
 }
 
+/// The `· 4m` elapsed tag for a long-running bounded *job* — whole minutes
+/// since the run's true start (`since_tick` survives re-promotions of the same
+/// command, `command.rs`), frozen at `1h+` like the wait tag. Jobs only
+/// (`docs/activity-model.md` §3): agents label their own turns and services
+/// never complete, so neither wears a stopwatch. `None` under a minute. Ticks
+/// read as seconds because a Running job is exactly what holds the 1 Hz
+/// cadence armed (`has_pending_or_active`).
+fn run_tag(status: Status, kind: Kind, since_tick: Option<u64>, now_tick: u64) -> Option<String> {
+    if status != Status::Running || kind.is_agent() || kind.is_service() {
+        return None;
+    }
+    let age = now_tick.saturating_sub(since_tick?);
+    if age < 60 {
+        None
+    } else if age < crate::ledger::SATURATE_S {
+        Some(format!("{}m", age / 60))
+    } else {
+        Some("1h+".to_string())
+    }
+}
+
+/// Sibling of [`with_wait_tag`] for the Running-job elapsed tag; at most one of
+/// the two ever applies (they key on disjoint statuses).
+fn with_run_tag(identity: String, status: Status, kind: Kind, since_tick: Option<u64>, now_tick: u64) -> String {
+    match run_tag(status, kind, since_tick, now_tick) {
+        Some(tag) => format!("{identity} · {tag}"),
+        None => identity,
+    }
+}
+
 /// The row's line 1: spine + glyph + tab number + name + bell, every column
 /// budget clamped so the emitted line never exceeds `width`. This is the
 /// densest width-math in the file, self-contained here so `render_row` reads
@@ -644,8 +693,10 @@ fn tab_header_line(row: &TabRow, opts: &RenderOpts, tab_target: &RailTarget) -> 
     // col 1: status glyph (working spins; eases to a slow blink for
     // long-runners — see `spin_glyph`).
     let glyph_char = if st == Status::Running {
-        let since_tick = row.display.detail.as_ref().map(|d| d.since_tick).unwrap_or(now_tick);
-        spin_glyph(now_tick, since_tick)
+        let detail = row.display.detail.as_ref();
+        let since_tick = detail.map(|d| d.since_tick).unwrap_or(now_tick);
+        let kind = detail.map(|d| d.kind).unwrap_or(Kind::Other);
+        running_glyph(kind, now_tick, since_tick)
     } else {
         st.glyph_for(opts.glyphs)
     };
@@ -797,12 +848,17 @@ fn render_row(row: &TabRow, opts: &RenderOpts) -> Vec<Line> {
         if skip_silent {
             let says_something = !identity.trim().is_empty()
                 || pane.outcome().is_some_and(|o| o.renders_tag());
-            if pane_status == Status::Idle || !says_something {
+            // An Interactive pane's muted label IS its content — it renders
+            // as Idle but is never "silent" (an open editor names the pane).
+            if (pane_status == Status::Idle && !pane.is_interactive()) || !says_something {
                 return Vec::new();
             }
         }
         let identity =
             with_wait_tag(identity, pane_status, pane.pending_epoch_s(), opts.now_epoch_s);
+        let identity = with_run_tag(
+            identity, pane_status, pane.kind(), pane.since_tick(), opts.now_tick,
+        );
         let pane_target = RailTarget { tab_position: tab_target.tab_position, pane_id: Some(pane.pane_id()), session: None };
         let hotspot = pane.has_unacknowledged_status_pending()
             .then(|| HotspotAction::Acknowledge { target: pane_target.clone() });
@@ -833,7 +889,7 @@ fn render_row(row: &TabRow, opts: &RenderOpts) -> Vec<Line> {
     // belong to the tab above."
     if is_multi_pane(&row.display) {
         let tracked_panes: Vec<&PaneDisplay> = row.display.panes.iter()
-            .filter(|p| p.is_tracked())
+            .filter(|p| p.earns_pane_line())
             .collect();
         let total_tracked = tracked_panes.len();
         let show = total_tracked.min(MAX_PANE_LINES);
@@ -882,7 +938,7 @@ fn render_row(row: &TabRow, opts: &RenderOpts) -> Vec<Line> {
     // completion earns no line at all). Idle stays header-only. The gate
     // itself lives inside `pane_lines` (`skip_silent`), judged on the very
     // identity it emits.
-    if let Some(pane) = row.display.panes.iter().find(|p| p.is_tracked()) {
+    if let Some(pane) = row.display.panes.iter().find(|p| p.earns_pane_line()) {
         lines.extend(pane_lines(pane, Branch::Elbow, true));
     }
     lines
@@ -991,7 +1047,7 @@ fn emit_pane_line(
     let status = pane.render_status();
     let glyph = if status == Status::Running {
         let since_tick = pane.since_tick().unwrap_or(opts.now_tick);
-        spin_glyph(opts.now_tick, since_tick)
+        running_glyph(pane.kind(), opts.now_tick, since_tick)
     } else {
         status.glyph_for(opts.glyphs)
     };

--- a/crates/plugin/src/render.rs
+++ b/crates/plugin/src/render.rs
@@ -450,6 +450,9 @@ impl RenderedRail {
         self.targets.get(line as usize).cloned().flatten()
     }
 
+    /// Test vocabulary — production hotspot resolution goes through
+    /// `hotspot_at` (column-aware); this line-only form exists for asserts.
+    #[cfg(test)]
     pub(crate) fn hotspot_at_line(&self, line: isize) -> Option<(usize, HotspotAction)> {
         if line < 0 {
             return None;

--- a/crates/plugin/src/render/tests.rs
+++ b/crates/plugin/src/render/tests.rs
@@ -19,6 +19,24 @@ fn wait_tag_is_pending_only_minute_floored_and_frozen_at_saturation() {
 }
 
 #[test]
+fn run_tag_is_running_jobs_only_same_minute_band_as_wait_tag() {
+    // Jobs wear the stopwatch; the band matches wait_tag (shared minute_tag).
+    assert_eq!(run_tag(Status::Running, Kind::Build, Some(0), 59), None);
+    assert_eq!(run_tag(Status::Running, Kind::Build, Some(0), 240).as_deref(), Some("4m"));
+    assert_eq!(
+        run_tag(Status::Running, Kind::Command, Some(0), crate::ledger::SATURATE_S).as_deref(),
+        Some("1h+"),
+        "frozen at 1h+ — the display never changes again"
+    );
+    // Agents label their own turns; services never complete: neither is timed.
+    assert_eq!(run_tag(Status::Running, Kind::Claude, Some(0), 9_999), None);
+    assert_eq!(run_tag(Status::Running, Kind::Server, Some(0), 9_999), None);
+    // Non-Running statuses and unstamped panes (untracked): no tag.
+    assert_eq!(run_tag(Status::Done, Kind::Build, Some(0), 9_999), None);
+    assert_eq!(run_tag(Status::Running, Kind::Build, None, 9_999), None);
+}
+
+#[test]
 fn truncate_does_not_strand_a_zwj_before_the_ellipsis() {
     // A ZWJ family emoji cut mid-cluster must not leave a dangling U+200D that
     // fuses with the appended '…'. The result ends in a clean ellipsis.

--- a/crates/plugin/src/render/tests.rs
+++ b/crates/plugin/src/render/tests.rs
@@ -2523,6 +2523,24 @@ fn heartbeat_marches_one_column_per_tick_while_working() {
 }
 
 #[test]
+fn heartbeat_stays_off_for_a_service_only_rail() {
+    // A Running *service* holds the steady ▸ and never arms the Fast cadence
+    // — a sweep here would only teleport once per Slow fire, and motion
+    // promises bounded work (docs/activity-model.md §1). The tab detail's
+    // kind is the exact gate: the job-over-service tie-break guarantees the
+    // detail is a job whenever any Running job exists.
+    let server = PrimaryDetail { kind: Kind::Server, ..pd("r", "b", "npm run dev", Status::Running) };
+    let rows = vec![tab(1, "dev", display(Status::Running, 0, 1, Some(server)))];
+    let s = render(&rows, &ro(20, 3));
+    let rule = strip_sgr(s.lines().nth(1).unwrap());
+    assert!(
+        !rule.contains('◆'),
+        "no heartbeat for a service-only Running rail: {:?}",
+        rule
+    );
+}
+
+#[test]
 fn heartbeat_absent_when_idle_and_in_cards() {
     // No Running row at all: the rule stays plain regardless of tick.
     let idle_rows = vec![idle_row(1)];

--- a/crates/plugin/src/rollup.rs
+++ b/crates/plugin/src/rollup.rs
@@ -105,6 +105,9 @@ impl PaneDisplay {
         Self::Untracked { pane_id, title }
     }
 
+    /// Tracked only (an observation-backed row) — test vocabulary; production
+    /// code branches on `earns_pane_line`/`is_interactive` instead.
+    #[cfg(test)]
     pub(crate) fn is_tracked(&self) -> bool {
         matches!(self, Self::Tracked { .. })
     }

--- a/crates/plugin/src/rollup.rs
+++ b/crates/plugin/src/rollup.rs
@@ -81,6 +81,18 @@ pub enum PaneDisplay {
         pane_id: u32,
         title: String,
     },
+    /// A pane whose foreground is an interactive command (editor/pager/TUI) —
+    /// the Companion class (`docs/activity-model.md`): it waits on the user,
+    /// so it is pane *context*, not activity. Renders as a muted identity
+    /// label (`└ ○ $ nvim README.md`), never a spinner, and contributes
+    /// nothing to counts, severity, or notifications. Built from the command
+    /// store's quiet pending; shown only when no live observation outranks it
+    /// (an active/attention observation keeps its `Tracked` row).
+    Interactive {
+        pane_id: u32,
+        kind: Kind,
+        msg: String,
+    },
 }
 
 impl PaneDisplay {
@@ -97,16 +109,29 @@ impl PaneDisplay {
         matches!(self, Self::Tracked { .. })
     }
 
+    /// Whether this pane earns a line in the rail's pane roster: tracked
+    /// panes (they have an observation to show) and interactive panes (their
+    /// muted identity label IS the line). Untracked panes render nothing.
+    pub(crate) fn earns_pane_line(&self) -> bool {
+        matches!(self, Self::Tracked { .. } | Self::Interactive { .. })
+    }
+
+    pub(crate) fn is_interactive(&self) -> bool {
+        matches!(self, Self::Interactive { .. })
+    }
+
     pub(crate) fn pane_id(&self) -> u32 {
         match self {
-            Self::Tracked { pane_id, .. } | Self::Untracked { pane_id, .. } => *pane_id,
+            Self::Tracked { pane_id, .. }
+            | Self::Untracked { pane_id, .. }
+            | Self::Interactive { pane_id, .. } => *pane_id,
         }
     }
 
     pub(crate) fn status(&self) -> Option<Status> {
         match self {
             Self::Tracked { status, .. } => Some(*status),
-            Self::Untracked { .. } => None,
+            Self::Untracked { .. } | Self::Interactive { .. } => None,
         }
     }
 
@@ -116,14 +141,14 @@ impl PaneDisplay {
 
     pub(crate) fn kind(&self) -> Kind {
         match self {
-            Self::Tracked { kind, .. } => *kind,
+            Self::Tracked { kind, .. } | Self::Interactive { kind, .. } => *kind,
             Self::Untracked { .. } => Kind::Other,
         }
     }
 
     pub(crate) fn msg(&self) -> &str {
         match self {
-            Self::Tracked { msg, .. } => msg,
+            Self::Tracked { msg, .. } | Self::Interactive { msg, .. } => msg,
             Self::Untracked { title, .. } => title,
         }
     }
@@ -131,7 +156,7 @@ impl PaneDisplay {
     pub(crate) fn task(&self) -> &str {
         match self {
             Self::Tracked { task, .. } => task,
-            Self::Untracked { .. } => "",
+            Self::Untracked { .. } | Self::Interactive { .. } => "",
         }
     }
 
@@ -141,14 +166,14 @@ impl PaneDisplay {
     pub(crate) fn since_tick(&self) -> Option<u64> {
         match self {
             Self::Tracked { since_tick, .. } => Some(*since_tick),
-            Self::Untracked { .. } => None,
+            Self::Untracked { .. } | Self::Interactive { .. } => None,
         }
     }
 
     pub(crate) fn outcome(&self) -> Option<Outcome> {
         match self {
             Self::Tracked { outcome, .. } => *outcome,
-            Self::Untracked { .. } => None,
+            Self::Untracked { .. } | Self::Interactive { .. } => None,
         }
     }
 
@@ -156,7 +181,7 @@ impl PaneDisplay {
     pub(crate) fn pending_epoch_s(&self) -> Option<u64> {
         match self {
             Self::Tracked { pending_epoch_s, .. } => *pending_epoch_s,
-            Self::Untracked { .. } => None,
+            Self::Untracked { .. } | Self::Interactive { .. } => None,
         }
     }
 
@@ -193,14 +218,22 @@ pub struct ProgressCounts {
 ///
 /// `resolve` maps a pane id to its resolved observation, if any. The caller owns
 /// the precedence across observation sources (status pipe vs command); this
-/// function only sees "is there an observation for this pane?".
+/// function only sees "is there an observation for this pane?". `quiet` maps a
+/// pane id to its interactive foreground identity `(msg, kind)`, if any — the
+/// command store's quiet pending (`docs/activity-model.md` §5).
 ///
 /// A pane with no observation — or one that has never been active — renders as an
 /// untracked pane and does not count toward `done/total`. `pending` is counted
-/// whenever an observation reports `Pending`, active or not.
-pub fn roll_up<'a>(
+/// whenever an observation reports `Pending`, active or not. A quiet identity
+/// renders as [`PaneDisplay::Interactive`] whenever no live observation outranks
+/// it: it replaces the Untracked face and an *Idle* observation's muted row
+/// ("nvim" beats a stale finished-command echo), but never a non-idle one —
+/// counts and severity always come from observations alone, so an open editor
+/// can't read as work in `done/total`.
+pub fn roll_up<'a, 'q>(
     panes: &[TerminalPane],
     resolve: impl Fn(u32) -> Option<&'a TrackedObservation>,
+    quiet: impl Fn(u32) -> Option<(&'q str, Kind)>,
 ) -> TabDisplay {
     let mut best: Option<PrimaryDetail> = None;
     let mut done = 0usize;
@@ -208,9 +241,19 @@ pub fn roll_up<'a>(
     let mut pending = 0usize;
     let mut pane_displays = Vec::with_capacity(panes.len());
 
+    let interactive = |pane_id: u32| {
+        quiet(pane_id).map(|(msg, kind)| PaneDisplay::Interactive {
+            pane_id,
+            kind,
+            msg: msg.to_string(),
+        })
+    };
+
     for pane in panes {
         let Some(s) = resolve(pane.id) else {
-            pane_displays.push(PaneDisplay::untracked(pane.id, &pane.title));
+            let display = interactive(pane.id)
+                .unwrap_or_else(|| PaneDisplay::untracked(pane.id, &pane.title));
+            pane_displays.push(display);
             continue;
         };
 
@@ -225,7 +268,12 @@ pub fn roll_up<'a>(
             if s.status == Status::Pending {
                 pending += 1;
             }
-            pane_displays.push(PaneDisplay::Tracked {
+            let display = if s.status == Status::Idle {
+                interactive(pane.id)
+            } else {
+                None
+            };
+            pane_displays.push(display.unwrap_or_else(|| PaneDisplay::Tracked {
                 pane_id: pane.id,
                 kind: s.kind,
                 origin: s.origin,
@@ -236,18 +284,23 @@ pub fn roll_up<'a>(
                 outcome: pane_outcome(s),
                 pending_epoch_s: s.pending_epoch_s,
                 acknowledged: s.acknowledged,
-            });
+            }));
         } else {
-            pane_displays.push(PaneDisplay::untracked(pane.id, &pane.title));
+            let display = interactive(pane.id)
+                .unwrap_or_else(|| PaneDisplay::untracked(pane.id, &pane.title));
+            pane_displays.push(display);
         }
-        // Most-urgent active pane wins, ties broken by most-recent change.
-        // `Status: Ord` ranks severity, so this is a single lexicographic
-        // `(status, tick)` compare — `>=` keeps the last pane on a full tie.
+        // Most-urgent active pane wins; on equal severity a bounded *job*
+        // outranks a *service* (a spinning build summarizes the tab better
+        // than a dev server that is merely up — `docs/activity-model.md` §3);
+        // remaining ties break by most-recent change. `Status: Ord` ranks
+        // severity, so this is a single lexicographic `(status, job, tick)`
+        // compare — `>=` keeps the last pane on a full tie.
         if s.status.is_active() {
-            let key = (s.status, s.last_change_tick);
+            let key = (s.status, !s.kind.is_service(), s.last_change_tick);
             let wins = best
                 .as_ref()
-                .is_none_or(|d| key >= (d.status, d.since_tick));
+                .is_none_or(|d| key >= (d.status, !d.kind.is_service(), d.since_tick));
             if wins {
                 best = Some(PrimaryDetail {
                     repo: s.repo.clone(),

--- a/crates/plugin/src/rollup/tests.rs
+++ b/crates/plugin/src/rollup/tests.rs
@@ -376,6 +376,28 @@ fn quiet_identity_never_outranks_a_live_observation() {
 }
 
 #[test]
+fn primary_detail_tie_break_prefers_a_job_over_a_service() {
+    // On equal severity a bounded job outranks a service — a spinning build
+    // summarizes the tab better than a dev server that is merely up
+    // (docs/activity-model.md §3). The service has the LATER tick, so this
+    // pins the middle key of (status, job, tick): drop it and the recency
+    // tie-break hands the header to the server's steady mark.
+    let mut map = HashMap::new();
+    let build = TrackedObservation { kind: Kind::Build, ..obs(ObservationOrigin::Command, Status::Running, 1) };
+    let server = TrackedObservation { kind: Kind::Server, ..obs(ObservationOrigin::Command, Status::Running, 9) };
+    map.insert(1, build);
+    map.insert(2, server);
+    let panes = [pane(1, "build"), pane(2, "dev")];
+    let display = roll_up(&panes, resolver(&map), |_| None);
+    assert_eq!(display.detail.unwrap().kind, Kind::Build);
+    // Severity still wins over the job preference: a Pending service beats a
+    // Running job outright.
+    map.get_mut(&2).unwrap().status = Status::Pending;
+    let display = roll_up(&panes, resolver(&map), |_| None);
+    assert_eq!(display.detail.unwrap().kind, Kind::Server);
+}
+
+#[test]
 fn interactive_earns_a_pane_line_but_is_not_tracked() {
     let d = PaneDisplay::Interactive { pane_id: 7, kind: Kind::Command, msg: "nvim".into() };
     assert!(d.earns_pane_line());

--- a/crates/plugin/src/rollup/tests.rs
+++ b/crates/plugin/src/rollup/tests.rs
@@ -42,7 +42,7 @@ fn resolver<'a>(
 
 #[test]
 fn empty_panes_roll_up_to_idle() {
-    let display = roll_up(&[], |_id| None);
+    let display = roll_up(&[], |_id| None, |_| None);
     assert_eq!(display.status, Status::Idle);
     assert_eq!(display.progress, ProgressCounts::default());
     assert!(display.detail.is_none());
@@ -55,7 +55,7 @@ fn untracked_panes_are_shown_but_not_counted() {
     map.insert(1, obs(ObservationOrigin::StatusPipe, Status::Running, 1));
     let panes = [pane(1, "codex"), pane(2, "shell")];
 
-    let display = roll_up(&panes, resolver(&map));
+    let display = roll_up(&panes, resolver(&map), |_| None);
 
     assert_eq!(display.status, Status::Running);
     assert_eq!(display.progress.total, 1, "only the tracked pane counts");
@@ -72,7 +72,7 @@ fn severity_precedence_picks_highest_active() {
     map.insert(2, obs(ObservationOrigin::Command, Status::Error, 1));
     let panes = [pane(1, "a"), pane(2, "b")];
 
-    let display = roll_up(&panes, resolver(&map));
+    let display = roll_up(&panes, resolver(&map), |_| None);
 
     assert_eq!(display.status, Status::Error, "error outranks done");
     let detail = display.detail.expect("an active pane sets the detail");
@@ -88,7 +88,7 @@ fn tie_break_prefers_later_change_tick_over_position() {
     map.insert(2, obs(ObservationOrigin::StatusPipe, Status::Running, 5));
     let panes = [pane(1, "a"), pane(2, "b")];
 
-    let display = roll_up(&panes, resolver(&map));
+    let display = roll_up(&panes, resolver(&map), |_| None);
 
     assert_eq!(display.status, Status::Running);
     assert_eq!(
@@ -106,7 +106,7 @@ fn counts_done_total_and_pending() {
     map.insert(3, obs(ObservationOrigin::StatusPipe, Status::Pending, 1));
     let panes = [pane(1, "a"), pane(2, "b"), pane(3, "c")];
 
-    let display = roll_up(&panes, resolver(&map));
+    let display = roll_up(&panes, resolver(&map), |_| None);
 
     assert_eq!(display.progress.total, 3);
     assert_eq!(display.progress.done, 1);
@@ -126,7 +126,7 @@ fn pending_is_only_counted_for_tracked_panes() {
     map.insert(1, stale);
     let panes = [pane(1, "shell")];
 
-    let display = roll_up(&panes, resolver(&map));
+    let display = roll_up(&panes, resolver(&map), |_| None);
 
     assert_eq!(display.progress.total, 0, "an un-tracked pane is not in total");
     assert_eq!(
@@ -159,7 +159,7 @@ fn pane_outcome_maps_finished_commands_only() {
 fn tracked_pane_display_carries_last_change_tick_as_since_tick() {
     let panes = [pane(1, "shell")];
     let ob = obs(ObservationOrigin::StatusPipe, Status::Running, 42);
-    let display = roll_up(&panes, |id| (id == 1).then_some(&ob));
+    let display = roll_up(&panes, |id| (id == 1).then_some(&ob), |_| None);
     match &display.panes[0] {
         PaneDisplay::Tracked { since_tick, .. } => assert_eq!(*since_tick, 42),
         other => panic!("expected tracked pane, got {other:?}"),
@@ -172,7 +172,7 @@ fn task_threads_through_to_pane_display_and_primary_detail() {
     let mut obs = TrackedObservation::command(Status::Pending, "r".into(), "approve?".into(), Kind::Claude, 3);
     obs.origin = ObservationOrigin::StatusPipe;
     obs.task = "fix flaky e2e".into();
-    let display = roll_up(&panes, |id| (id == 1).then_some(&obs));
+    let display = roll_up(&panes, |id| (id == 1).then_some(&obs), |_| None);
     match &display.panes[0] {
         PaneDisplay::Tracked { task, msg, .. } => {
             assert_eq!(task, "fix flaky e2e");
@@ -267,7 +267,7 @@ proptest! {
     #[test]
     fn roll_up_invariants(specs in pane_specs()) {
         let (panes, map) = build(&specs);
-        let d = roll_up(&panes, |id| map.get(&id));
+        let d = roll_up(&panes, |id| map.get(&id), |_| None);
 
         // Every input pane appears exactly once, in input order.
         prop_assert_eq!(d.panes.len(), panes.len());
@@ -315,8 +315,8 @@ proptest! {
     #[test]
     fn roll_up_aggregate_is_order_independent(specs in pane_specs(), seed in any::<u64>()) {
         let (panes, map) = build(&specs);
-        let d1 = roll_up(&panes, |id| map.get(&id));
-        let d2 = roll_up(&shuffled(&panes, seed), |id| map.get(&id));
+        let d1 = roll_up(&panes, |id| map.get(&id), |_| None);
+        let d2 = roll_up(&shuffled(&panes, seed), |id| map.get(&id), |_| None);
 
         prop_assert_eq!(d1.status, d2.status);
         prop_assert_eq!(d1.progress, d2.progress);
@@ -325,4 +325,66 @@ proptest! {
             d2.detail.as_ref().map(|x| x.status)
         );
     }
+}
+
+// ── Interactive (Companion) panes: docs/activity-model.md §3 ──
+
+/// A quiet lookup that answers "nvim" for the given pane id.
+fn quiet_nvim(target: u32) -> impl Fn(u32) -> Option<(&'static str, Kind)> {
+    move |id| (id == target).then_some(("nvim", Kind::Command))
+}
+
+#[test]
+fn quiet_identity_renders_interactive_where_untracked_would_be() {
+    let panes = [pane(1, "shell")];
+    let display = roll_up(&panes, |_| None, quiet_nvim(1));
+    assert_eq!(
+        display.panes[0],
+        PaneDisplay::Interactive { pane_id: 1, kind: Kind::Command, msg: "nvim".into() }
+    );
+    // Pure context: no counts, no severity, no detail.
+    assert_eq!(display.status, Status::Idle);
+    assert_eq!(display.progress, ProgressCounts::default());
+    assert!(display.detail.is_none());
+}
+
+#[test]
+fn quiet_identity_replaces_an_idle_observations_muted_row_but_keeps_counts() {
+    // An Idle ever_active observation is a stale finished-command echo; the
+    // open editor is the better label. Counts still come from the
+    // observation alone — an editor must never read as work in done/total.
+    let mut map = HashMap::new();
+    map.insert(1, obs(ObservationOrigin::Command, Status::Idle, 1));
+    let panes = [pane(1, "shell")];
+    let display = roll_up(&panes, resolver(&map), quiet_nvim(1));
+    assert!(display.panes[0].is_interactive());
+    assert_eq!(display.progress.total, 1, "ever_active stickiness is untouched");
+}
+
+#[test]
+fn quiet_identity_never_outranks_a_live_observation() {
+    for status in [Status::Running, Status::Pending, Status::Done, Status::Error] {
+        let mut map = HashMap::new();
+        map.insert(1, obs(ObservationOrigin::StatusPipe, status, 1));
+        let panes = [pane(1, "shell")];
+        let display = roll_up(&panes, resolver(&map), quiet_nvim(1));
+        assert!(
+            display.panes[0].is_tracked(),
+            "{status:?} keeps its Tracked row"
+        );
+    }
+}
+
+#[test]
+fn interactive_earns_a_pane_line_but_is_not_tracked() {
+    let d = PaneDisplay::Interactive { pane_id: 7, kind: Kind::Command, msg: "nvim".into() };
+    assert!(d.earns_pane_line());
+    assert!(d.is_interactive());
+    assert!(!d.is_tracked());
+    assert_eq!(d.render_status(), Status::Idle);
+    assert_eq!(d.msg(), "nvim");
+    assert_eq!(d.kind(), Kind::Command);
+    assert_eq!(d.status(), None, "no status — context, not activity");
+    assert_eq!(d.outcome(), None);
+    assert_eq!(d.since_tick(), None);
 }

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -1061,7 +1061,7 @@ impl PluginRuntime {
     /// waking every second. Four triggers:
     ///
     /// - **animating work** — a `Running` agent/command whose glyph spins each
-    ///   tick (`RadarState::has_running_work`);
+    ///   tick (`RadarState::needs_fast_ticks`);
     /// - **an un-carried completion edge** — a `status_pipe` payload defers its
     ///   recede + notification to the timer (it can't trust its own focus, see
     ///   `RadarState::status_pipe`), so we must keep ticking until the settle has
@@ -1069,10 +1069,10 @@ impl PluginRuntime {
     ///   advances the baseline, so a *backgrounded* `Done`/`Error`/`Pending` stops
     ///   pinning the timer awake once notified — a later focus change or broadcast
     ///   re-arms it. (The pre-settle baseline read costs at most one extra tick.)
-    /// - **a command `Done` awaiting its TTL recede** (`RadarState::command_awaiting_recede`)
+    /// - **a command `Done` awaiting its TTL recede** (`RadarState::has_done_awaiting_recede`)
     ///   — the row itself is static (it doesn't animate and its notify already
     ///   fired), but the ledger handoff at `DONE_TTL_TICKS` still needs a tick to
-    ///   land on schedule, so it keeps this armed even though `has_running_work`
+    ///   land on schedule, so it keeps this armed even though `needs_fast_ticks`
     ///   stays narrow (see that method's doc for the arming split).
     /// - **an active ping flash** (`RadarState::has_active_flash`) — the
     ///   flip-to-pending glance-catcher is a two-tick visual, not a card fact,
@@ -1080,9 +1080,9 @@ impl PluginRuntime {
     ///
     /// [`has_unsettled_notifications`]: Self::has_unsettled_notifications
     fn timer_should_continue(&self) -> bool {
-        self.radar.has_running_work()
+        self.radar.needs_fast_ticks()
             || self.has_unsettled_notifications()
-            || self.radar.command_awaiting_recede()
+            || self.radar.has_done_awaiting_recede()
             || self.radar.has_active_flash(self.tick)
     }
 

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -365,6 +365,11 @@ impl PluginRuntime {
                 self.tick = tick;
             }
         }
+        // Level-triggered interactive-set application, AFTER the snapshot load
+        // so a rehydrated stale Running-nvim row is demoted here — the TUI
+        // fires no further CommandChanged until it exits, so this is the only
+        // edge that can catch it (`docs/activity-model.md` §5).
+        self.radar.set_interactive_commands(&self.config.interactive_commands);
         // Seed the notification baseline from the restored snapshot so that
         // pre-existing completions never fire a spurious Notify effect.
         self.notify_prev = crate::notify_rules::status_map(&self.radar.notify_views());
@@ -821,6 +826,11 @@ impl PluginRuntime {
             return Outcome::none();
         };
         self.config.apply_overrides(&kv);
+        // Re-apply the interactive set level-triggered: an `interactive_commands`
+        // override must demote an already-promoted Running TUI row NOW — it will
+        // never fire another CommandChanged until it exits. A sweep that changed
+        // state persists, so instances spawned later rehydrate the demotion.
+        let swept = self.radar.set_interactive_commands(&self.config.interactive_commands);
         let renames = self.radar.recompute_renames(self.config.naming);
         let change = RadarChange {
             render: true,
@@ -828,6 +838,7 @@ impl PluginRuntime {
             // A config override (density, glyphs, header…) redraws identical
             // rows differently — bypass the rows-diff render gate.
             force_render: true,
+            snapshot: SnapshotWrite::now_if(swept),
             ..RadarChange::default()
         };
         self.project(vec![], change, crate::clock::now_epoch_s())

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -174,7 +174,7 @@ fn denied_rail_with_running_snapshot_never_arms_the_timer() {
     );
 
     assert!(runtime.permission.denied());
-    assert!(runtime.radar.has_running_work());
+    assert!(runtime.radar.needs_fast_ticks());
     assert!(
         !outcome.effects.iter().any(|e| matches!(e, Effect::SetTimeout(_))),
         "denied rail must not tick for work it can never observe finishing"
@@ -2636,7 +2636,7 @@ mod timer_chain_fuzz {
     enum Step {
         /// Pop and deliver the earliest scheduled fire (real FIFO order).
         Fire,
-        /// A domain edge that can flip `has_running_work` — the real trigger
+        /// A domain edge that can flip `needs_fast_ticks` — the real trigger
         /// for a Slow<->Fast cadence transition.
         SetRunning(bool),
         /// The cross-session cycle's own direct `arm_timer_if_needed` call

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -73,6 +73,62 @@ fn load_rehydrates_snapshot_and_requests_permission_for_owner() {
 }
 
 #[test]
+fn load_sweeps_a_rehydrated_running_interactive_row() {
+    // The primary user journey of `interactive_commands`/the built-in set:
+    // hit the perpetual-nvim bug, upgrade/reload — the snapshot rehydrates
+    // the Running row and nvim fires no further CommandChanged until it
+    // exits, so the post-`load_snapshot` sweep is the ONLY edge that can
+    // demote it. Pins the load ordering (config → snapshot → sweep): a
+    // reorder breaks this silently.
+    let mut seeded = RadarState::default();
+    seeded.command_mut().insert_snapshot_observation(
+        9,
+        crate::observation::TrackedObservation::command(
+            Status::Running, "proj".into(), "nvim README.md".into(), crate::kind::Kind::Command, 7,
+        ),
+    );
+    let snapshot = seeded.snapshot_json(None, 7);
+
+    let mut runtime = PluginRuntime::default();
+    runtime.load(
+        config(),
+        Some(&snapshot),
+        PermissionProbe { marker: None, lock_acquired: true },
+    );
+
+    let obs = runtime.radar.command_store().get(9).unwrap();
+    assert_eq!(obs.status, Status::Idle, "rehydrated spinner demoted at load");
+    assert_eq!(
+        runtime.radar.command_store().quiet_identity(9),
+        Some(("nvim README.md", crate::kind::Kind::Command)),
+        "identity survives as the quiet pending (muted label / labeled exit)"
+    );
+}
+
+#[test]
+fn config_pipe_interactive_override_demotes_live_rows_and_persists() {
+    // Mid-session `config.v1` override: adding a name must demote an
+    // already-promoted Running row NOW (it will never fire another
+    // CommandChanged) and persist the sweep so instances spawned later
+    // rehydrate the demotion instead of the stale spinner.
+    let mut runtime = runtime_with_config(config());
+    runtime.permission = PermissionState::Resolved { granted: true };
+    runtime.command_changed(4, &["gdb".to_string()], true);
+    runtime.tick += crate::command::DEBOUNCE_TICKS;
+    runtime.radar.timer(runtime.tick, 0);
+    assert_eq!(runtime.radar.command_store().get(4).unwrap().status, Status::Running);
+
+    let outcome = runtime.config_pipe(r#"{"interactive_commands":"gdb"}"#);
+
+    assert_eq!(runtime.radar.command_store().get(4).unwrap().status, Status::Idle);
+    assert!(
+        outcome.effects.iter().any(|e| matches!(e, Effect::PersistSnapshot)),
+        "the sweep is a persisted edge: {:?}",
+        outcome.effects
+    );
+}
+
+#[test]
 fn load_denied_marker_records_denial_without_requesting_permission() {
     let mut runtime = PluginRuntime::default();
     let outcome = runtime.load(
@@ -475,7 +531,7 @@ fn status_pipe_mutates_store_arms_timer_and_persists_snapshot() {
     let outcome = runtime.status_pipe(&raw);
 
     assert!(outcome.render);
-    assert!(runtime.radar.status_store().any_running());
+    assert!(runtime.radar.status_store().needs_ticks());
     // Canonical `project` order is renames → snapshot → cwd → SetTimeout →
     // notify, so PersistSnapshot now precedes SetTimeout. Assert membership,
     // not position — the order contract has its own dedicated test.

--- a/crates/plugin/src/status_store.rs
+++ b/crates/plugin/src/status_store.rs
@@ -262,16 +262,18 @@ impl StatusStore {
         self.store.get(pane_id)
     }
 
-    /// True if any observation is currently `Running` — the one *animated* state
-    /// (its glyph spins each tick). Matches `CommandStore::has_pending_or_active`'s
-    /// narrowness on purpose: a finished `Done`/`Error` or a waiting `Pending` is
-    /// terminal for tick purposes — it doesn't animate, and its notification/recede
-    /// is a one-shot the settle carries — so it must NOT pin the timer awake. (An
-    /// earlier version counted every non-idle status here to "refresh elapsed
-    /// time," but elapsed time isn't rendered, so a backgrounded `Done` just spun
-    /// the timer forever — see the timer-arming discussion in `runtime`.)
+    /// True if any observation is currently `Running` *and animating* — the
+    /// spinning glyph (and, for jobs, the advancing `· 4m` run tag) is what
+    /// needs ticks. Matches `CommandStore::has_pending_or_active`'s narrowness
+    /// on purpose: a finished `Done`/`Error` or a waiting `Pending` is terminal
+    /// for tick purposes — its notification/recede is a one-shot the settle
+    /// carries — so it must NOT pin the timer awake. Running *services* are
+    /// likewise excluded (same rule as the command store): a producer pushing
+    /// `source: server` renders the steady mark, so nothing animates
+    /// (`docs/activity-model.md` §3).
     pub fn any_running(&self) -> bool {
-        self.store.any(|s| s.status == crate::status::Status::Running)
+        self.store
+            .any(|s| s.status == crate::status::Status::Running && !s.kind.is_service())
     }
 
     pub(crate) fn observations(&self) -> impl Iterator<Item = (u32, &TrackedObservation)> {

--- a/crates/plugin/src/status_store.rs
+++ b/crates/plugin/src/status_store.rs
@@ -8,8 +8,9 @@ use crate::status::Status;
 use std::collections::{HashMap, HashSet};
 
 /// Ticks a `Running` pane may sit at a shell prompt before its pushed status is
-/// declared stale and cleared to idle (~seconds at the Fast cadence, which a
-/// Running row always keeps armed). Long enough that a mid-turn foreground
+/// declared stale and cleared to idle (~seconds at the Fast cadence, which the
+/// armed clock itself keeps alive — `needs_ticks` counts live suspect clocks,
+/// since a Running *service* row no longer arms it). Long enough that a mid-turn foreground
 /// flicker — which re-asserts the agent's foreground or a fresh hook payload
 /// well inside the window — never trips it; short enough that killing an agent
 /// mid-turn doesn't leave a "working" row spinning forever.
@@ -202,8 +203,10 @@ impl StatusStore {
     /// suspicion has outlived the grace window gets cleared to idle — its
     /// producer died mid-turn and will never send the clearing broadcast.
     /// Returns the cleared pane ids (Running is not a completion, so there is
-    /// no ledger edge to hand back). Driven by the timer, which a Running row
-    /// always keeps armed at the Fast cadence.
+    /// no ledger edge to hand back). Driven by the timer, which `needs_ticks`
+    /// keeps armed at the Fast cadence while any suspect clock is live — the
+    /// clock itself is the arming reason, since a Running *service* row no
+    /// longer is (`docs/activity-model.md` §3).
     pub fn expire_stale_running(&mut self, now_tick: u64) -> Vec<u32> {
         let due: Vec<u32> = self
             .suspect_running
@@ -262,18 +265,18 @@ impl StatusStore {
         self.store.get(pane_id)
     }
 
-    /// True if any observation is currently `Running` *and animating* — the
-    /// spinning glyph (and, for jobs, the advancing `· 4m` run tag) is what
-    /// needs ticks. Matches `CommandStore::has_pending_or_active`'s narrowness
-    /// on purpose: a finished `Done`/`Error` or a waiting `Pending` is terminal
-    /// for tick purposes — its notification/recede is a one-shot the settle
-    /// carries — so it must NOT pin the timer awake. Running *services* are
-    /// likewise excluded (same rule as the command store): a producer pushing
-    /// `source: server` renders the steady mark, so nothing animates
-    /// (`docs/activity-model.md` §3).
-    pub fn any_running(&self) -> bool {
-        self.store
-            .any(|s| s.status == crate::status::Status::Running && !s.kind.is_service())
+    /// True while this store has tick-driven work: an *animated* Running row
+    /// ([`TrackedObservation::animating`] — the spinning glyph and, for jobs,
+    /// the advancing `· 4m` run tag are what need ticks; a Running service
+    /// holds the steady mark and is excluded), or an armed stale-Running
+    /// grace clock (`suspect_running` is measured in ticks, and for a service
+    /// row this predicate is its only tick source — the ghost of a killed
+    /// `source: server` producer must expire in ~15s, not ~15 Slow fires).
+    /// A finished `Done`/`Error` or a waiting `Pending` is terminal for tick
+    /// purposes — its notification/recede is a one-shot the settle carries —
+    /// so it must NOT pin the timer awake.
+    pub fn needs_ticks(&self) -> bool {
+        !self.suspect_running.is_empty() || self.store.any(TrackedObservation::animating)
     }
 
     pub(crate) fn observations(&self) -> impl Iterator<Item = (u32, &TrackedObservation)> {
@@ -313,6 +316,26 @@ mod tests {
 
     fn payload_with_task(pane_id: u32, status: Status, task: &str) -> StatusPayload {
         StatusPayload { task: task.into(), ..payload(pane_id, status) }
+    }
+
+    #[test]
+    fn needs_ticks_excludes_running_services_but_counts_suspect_clocks() {
+        // A pushed `source: server` Running row (reachable via `notify
+        // generic`) holds the steady mark — it must not pin the 1 Hz timer…
+        let mut s = StatusStore::default();
+        s.apply(StatusPayload { source: "server".into(), ..payload(1, Status::Running) }, 1, 0);
+        assert!(!s.needs_ticks(), "a steady service costs zero ticks");
+        // …but its stale-Running grace clock is tick-measured, and this
+        // predicate is that clock's ONLY tick source for a service row: a
+        // killed producer's ghost must expire in ~15s, not ~15 Slow fires.
+        s.clear_on_prompt_return(1, 2);
+        assert!(s.needs_ticks(), "an armed suspect clock needs ticks");
+        let cleared = s.expire_stale_running(2 + RUNNING_SUSPECT_GRACE_TICKS);
+        assert_eq!(cleared, vec![1], "ghost expires to idle");
+        assert!(!s.needs_ticks(), "expiry disarms");
+        // A non-service Running row still arms, as ever.
+        s.apply(payload(2, Status::Running), 10, 0);
+        assert!(s.needs_ticks());
     }
 
     #[test]
@@ -408,7 +431,7 @@ mod tests {
         assert_eq!(s.get(1).unwrap().status, Status::Idle);
         assert_eq!(s.get(1).unwrap().repo, "r", "repo kept so the tab keeps its name");
         assert!(s.get(1).unwrap().ever_active, "stays a muted row, not removed");
-        assert!(!s.any_running(), "the ghost no longer pins the fast timer");
+        assert!(!s.needs_ticks(), "the ghost no longer pins the fast timer");
     }
 
     #[test]
@@ -481,7 +504,7 @@ mod tests {
         s.apply(payload(1, Status::Running), 1, 0);
         s.apply(payload(1, Status::Idle), 2, 0);
         assert!(s.get(1).unwrap().ever_active);
-        assert!(!s.any_running());
+        assert!(!s.needs_ticks());
     }
 
     #[test]

--- a/crates/plugin/tests/e2e/main.rs
+++ b/crates/plugin/tests/e2e/main.rs
@@ -1123,7 +1123,7 @@ fn session_next_switches_to_the_session_with_attention() {
     // heartbeat and this test would need up to a minute of real wall time to
     // stay honest. Piping a `running` status into A's OWN terminal arms A's
     // Fast cadence indefinitely (an active `Running` row animates every
-    // tick — see `timer_should_continue`/`has_running_work`) without giving A
+    // tick — see `timer_should_continue`/`needs_fast_ticks`) without giving A
     // any attention of its own, so it doesn't interfere with the ordering
     // assertion below (B is still the only attention>0 peer).
     let pane_a = a.discover_terminal_pane_id();

--- a/docs/activity-model.md
+++ b/docs/activity-model.md
@@ -38,16 +38,18 @@ The classes are the *semantic model*, deliberately NOT an `AttentionClass`
 enum: tracing the actual consumers shows no call site would ever match all
 three variants. `Companion` is consumed entirely at intake (the promotion
 policy, §5) — it never becomes an observation, so roll-up, notify, and render
-never see it. `Service` needs exactly two consumers: the glyph split
-(`render::running_glyph`, the single owner) and the cadence term
-(`TrackedObservation::animating`, the single owner — both stores' predicates
-call it). `Job` is the default everywhere. The codebase's existing pattern
-for this is **predicates, not parallel enums**
+never see it. `Service` has two *owners* — the glyph split
+(`render::running_glyph`) and the cadence term
+(`TrackedObservation::animating`, which both stores' predicates call) — plus
+two Kind-reading presentation refinements: the run-tag exclusion
+(`render::run_tag` — services never wear a stopwatch, §3) and the
+job-over-service roll-up tie-break. `Job` is the default everywhere. The
+codebase's existing pattern for this is **predicates, not parallel enums**
 (`Kind::is_agent()`, `Status::{is_active, needs_attention, is_completion}`),
 so the code realizes the model as: the interactive set as intake policy
 (`Companion`), and the `Kind::is_service()` predicate (`Service`) behind
-those two owners. A speculative enum with zero exhaustive matchers would be
-a maintenance liability, not a seam.
+those four readers. A speculative enum with zero exhaustive matchers would
+be a maintenance liability, not a seam.
 
 - **`Job`** — bounded work with an end. Kinds: `Test`, `Build`, `Deploy`,
   `Command`, `Other`.
@@ -186,7 +188,7 @@ One state-machine change carries the whole model. In `CommandStore`, a
   completion, so `zellij run -- nvim` closing reads `nvim ✓`, never a blank
   row. (The identity-less untracked-pane fallback stays load-bearing for
   fast run-pane commands; do not guard it.)
-- **`has_pending_or_active` counts only promotable pendings** — an open
+- **`needs_ticks` counts only promotable pendings** — an open
   editor must not pin the 1 Hz timer (the v0.3.1 cadence guarantee).
 - Prompt contract, agent grace clocks, prune grace (`tracked_pane_ids`
   already includes pendings): all untouched.

--- a/docs/activity-model.md
+++ b/docs/activity-model.md
@@ -1,8 +1,8 @@
 # The activity model: states, classes, and presentation
 
-**Status:** design — partially shipped; the target model for issue #13 and its
-follow-ups. `docs/design.md` documents the pipeline (how state moves);
-this documents the *semantics* (what state means and how it should look).
+**Status:** living design — shipped (see §7); kept current as the
+implementation evolves. `docs/design.md` documents the pipeline (how state
+moves); this documents the *semantics* (what state means and how it looks).
 
 ## 1. The core principle
 
@@ -42,10 +42,10 @@ never see it. `Service` needs exactly three one-line checks (two `spin_glyph`
 call sites, one cadence predicate). `Job` is the default everywhere. The
 codebase's existing pattern for this is **predicates, not parallel enums**
 (`Kind::is_agent()`, `Status::{is_active, needs_attention, is_completion}`),
-so the code realizes the model as: the interactive set as intake policy now,
-and a `Kind::is_service()` predicate added *with its first consumer* in the
-Service follow-up. A speculative enum with zero exhaustive matchers would be
-a maintenance liability, not a seam.
+so the code realizes the model as: the interactive set as intake policy
+(`Companion`), and the `Kind::is_service()` predicate (`Service`) consulted
+by the two glyph sites and the cadence predicates. A speculative enum with
+zero exhaustive matchers would be a maintenance liability, not a seam.
 
 - **`Job`** — bounded work with an end. Kinds: `Test`, `Build`, `Deploy`,
   `Command`, `Other`.
@@ -66,16 +66,21 @@ a maintenance liability, not a seam.
 unchanged — it is the *wire and lifecycle* vocabulary and it is correct.
 Presentation is `f(Status, class)`:
 
-Each cell is tagged: **(shipped)** today, **(#13)** ships with the issue-13
-fix, **(follow-up)** independent later work.
+All cells below are **implemented** (the executable examples live in
+`docs/rail-reference.md` — scenarios AD/AE); only the upstream detection
+signal (§4 layer 4) remains future work.
 
 | | `Job` | `Service` | `Companion` |
 |---|---|---|---|
-| **Running** | `⠋` spinner + activity string (shipped); elapsed `· 4m` text tag (follow-up — the eased-spinner machinery and preserved start tick exist, `EASE_AFTER_TICKS`, but no elapsed text is rendered today) | steady non-animated mark (e.g. `▸`) + name, **no spinner, no fast cadence** (follow-up; requires a `docs/rail-reference.md` edit — it is the executable spec) | *never enters Running* — suppressed at intake (§4) (#13); muted identity label (follow-up, see §5 for the real path) |
-| **Done** | `✓` + ledger hand-off, TTL recede to Idle, notify (shipped) | exit of a service — `✓`/`✗` per code, notify: a dead dev server is news (shipped) | labeled completion (`nvim ✓`) via preserved identity for held/run panes (#13); recede as Job |
-| **Error** | `✗`, persists until re-run, notify (shipped) | same (shipped) | same (#13) |
-| **Pending** | agent-origin only: `◆` waiting-for-you + wait-age tag (shipped) | n/a | n/a |
-| **Idle** | muted row if `ever_active` (shipped) | muted row (shipped) | renders nothing (#13); muted identity label (follow-up) |
+| **Running** | `⠋` spinner + activity string; `· 4m` run tag once ≥ 1 minute (whole minutes, frozen at `1h+`; the true start survives re-promotions) | steady non-animated `▸` mark + name, **no spinner, no fast cadence** | *never enters Running* — suppressed at intake (§4); renders the muted identity label (`○ $ nvim README.md`) |
+| **Done** | `✓` + ledger hand-off, TTL recede to Idle, notify | exit of a service — `✓`/`✗` per code, notify: a dead dev server is news | labeled completion (`nvim ✓`) via preserved identity for held/run panes; recede as Job |
+| **Error** | `✗`, persists until re-run, notify | same | same |
+| **Pending** | agent-origin only: `◆` waiting-for-you + wait-age tag | n/a | n/a |
+| **Idle** | muted row if `ever_active` | muted row | muted identity label while the program is foreground (it also replaces a stale finished-command echo); nothing once it exits |
+
+Ties in the tab-level roll-up: on equal severity a bounded job outranks a
+service as the tab's primary detail — a spinning build summarizes the tab
+better than a server that is merely up.
 
 Cadence rule, restated per class: only `Job × Running` (plus unsettled
 notifications, flashes, and Done-awaiting-recede) keeps the 1 Hz timer armed.
@@ -202,20 +207,21 @@ basename by construction of every display path — pinned by a guard test
 Why identity-preserving suppression rather than the simpler ignore-branch
 (measured cost: ~15 lines — one field, one intake arm, two predicate
 filters): the preserved identity is exactly the state the target
-presentations need — the labeled exit uses it from #13 onward (without it, a
-held `zellij run -- nvim` exit inserts a *blank* Done row and a blank-bodied
+presentations need — the labeled exit uses it (without it, a held
+`zellij run -- nvim` exit inserts a *blank* Done row and a blank-bodied
 notification), and a future alt-screen classifier produces the identical
 mark. The ignore-branch discards identity and is forward-incompatible.
 
-**The muted-label follow-up is a real feature, not a free render.** Quiet
-pendings live in `CommandStore.pending`; `rows()` reads only observations,
-and the multi-pane roster filters to tracked panes — untracked panes emit no
-lines. The honest path: a quiet-identity accessor on `CommandStore` feeding a
-new `PaneDisplay` variant through `roll_up`, plus including those panes in
-the roster. The tempting shortcut — promote quiet commands to an *Idle*
-observation carrying identity — is wrong twice: `ever_active: true` would
-count an open editor in `done/total` progress forever, and `ever_active:
-false` renders as Untracked anyway (the identity never shows).
+**The muted label is a roll-up feature, not a free render.** Quiet pendings
+live in `CommandStore.pending`; `rows()` reads only observations, and the
+pane roster otherwise shows tracked panes. The implemented path:
+`CommandStore::quiet_identity` feeds `roll_up`'s `quiet` lookup, which
+builds `PaneDisplay::Interactive` — shown only where no live observation
+outranks it, included in the roster via `earns_pane_line`. The tempting
+shortcut — promote quiet commands to an *Idle* observation carrying identity
+— is wrong twice: `ever_active: true` would count an open editor in
+`done/total` progress forever, and `ever_active: false` renders as Untracked
+anyway (the identity never shows).
 
 ## 6. Extension guide
 
@@ -231,17 +237,18 @@ false` renders as Untracked anyway (the identity never shows).
 - **New pushed agent** → unchanged: `Agent` variant + `AGENT_NAMES` entry;
   the guard test walks you through it.
 
-## 7. Shipping order
+## 7. Status
 
-1. **Now (issue #13):** quiet-pending mechanism + built-in interactive set +
-   `interactive_commands` config key; Companion panes render idle. Guard
-   tests ship with it: display-first-token == exe basename for all rules
-   (the sweep's matching invariant), and `DEFAULT_INTERACTIVE` disjoint from
-   `IGNORE_NAMES`/`AGENT_NAMES` (§4). No `rail-reference.md` edit needed —
-   quiet panes render nothing. Plus a `docs/configuration.md` row:
-   `interactive_commands` — comma/space-separated exe names, default empty —
-   "extra commands treated as interactive: never shown as a running row;
-   extends the built-in editor/pager/TUI set."
-2. **Next, independent:** muted identity label for Companion panes; steady
-   `Service` mark + cadence exclusion; elapsed-time tag on long `Job` runs.
-3. **Upstream:** propose `is_alternate_screen`/`is_raw_mode` on `PaneInfo`.
+**Shipped in one cut** (issue #13 plus the semantics it exposed): the
+quiet-pending mechanism, the built-in interactive set + `interactive_commands`
+config key (level-triggered sweep), the Companion muted identity label
+(`PaneDisplay::Interactive`), the Service steady `▸` mark + cadence
+exclusion (both stores), the long-Job `· Nm` run tag, and the job-over-service
+roll-up tie-break. Guard tests pin the seams: display-first-token == exe
+basename (the sweep's matching invariant), `DEFAULT_INTERACTIVE` disjoint
+from `IGNORE_NAMES`/`AGENT_NAMES` (§4), and the executable rail spec
+scenarios AD/AE (`docs/rail-reference.md`).
+
+**Remaining:** propose `is_alternate_screen`/`is_raw_mode` on Zellij's
+`PaneInfo` (§4 layer 4) — the general detector that would cover REPLs and
+TUIs behind ssh/docker, with the name lists decaying into a fallback.

--- a/docs/activity-model.md
+++ b/docs/activity-model.md
@@ -1,0 +1,247 @@
+# The activity model: states, classes, and presentation
+
+**Status:** design — partially shipped; the target model for issue #13 and its
+follow-ups. `docs/design.md` documents the pipeline (how state moves);
+this documents the *semantics* (what state means and how it should look).
+
+## 1. The core principle
+
+> **A spinner means bounded work in progress.** Animation is a promise:
+> "this will complete, and you will want to know when."
+
+Everything else follows from one observation: the rail today conflates *"a
+foreground process exists"* with *"work is happening."* The user-meaningful
+axis is **attention direction** — who is waiting on whom:
+
+- You wait on **it** → activity. Show progress, notify on completion.
+- **It** waits on you → attention. Show urgency (pending/error).
+- Neither (unending by design, or interactive) → context. Show identity,
+  quietly, or nothing. Never a spinner, never a completion promise.
+
+An open editor is not activity. A dev server is not "still running" in any
+sense the user needs animated. A `cargo build` is exactly what the spinner
+was made for.
+
+## 2. The three orthogonal axes
+
+Every tracked pane's presentation is a function of three independent facts.
+Keeping them orthogonal — rather than growing one enum sideways — is what
+keeps the model extensible:
+
+| Axis | Type | Values | Who owns it |
+|---|---|---|---|
+| **Origin** | `ObservationOrigin` (exists) | `StatusPipe` \| `Command` | intake: pushed payload vs `CommandChanged` |
+| **Kind** | `Kind` (exists) | Claude, Codex, Gemini, Test, Build, Deploy, Server, Command, Other | classification (`Agent::derive` / `command::classify`) |
+| **Class** | semantic vocabulary — **not** a stored or derived Rust type | `Job` \| `Service` \| `Companion` | this document |
+
+The classes are the *semantic model*, deliberately NOT an `AttentionClass`
+enum: tracing the actual consumers shows no call site would ever match all
+three variants. `Companion` is consumed entirely at intake (the promotion
+policy, §5) — it never becomes an observation, so roll-up, notify, and render
+never see it. `Service` needs exactly three one-line checks (two `spin_glyph`
+call sites, one cadence predicate). `Job` is the default everywhere. The
+codebase's existing pattern for this is **predicates, not parallel enums**
+(`Kind::is_agent()`, `Status::{is_active, needs_attention, is_completion}`),
+so the code realizes the model as: the interactive set as intake policy now,
+and a `Kind::is_service()` predicate added *with its first consumer* in the
+Service follow-up. A speculative enum with zero exhaustive matchers would be
+a maintenance liability, not a seam.
+
+- **`Job`** — bounded work with an end. Kinds: `Test`, `Build`, `Deploy`,
+  `Command`, `Other`.
+- **`Service`** — unending by design. Kind: `Server` (`npm run dev`,
+  `cargo watch`). Completion is not expected; an *exit* is news (often bad).
+- **`Companion`** — interactive; it waits on the user. Editors, pagers,
+  monitors, git TUIs, file managers, REPLs. Reachable only via the
+  interactive classification (§4); it is a class, not a `Kind` — `nvim` and
+  `htop` don't need distinct kinds to share a presentation.
+- **Agents are outside this axis.** They are push-owned: their producer
+  reports `Running`/`Pending`/`Done` directly, so no class needs deriving —
+  which is also why "class is a function of Kind" holds (an agent turn being
+  a bounded job is the *producer's* contract, not a classification).
+
+## 3. The state × class presentation matrix
+
+`Status` (Idle < Done < Running < Pending < Error, severity-ordered) is
+unchanged — it is the *wire and lifecycle* vocabulary and it is correct.
+Presentation is `f(Status, class)`:
+
+Each cell is tagged: **(shipped)** today, **(#13)** ships with the issue-13
+fix, **(follow-up)** independent later work.
+
+| | `Job` | `Service` | `Companion` |
+|---|---|---|---|
+| **Running** | `⠋` spinner + activity string (shipped); elapsed `· 4m` text tag (follow-up — the eased-spinner machinery and preserved start tick exist, `EASE_AFTER_TICKS`, but no elapsed text is rendered today) | steady non-animated mark (e.g. `▸`) + name, **no spinner, no fast cadence** (follow-up; requires a `docs/rail-reference.md` edit — it is the executable spec) | *never enters Running* — suppressed at intake (§4) (#13); muted identity label (follow-up, see §5 for the real path) |
+| **Done** | `✓` + ledger hand-off, TTL recede to Idle, notify (shipped) | exit of a service — `✓`/`✗` per code, notify: a dead dev server is news (shipped) | labeled completion (`nvim ✓`) via preserved identity for held/run panes (#13); recede as Job |
+| **Error** | `✗`, persists until re-run, notify (shipped) | same (shipped) | same (#13) |
+| **Pending** | agent-origin only: `◆` waiting-for-you + wait-age tag (shipped) | n/a | n/a |
+| **Idle** | muted row if `ever_active` (shipped) | muted row (shipped) | renders nothing (#13); muted identity label (follow-up) |
+
+Cadence rule, restated per class: only `Job × Running` (plus unsettled
+notifications, flashes, and Done-awaiting-recede) keeps the 1 Hz timer armed.
+`Service` and `Companion` must never pin fast cadence — a dev server or an
+open editor left overnight costs zero ticks. This closes an existing hole:
+today `Kind::Server` spins (and ticks) forever. Note the long-runner *easing*
+does not save cadence — an eased spinner still repaints every 4th tick — so
+Service relief comes only from the steady mark plus the predicate change.
+
+Two behavior deltas #13 ships that reviewers should expect:
+- Closing nvim in a shell pane no longer fires a "done — nvim" notification
+  (no observation ever exists); a held `zellij run -- nvim` exit still
+  notifies, because pane death is a genuine event.
+- A tab holding [agent, nvim] drops from the multi-pane tree to single-pane
+  rendering (`is_multi_pane` counts tracked panes) — intended.
+
+Notification rule per class: `Job` notifies on Done/Error (the core product);
+`Service` notifies on exit (state *changed*, not state *continuing*);
+`Companion` never notifies except a labeled exit of a held pane.
+
+## 4. Detection: how a command earns its class
+
+Detection is layered, and the layers are **replaceable classifiers feeding one
+mechanism** — this is the anti-cat-and-mouse structure. The mechanism (§5)
+never knows how the classification was made.
+
+1. **Identity** (exists): exe name is an agent's wire-source token → agent
+   kinds, owned by the push pipe (`AGENT_NAMES`).
+2. **Structured argv** (exists): `TOOL_RULES` table → `Test`/`Build`/
+   `Deploy`/`Server`. Verb- and word-bounded, sees through `sudo`/`env`/
+   wrappers via the single `effective_program` peel — which also means
+   *children* classify: `git commit` spawning `$EDITOR` fires its own
+   `CommandChanged` and is classified as the editor.
+3. **Interactive names** (new, ships with issue #13): a conservative built-in
+   set of unambiguous TUIs (`vi`/`vim`/`nvim`/`emacs`/`nano`/`hx`/`less`/
+   `more`/`man`/`htop`/`btop`/`top`/`lazygit`/`tig`/`gitui`/`k9s`/`fzf`/
+   `ranger`/`yazi`/`nnn`/`mc`) housed beside `TOOL_RULES` — it is
+   classification data, not an ignore list — extended by the
+   `interactive_commands` config key (comma/space-separated exe names,
+   live-applied via `config.v1`). The config field holds the user's *extras
+   only* (default: empty); the effective set is `DEFAULT_INTERACTIVE ∪
+   extras`, composed in the setter — because the `config_fields!` macro
+   assigns wholesale, a field seeded with the defaults would let
+   `interactive_commands "k9s"` silently *replace* them and un-quiet nvim.
+   Override semantics stay consistent with every other key
+   (wholesale-replace of the extras). Matched on `program_name` after the
+   peel.
+4. **Terminal signals** (future, upstream): `is_alternate_screen` /
+   `is_raw_mode` on Zellij's `PaneInfo` — the genuinely general detector.
+   Alt-screen sees through `ssh`/`docker exec -it`; raw-mode covers REPLs
+   (`python` bare vs `python train.py` — undecidable by name, decidable by
+   termios). Verified absent from zellij-tile 0.44.3 *and* unreleased main;
+   Zellij tracks both internally, so this is a feasible contribution. When it
+   lands, layer 4 outranks layer 3 and the name list decays into a fallback
+   for older Zellij — no state-machine change, it just becomes another
+   producer of the same classification.
+
+**Known accepted gaps** (status-quo noise, never broken semantics): bare
+REPLs and remote TUIs over ssh until layer 4 exists; Debian-style variant
+binaries (`vim.basic`) until configured. A miss is always cosmetic and
+self-describing — the noisy row displays the exact string the user pastes
+into the config key.
+
+**Three lists, three contracts** — the roles must never be merged:
+
+| List | Meaning | Consulted by |
+|---|---|---|
+| `IGNORE_NAMES` | "this pane is back at a shell prompt" | `is_shell_prompt` → exit-clears pushed status, arms the Running grace clock |
+| `AGENT_NAMES` | "owned by the push pipe; never command-track" | intake suppression + grace-clock cancel; pinned equal to the CLI's adapters |
+| interactive set | "a real command that never earns a Running row" | promotion policy only (§5) — **not** consulted by `is_shell_prompt` |
+
+Putting an editor in `IGNORE_NAMES` would make "opened nvim" read as
+"returned to shell" and wrongly exit-clear a finished agent's pushed status.
+That conflation is the trap issue #13's reporter flagged. The table's
+enforced home is the doc comments in `command.rs` plus a guard test
+(`interactive_set_disjoint_from_prompt_and_agent_names`: `DEFAULT_INTERACTIVE
+∩ IGNORE_NAMES = ∅` and `∩ AGENT_NAMES = ∅`, same style as
+`agent_names_match_push_adapter_sources`) — a name drifting into two lists
+silently re-creates the trap.
+
+## 5. The mechanism: quiet pendings
+
+One state-machine change carries the whole model. In `CommandStore`, a
+`Pending` entry gains `promotable: bool`:
+
+- **Intake** of an interactive-classified foreground command: arm the
+  tentative-Done for any prior Running row (opening nvim after `cargo build`
+  finished still flips the build to Done), clear the exit dedup (a re-run's
+  exit must apply fresh), and insert a **non-promotable pending** carrying
+  the classified identity.
+- **Promotion** (`on_timer`) filters on `promotable` — the Running row never
+  materializes.
+- **`on_exit` is unchanged** — the surviving pending's identity labels the
+  completion, so `zellij run -- nvim` closing reads `nvim ✓`, never a blank
+  row. (The identity-less untracked-pane fallback stays load-bearing for
+  fast run-pane commands; do not guard it.)
+- **`has_pending_or_active` counts only promotable pendings** — an open
+  editor must not pin the 1 Hz timer (the v0.3.1 cadence guarantee).
+- Prompt contract, agent grace clocks, prune grace (`tracked_pane_ids`
+  already includes pendings): all untouched.
+
+**Level-triggered application.** One function, `apply_interactive_set`
+(store the composed set + sweep already-promoted state: demote matching
+Running command-origin rows to Idle without ledgering, flip matching
+promotable pendings quiet), called from two places — the end of
+`PluginRuntime::load` and after `apply_overrides` on the `config.v1` pipe.
+`load` assigns config *before* `load_snapshot`, so the single post-load call
+covers both a mid-session config change and a stale Running-nvim row
+rehydrated from another instance's snapshot; no ordering special cases.
+
+The sweep is what makes the fix apply to already-promoted rows at all: a
+mid-session TUI never fires another `CommandChanged` until it exits, so
+without it a config change — or a restart, whose snapshot rehydrates the
+Running row — leaves the spinner (and its 1 Hz cadence pin) live until the
+editor closes. The simpler "drop all command-origin Running rows and let
+re-promotion recover" is unsound: re-reports are incidental, not guaranteed
+(the `DEBOUNCE_TICKS` comment in `command.rs` — a dropped edge means nothing
+ever calls `on_command_changed` again), so a legit build row could vanish
+permanently. The sweep matches on the display's first whitespace token,
+which equals the exe
+basename by construction of every display path — pinned by a guard test
+(§7), since three functions hold that invariant.
+
+Why identity-preserving suppression rather than the simpler ignore-branch
+(measured cost: ~15 lines — one field, one intake arm, two predicate
+filters): the preserved identity is exactly the state the target
+presentations need — the labeled exit uses it from #13 onward (without it, a
+held `zellij run -- nvim` exit inserts a *blank* Done row and a blank-bodied
+notification), and a future alt-screen classifier produces the identical
+mark. The ignore-branch discards identity and is forward-incompatible.
+
+**The muted-label follow-up is a real feature, not a free render.** Quiet
+pendings live in `CommandStore.pending`; `rows()` reads only observations,
+and the multi-pane roster filters to tracked panes — untracked panes emit no
+lines. The honest path: a quiet-identity accessor on `CommandStore` feeding a
+new `PaneDisplay` variant through `roll_up`, plus including those panes in
+the roster. The tempting shortcut — promote quiet commands to an *Idle*
+observation carrying identity — is wrong twice: `ever_active: true` would
+count an open editor in `done/total` progress forever, and `ever_active:
+false` renders as Untracked anyway (the identity never shows).
+
+## 6. Extension guide
+
+- **New tool classifies wrong** → one `TOOL_RULES` row (kind + display).
+- **New TUI shows a spinner** → user: one `interactive_commands` entry,
+  live; maintainer: one name in the built-in set if it's ubiquitous.
+- **New presentation-relevant distinction** (e.g. a future `Remote` class) →
+  a row in the §3 matrix first, then a `Kind` predicate added *with its
+  first consumer* (`is_agent()`-style) — never a speculative enum ahead of a
+  call site that matches it.
+- **New detector** (alt-screen, raw-mode, anything) → a new producer of the
+  existing classification; zero changes to stores, roll-up, or render.
+- **New pushed agent** → unchanged: `Agent` variant + `AGENT_NAMES` entry;
+  the guard test walks you through it.
+
+## 7. Shipping order
+
+1. **Now (issue #13):** quiet-pending mechanism + built-in interactive set +
+   `interactive_commands` config key; Companion panes render idle. Guard
+   tests ship with it: display-first-token == exe basename for all rules
+   (the sweep's matching invariant), and `DEFAULT_INTERACTIVE` disjoint from
+   `IGNORE_NAMES`/`AGENT_NAMES` (§4). No `rail-reference.md` edit needed —
+   quiet panes render nothing. Plus a `docs/configuration.md` row:
+   `interactive_commands` — comma/space-separated exe names, default empty —
+   "extra commands treated as interactive: never shown as a running row;
+   extends the built-in editor/pager/TUI set."
+2. **Next, independent:** muted identity label for Companion panes; steady
+   `Service` mark + cadence exclusion; elapsed-time tag on long `Job` runs.
+3. **Upstream:** propose `is_alternate_screen`/`is_raw_mode` on `PaneInfo`.

--- a/docs/activity-model.md
+++ b/docs/activity-model.md
@@ -38,14 +38,16 @@ The classes are the *semantic model*, deliberately NOT an `AttentionClass`
 enum: tracing the actual consumers shows no call site would ever match all
 three variants. `Companion` is consumed entirely at intake (the promotion
 policy, §5) — it never becomes an observation, so roll-up, notify, and render
-never see it. `Service` needs exactly three one-line checks (two `spin_glyph`
-call sites, one cadence predicate). `Job` is the default everywhere. The
-codebase's existing pattern for this is **predicates, not parallel enums**
+never see it. `Service` needs exactly two consumers: the glyph split
+(`render::running_glyph`, the single owner) and the cadence term
+(`TrackedObservation::animating`, the single owner — both stores' predicates
+call it). `Job` is the default everywhere. The codebase's existing pattern
+for this is **predicates, not parallel enums**
 (`Kind::is_agent()`, `Status::{is_active, needs_attention, is_completion}`),
 so the code realizes the model as: the interactive set as intake policy
-(`Companion`), and the `Kind::is_service()` predicate (`Service`) consulted
-by the two glyph sites and the cadence predicates. A speculative enum with
-zero exhaustive matchers would be a maintenance liability, not a seam.
+(`Companion`), and the `Kind::is_service()` predicate (`Service`) behind
+those two owners. A speculative enum with zero exhaustive matchers would be
+a maintenance liability, not a seam.
 
 - **`Job`** — bounded work with an end. Kinds: `Test`, `Build`, `Deploy`,
   `Command`, `Other`.
@@ -82,13 +84,20 @@ Ties in the tab-level roll-up: on equal severity a bounded job outranks a
 service as the tab's primary detail — a spinning build summarizes the tab
 better than a server that is merely up.
 
-Cadence rule, restated per class: only `Job × Running` (plus unsettled
-notifications, flashes, and Done-awaiting-recede) keeps the 1 Hz timer armed.
-`Service` and `Companion` must never pin fast cadence — a dev server or an
-open editor left overnight costs zero ticks. This closes an existing hole:
-today `Kind::Server` spins (and ticks) forever. Note the long-runner *easing*
+Cadence rule, restated per class: only *animating* work
+(`TrackedObservation::animating` = `Job × Running`) plus **scheduled
+one-shots** keep the 1 Hz timer armed — the one-shots being promotable
+pendings awaiting debounce, tentative-Dones awaiting confirm
+(`pending_done`), stale-Running grace clocks (`suspect_running`), unsettled
+notifications, flashes, and Done-awaiting-recede. The one-shots must count
+explicitly *because* the service exclusion exists: pre-exclusion, "some row
+is Running" was an implicit tick source for all of them, and a Ctrl-C'd dev
+server still needs its Done confirm (and a killed `server`-source producer
+its ghost-expiry) within seconds, not on the ≤60s Slow heartbeat. `Service`
+and `Companion` rows themselves never pin fast cadence — a dev server or an
+open editor left overnight costs zero ticks. Note the long-runner *easing*
 does not save cadence — an eased spinner still repaints every 4th tick — so
-Service relief comes only from the steady mark plus the predicate change.
+Service relief comes only from the steady mark plus the `animating` term.
 
 One behavior delta reviewers should expect: closing nvim in a shell pane no
 longer fires a "done — nvim" notification (no observation ever exists); a
@@ -113,11 +122,12 @@ never knows how the classification was made.
    wrappers via the single `effective_program` peel — which also means
    *children* classify: `git commit` spawning `$EDITOR` fires its own
    `CommandChanged` and is classified as the editor.
-3. **Interactive names** (the issue-#13 fix): a conservative built-in
-   set of unambiguous TUIs (`vi`/`vim`/`nvim`/`emacs`/`nano`/`hx`/`less`/
-   `more`/`man`/`htop`/`btop`/`top`/`lazygit`/`tig`/`gitui`/`k9s`/`fzf`/
-   `ranger`/`yazi`/`nnn`/`mc`) housed beside `TOOL_RULES` — it is
-   classification data, not an ignore list — extended by the
+3. **Interactive names** (the issue-#13 fix): a conservative built-in set of
+   unambiguous TUIs — editors, pagers, `man`, monitors, git TUIs, file
+   managers, `fzf`; the authoritative list is `DEFAULT_INTERACTIVE` in
+   `crates/core/src/command.rs` (this doc deliberately doesn't copy it — the
+   list grows and a doc copy has no guard) — housed beside `TOOL_RULES`. It
+   is classification data, not an ignore list, extended by the
    `interactive_commands` config key (comma/space-separated exe names,
    live-applied via `config.v1`). The config field holds the user's *extras
    only* (default: empty); the effective set is `DEFAULT_INTERACTIVE ∪
@@ -181,11 +191,15 @@ One state-machine change carries the whole model. In `CommandStore`, a
 - Prompt contract, agent grace clocks, prune grace (`tracked_pane_ids`
   already includes pendings): all untouched.
 
-**Level-triggered application.** One function, `apply_interactive_set`
-(store the composed set + sweep already-promoted state: demote matching
-Running command-origin rows to Idle without ledgering, flip matching
-promotable pendings quiet), called from two places — the end of
-`PluginRuntime::load` and after `apply_overrides` on the `config.v1` pipe.
+**Level-triggered application.** One function,
+`CommandStore::set_interactive_extras` (reached via
+`RadarState::set_interactive_commands`): store the composed set + sweep
+already-promoted state — demote matching Running command-origin rows to Idle
+without ledgering, reconstructing their quiet pending from the observation so
+the swept state is identical to the intake state (muted label, labeled exit,
+symmetric un-quiet), and re-judge every pending against the new set. Called
+from two places — the end of `PluginRuntime::load` and after
+`apply_overrides` on the `config.v1` pipe.
 `load` assigns config *before* `load_snapshot`, so the single post-load call
 covers both a mid-session config change and a stale Running-nvim row
 rehydrated from another instance's snapshot; no ordering special cases.

--- a/docs/activity-model.md
+++ b/docs/activity-model.md
@@ -90,12 +90,11 @@ today `Kind::Server` spins (and ticks) forever. Note the long-runner *easing*
 does not save cadence — an eased spinner still repaints every 4th tick — so
 Service relief comes only from the steady mark plus the predicate change.
 
-Two behavior deltas #13 ships that reviewers should expect:
-- Closing nvim in a shell pane no longer fires a "done — nvim" notification
-  (no observation ever exists); a held `zellij run -- nvim` exit still
-  notifies, because pane death is a genuine event.
-- A tab holding [agent, nvim] drops from the multi-pane tree to single-pane
-  rendering (`is_multi_pane` counts tracked panes) — intended.
+One behavior delta reviewers should expect: closing nvim in a shell pane no
+longer fires a "done — nvim" notification (no observation ever exists); a
+held `zellij run -- nvim` exit still notifies, because pane death is a
+genuine event. (A tab holding [agent, nvim] stays a multi-pane tree — the
+Interactive label earns a pane line via `earns_pane_line`.)
 
 Notification rule per class: `Job` notifies on Done/Error (the core product);
 `Service` notifies on exit (state *changed*, not state *continuing*);
@@ -114,7 +113,7 @@ never knows how the classification was made.
    wrappers via the single `effective_program` peel — which also means
    *children* classify: `git commit` spawning `$EDITOR` fires its own
    `CommandChanged` and is classified as the editor.
-3. **Interactive names** (new, ships with issue #13): a conservative built-in
+3. **Interactive names** (the issue-#13 fix): a conservative built-in
    set of unambiguous TUIs (`vi`/`vim`/`nvim`/`emacs`/`nano`/`hx`/`less`/
    `more`/`man`/`htop`/`btop`/`top`/`lazygit`/`tig`/`gitui`/`k9s`/`fzf`/
    `ranger`/`yazi`/`nnn`/`mc`) housed beside `TOOL_RULES` — it is

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,7 @@ ignored and invalid values fall back to the default (parsing never fails):
 | `notify_error` | `true` · `false` | `true` | Notify when a pane transitions into `error`. |
 | `notify_pending` | `true` · `false` | `true` | Notify when a pane transitions into `pending` (needs input). |
 | `notify_when_focused` | `true` · `false` | `false` | When `false`, suppress notifications for the focused pane (background panes only). |
+| `interactive_commands` | comma/space-separated exe names | *(empty)* | Extra commands treated as *interactive* (an editor/pager/TUI that waits on you): the pane never shows a spinning running row — just a muted identity label. Extends the built-in set (`vi(m)`/`nvim`/`emacs`/`nano`/`hx`/`less`/`man`/`htop`/`btop`/`lazygit`/`tig`/`k9s`/`fzf`/`ranger`/`yazi`/`mc`/…). Applies live: adding a name demotes an already-running row immediately. See [`activity-model.md`](activity-model.md). |
 
 Notifications fire only on transitions **into** an attention status and, by
 default, only for **background** panes — the focused pane is suppressed unless

--- a/docs/design.md
+++ b/docs/design.md
@@ -84,9 +84,11 @@ This mirrors Cmux's real status path while fitting Zellij's plugin architecture.
   The *semantics* of what each status/kind pairing should look like — attention
   classes (Job/Service/Companion), interactive-command suppression, cadence
   rules — live in [`activity-model.md`](activity-model.md).
-- Per-tab rows are **two lines**: line 1 = state dot + **display tab number** + name (+
-  `done/total` count when a tab holds multiple agents); line 2 = `repo/branch · elapsed` and a
-  truncated last message.
+- Per-tab rows are a **header line plus one line per tracked pane**: line 1 =
+  state glyph + **display tab number** + name; each pane line = tree connector +
+  status glyph + kind mark + identity/activity (see `rail-reference.md` — the
+  executable spec — for the exact grid; elapsed appears only as the per-pane
+  pending wait tag and long-job run tag, rule 2 there).
 - **Display tab number = `TabInfo.position + 1`** (see §6 — position is 0-indexed).
 - Plain (non-agent) tabs render name only — agent decoration is purely additive. The name is
   `TabInfo.name` (from the layout or zj-radar' own push-based naming, §6.1) — **not** from
@@ -183,8 +185,10 @@ tab), so tab state cannot come from names. The store keys by `PaneId`; `PaneUpda
 - **Count:** `total` = panes in this tab that have *ever* reported a non-idle agent state and
   still exist; `done` = those whose current status is `done`. Render as `done/total` when
   `total > 1`.
-- **Second-line detail (which pane's repo/branch/msg to show):** the highest-severity pane;
-  tie-break by most-recent `last_change_tick`.
+- **Primary detail (which pane's repo/branch/msg summarizes the tab):** the
+  highest-severity pane; on equal severity a bounded *job* outranks a *service*
+  (a spinning build beats a merely-up dev server — `activity-model.md` §3);
+  remaining ties by most-recent `last_change_tick`.
 - **Pruning:** on each `PaneUpdate`, drop state for `PaneId`s no longer present, so closed
   agents leave no ghost status.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -81,6 +81,9 @@ This mirrors Cmux's real status path while fitting Zellij's plugin architecture.
   the exact grid.
 - **Status vocabulary:** the pipe sends raw values `running`/`pending`/`done`/`error`/`idle`;
   the renderer maps `running`→working, `pending`→waiting-for-you, `idle`/absent→plain.
+  The *semantics* of what each status/kind pairing should look like — attention
+  classes (Job/Service/Companion), interactive-command suppression, cadence
+  rules — live in [`activity-model.md`](activity-model.md).
 - Per-tab rows are **two lines**: line 1 = state dot + **display tab number** + name (+
   `done/total` count when a tab holds multiple agents); line 2 = `repo/branch · elapsed` and a
   truncated last message.

--- a/docs/rail-reference.md
+++ b/docs/rail-reference.md
@@ -83,8 +83,11 @@ marker itself is never dropped for the badge's sake.
 
 **Header heartbeat sweep (Task 20).** In Compact/Comfortable density only (the
 densities with the `═` rule — Cards drops the rule entirely, so it never
-carries the heartbeat), whenever any row's `display.status == Status::Running`
-the rule line swaps one `═` character for a `◆` (`Role::Accent`, bold) at
+carries the heartbeat), whenever any row is Running *animating* work (its
+detail is a job, not a service — a rail whose only Running rows are steady-`▸`
+services draws no sweep, since without the Fast cadence the diamond would only
+teleport once per Slow fire, and motion promises bounded work) the rule line
+swaps one `═` character for a `◆` (`Role::Accent`, bold) at
 column `now_tick % width`, wrapping around as the tick advances — a pure,
 stateless function of `now_tick` that marches one column per render tick
 while any tab is actively working, and disappears the instant no row is

--- a/docs/rail-reference.md
+++ b/docs/rail-reference.md
@@ -17,7 +17,7 @@
    carries a `· Nm` wait tag (the cost of ignoring it — see T5), and a
    long-running bounded *job* (command-classified work: build/test/deploy/
    command — never an agent, never a server) carries a `· Nm` run tag (the
-   cost still being paid — see AD). Under a minute, and for every other
+   cost still being paid — see AE). Under a minute, and for every other
    status, lines stay bit-identical to the tagless rail.
    ⟦D-timer ✓ pending + long-job⟧
 3. **One line per real pane — no collapsing.** Every *tracked* pane (an agent or
@@ -30,9 +30,9 @@
    an editor/pager/TUI in the foreground (`nvim`, `less`, `htop`, … +
    `interactive_commands` config) never earns a Running row — its pane renders
    a *muted identity label* (idle glyph + kind mark + command), pure
-   navigation aid, zero urgency. See scenario AC. A running **server**
+   navigation aid, zero urgency. See scenario AD. A running **server**
    (`Kind::Server`) is activity that never *completes*: it keeps its row but
-   holds the steady `▸` mark instead of the spinner. See AD.
+   holds the steady `▸` mark instead of the spinner. See AE.
 5. **Safety cap 6.** At most 6 pane lines per tab; beyond that, a final
    `+N more` line. (High on purpose — the common case never folds.) ⟦D6 ✓ = 6⟧
 6. **Position order.** Tabs and panes render in position order — no

--- a/docs/rail-reference.md
+++ b/docs/rail-reference.md
@@ -10,19 +10,29 @@
 ## Design rules (this revision)
 
 1. **Width 32 columns.** The layout snippets all use `size=32` to match. ⟦D8⟧
-2. **Elapsed is pending-only.** No elapsed/timer on tab lines or calm pane
-   lines. The one exception (the ⟦D-timer⟧ "per-pane, not per-tab" answer,
-   scoped to where waiting is *costly*): a `pending` pane's identity line
-   carries a `· Nm` wait tag once it has waited ≥ 1 minute — whole minutes,
-   frozen at `1h+` (the ledger's saturate window, so the Slow heartbeat can
-   disarm). Under a minute, and for every other status, lines stay bit-identical
-   to the tagless rail. See scenario T5. ⟦D-timer ✓ pending-only⟧
+2. **Elapsed marks cost, nothing else.** No elapsed/timer on tab lines or calm
+   pane lines. Two per-pane exceptions (the ⟦D-timer⟧ "per-pane, not per-tab"
+   answer, scoped to where time is *costly*), both whole minutes ≥ 1m, frozen
+   at `1h+` (the ledger's saturate window): a `pending` pane's identity line
+   carries a `· Nm` wait tag (the cost of ignoring it — see T5), and a
+   long-running bounded *job* (command-classified work: build/test/deploy/
+   command — never an agent, never a server) carries a `· Nm` run tag (the
+   cost still being paid — see AD). Under a minute, and for every other
+   status, lines stay bit-identical to the tagless rail.
+   ⟦D-timer ✓ pending + long-job⟧
 3. **One line per real pane — no collapsing.** Every *tracked* pane (an agent or
    a real command) gets its own line regardless of status or tab focus. No
    tally, no `+N verb` — those were hard to parse.
 4. **Prompt programs are not panes.** `starship`/`zsh`/`bash`/… never surface as
    a pane line (the `$ (starship)` phantom is gone). A pane that has only ever
    run the shell prompt is untracked → no line. ⟦D4 ✓ locked⟧
+   **Interactive programs are context, not activity** (`docs/activity-model.md`):
+   an editor/pager/TUI in the foreground (`nvim`, `less`, `htop`, … +
+   `interactive_commands` config) never earns a Running row — its pane renders
+   a *muted identity label* (idle glyph + kind mark + command), pure
+   navigation aid, zero urgency. See scenario AC. A running **server**
+   (`Kind::Server`) is activity that never *completes*: it keeps its row but
+   holds the steady `▸` mark instead of the spinner. See AD.
 5. **Safety cap 6.** At most 6 pane lines per tab; beyond that, a final
    `+N more` line. (High on purpose — the common case never folds.) ⟦D6 ✓ = 6⟧
 6. **Position order.** Tabs and panes render in position order — no
@@ -38,7 +48,8 @@
 
 ## Vocabulary
 
-**Status glyphs (plain):** `○` idle · `⠋` working *(spins ⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏)* · `◆` needs-you ·
+**Status glyphs (plain):** `○` idle · `⠋` working *(spins ⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏; a running
+**server** holds a steady `▸` instead — services don't spin)* · `◆` needs-you ·
 `●` done · `✗` error.
 **Kind marks:** `✳` claude · `❉` codex · `✦` gemini · `$` command · `⚙` build ·
 `⚗` test · `⇡` deploy · `❯` server · `⦿` other.
@@ -882,6 +893,59 @@ alt-[n] jump
 > set `jump_hint "alt-n"` themselves. Without it the hint line simply doesn't
 > exist — the rail never advertises a chord that isn't bound. ⟦zero state +
 > jump_hint / spec §7,§9⟧
+
+---
+
+## AD. Interactive pane — muted identity label, never a Running row
+
+An editor in the foreground is *context*, not activity (rule 4;
+`docs/activity-model.md` Companion class). The pane renders a muted
+identity label — idle glyph, kind mark, the classified command — under the
+agent's tree, and contributes nothing to the tab glyph, counts, or
+notifications. The `interactive "<argv>"` input drives the real
+command-observer path: a quiet pending, no promotion.
+
+```rail-input
+width 32
+tab 1 "web"
+  claude running "editing api.ts" task "add rate limits"
+  interactive "nvim README.md"
+```
+```rail-expect
+ RADAR                        ·1
+◆═══════════════════════════════
+ ⠋ 1 web
+ ├ ⠋ ✳ add rate limits
+ └ ○ $ nvim README.md
+```
+
+> A tab holding only an interactive pane renders the same single muted line
+> under an idle header — never `⠋ running nvim` (the issue-#13 symptom).
+
+## AE. Service steady mark + the long-job `· Nm` run tag
+
+Two Running rows, two presentations (rule 2 + rule 4): the bounded *build*
+spins and — 4 minutes in (`now_tick 240`, statuses applied at tick 0) —
+carries the `· 4m` run tag; the *server* holds the steady `▸` and never
+wears a stopwatch (it isn't costing anyone a wait — it's just up). The tab
+glyph spins: on equal severity the bounded job outranks the service as the
+tab's primary detail. (The header divider's sweep dot rides `now_tick`,
+hence column 16 here: 240 mod 32.)
+
+```rail-input
+width 32
+now_tick 240
+tab 1 "dev"
+  build running "cargo build"
+  server running "npm run dev"
+```
+```rail-expect
+ RADAR                        ·1
+════════════════◆═══════════════
+ ⠋ 1 dev
+ ├ ⠋ ⚙ cargo build · 4m
+ └ ▸ ❯ npm run dev
+```
 
 ---
 


### PR DESCRIPTION
Closes #13.

## What

Implements the activity model (`docs/activity-model.md`, new): the rail's presentation now follows **attention direction** — a spinner means *bounded work in progress* — instead of "a foreground process exists."

- **Interactive commands (Companion class)** — editors/pagers/TUIs (`nvim`, `less`, `htop`, `lazygit`, … — `DEFAULT_INTERACTIVE`, extended by a new `interactive_commands` config key, live-applied) never earn a Running row. They record a *quiet pending*: identity kept for the muted pane label (`└ ○ $ nvim README.md`) and for labeled exits of held panes (`nvim ✓`, never a blank Done row), but no promotion, no spinner, no fast cadence.
- **Services** (`Kind::Server`) — a Running dev server holds a steady `▸` mark instead of a perpetual spinner and no longer pins the 1 Hz timer.
- **Long jobs** — Running builds/tests/commands gain a `· 4m` elapsed tag (≥1 min, frozen at `1h+`, same band as the pending wait tag).
- **Roll-up tie-break** — on equal severity a bounded job outranks a service as the tab's primary detail.

## Design notes

- The exclusion is **classification, not an ignore list**: `IGNORE_NAMES` (shell prompt → exit-clears pushed agent status) and `AGENT_NAMES` (push-owned) are untouched; a guard test pins the three lists disjoint. Putting editors in `IGNORE_NAMES` would have broken the prompt contract — the trap flagged in #13.
- The cadence rule is now structural: `TrackedObservation::animating` is the single term both stores' predicates use, and scheduled one-shots (`pending_done`, `suspect_running`) count explicitly — a Ctrl-C'd server still flips Done in ~2s and a killed producer's ghost expires in ~15s.
- Config holds user *extras only*; the effective set is composed in the store (`config_fields!` assigns wholesale — seeding defaults would let one entry replace them).
- The level-triggered sweep (load + `config.v1`) demotes already-promoted rows — a mid-session TUI fires no further `CommandChanged` until exit, and a restart's snapshot rehydrates the stale spinner, so the sweep is the only edge that can catch them. Demotion reconstructs the quiet pending so the swept state is identical to the intake state.
- Known accepted gaps (status-quo noise, never broken semantics): bare REPLs (`python` is name-ambiguous) and TUIs behind ssh/docker — only an upstream Zellij `PaneInfo` `is_alternate_screen`/`is_raw_mode` signal can cover those (verified absent from 0.44.3 and unreleased main; planned as a follow-up upstream proposal).

## Spec & tests

- `docs/rail-reference.md` (executable spec): rules 2/4 + vocabulary updated; new scenarios **AD** (interactive muted label) and **AE** (service mark + run tag); the DSL grew `interactive "<argv>"` panes and a `now_tick` directive.
- New tests: quiet-pending battery (never promotes, prior-Running flips Done, labeled held-pane exit, prompt contract untouched, level-triggered sweep + symmetric un-quiet), cadence pins (service exclusion in both stores, Done-confirm arming, suspect-clock arming), `run_tag` unit, rollup tie-break + Interactive precedence, runtime-level load-sweep and `config.v1` sweep-persist, and two guard tests (list disjointness; display-first-token == exe basename, the sweep's matching invariant).
- Docs: `docs/activity-model.md` (the semantic model), `configuration.md` row, `CONTEXT.md` + `design.md` destaled.

Gates: `just ci` green (clippy `-D warnings`, wasm build, bats), live E2E 13/13.

**Note:** `notify_codex_hook_broadcasts_pending_payload` (crates/cli/tests/cli.rs) is a pre-existing machine-conditional flake — verified failing identically on untouched main; this PR hardens it with a bounded poll + clear failure message but the root cause is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)