### PR TITLE
fix(claude): preserve native producer event order

### DIFF
--- a/plugins/zj-radar-claude/scripts/notify.sh
+++ b/plugins/zj-radar-claude/scripts/notify.sh
@@ -20,14 +20,8 @@ set -euo pipefail
 
 status="${1:-running}"
 
-# Read the hook payload up front so the running-path notify below can be
-# backgrounded. `running` rides UserPromptSubmit and Pre/PostToolUse — the
-# hottest events Claude has — and a synchronous notify blocks the harness
-# (UserPromptSubmit blocks the user's prompt) until it exits. On a quiet
-# machine that's milliseconds; on a saturated one (test suites, subagent
-# fleets) process spawns crawl and the hook eats the 30s timeout. A running
-# ping is fire-and-forget by nature: losing one under load is harmless,
-# blocking a prompt is not.
+# Read the hook payload up front, once: the cap below has to apply on both
+# dispatch paths, and the bash fallback re-parses the same buffer repeatedly.
 # Cap the read at 8 MiB (parity with the Rust CLI's MAX_STDIN_BYTES): a
 # degenerate multi-GB stream must bound memory, not buffer whole. Truncated
 # input just fails the jq parses below and no-ops — the safe degradation.
@@ -37,18 +31,21 @@ input="$(head -c 8388608 2>/dev/null || true)"
 # the same Zellij gate, pending backstop, and payload schema. Falls back to the
 # bash implementation below when the binary isn't installed.
 #
-# Dispatch split, reconciling the in-order contract with the hot-path note
-# above: `running` is backgrounded (self-healing — the next event overwrites
-# it, and the plugin's stale-Running grace clock catches a straggler), but the
-# EDGES (done/pending/idle) go synchronously — an edge overtaken by a stale
-# `running` is exactly the stuck-spinner bug the tail comment on the bash path
-# documents, and edges fire once per turn, off the harness's critical path.
+# Synchronous for EVERY status — the same in-order rule the bash path's tail
+# comment spells out. An earlier split backgrounded `running` (the hot path:
+# UserPromptSubmit and Pre/PostToolUse) and kept the edges synchronous, which
+# let a delayed `running` land AFTER the `done` that followed it; the plugin is
+# latest-wins, so the stale `running` took the pane and the spinner stuck.
+# Nothing reliably corrects that: `done` is the last hook of a turn, so there
+# may be no next event to overwrite it, and the stale-Running grace clock is
+# armed by a return-to-shell edge that never fires while Claude itself is the
+# pane's foreground process. The CLI bounds its own send (`pipe_send_timeout`
+# in crates/cli/src/notify.rs), so a wedged rail costs a capped wait rather
+# than an open-ended hook; a healthy local server answers in milliseconds.
 if command -v zj-radar >/dev/null 2>&1; then
-    if [[ "$status" == "running" ]]; then
-        ( printf '%s' "$input" | zj-radar notify claude --status "$status" >/dev/null 2>&1 & )
-    else
-        printf '%s' "$input" | zj-radar notify claude --status "$status" >/dev/null 2>&1 || true
-    fi
+    printf '%s' "$input" \
+        | zj-radar notify claude --status "$status" >/dev/null 2>&1 \
+        || true
     exit 0
 fi
 

--- a/plugins/zj-radar-claude/tests/notify.bats
+++ b/plugins/zj-radar-claude/tests/notify.bats
@@ -269,3 +269,61 @@ EOF
   [ "$status" -eq 0 ]
   (( SECONDS - start < 30 ))  # 5s fallback + slack, nowhere near the 60s hang
 }
+
+@test "native CLI dispatch keeps running→done in order (stuck-spinner guard)" {
+  # helper.bash strips every real zj-radar off PATH so the rest of this file
+  # exercises the bash fallback; this case pins the OTHER branch — the native
+  # dispatch, which is the only path an installed machine ever takes.
+  #
+  # The producer's contract is in-order (CONTEXT.md → Status contract: the
+  # plugin is latest-wins and no payload carries a sequence, so a producer that
+  # reorders its own sends has no downstream correction). A backgrounded
+  # `running` can be overtaken by the `done` that follows it, and the rail then
+  # spins forever: Claude stays the pane's foreground process while it sits at
+  # its prompt, so no return-to-shell edge ever arrives to clear it.
+  local cli_log="$FAKEBIN/cli.log"
+  # Fake CLI: drain stdin, parse --status, and record it AFTER the delay, so
+  # the log reflects ARRIVAL order rather than call order. A `running` send is
+  # the slow one — exactly the skew a loaded machine produces.
+  cat >"$FAKEBIN/zj-radar" <<EOF
+#!/usr/bin/env bash
+cat >/dev/null 2>&1 || true
+status=""
+while [[ \$# -gt 0 ]]; do
+  [[ "\$1" == "--status" ]] && { status="\$2"; shift; }
+  shift
+done
+[[ "\$status" == "running" ]] && sleep 1
+printf '%s\n' "\$status" >> "$cli_log"
+EOF
+  chmod +x "$FAKEBIN/zj-radar"
+  # Non-vacuity: the dispatch must resolve OUR fake. If it didn't, the script
+  # would fall through to the bash path and the ordering claim would be untested.
+  [ "$(command -v zj-radar)" = "$FAKEBIN/zj-radar" ]
+
+  rm -f "$RECORD" "$cli_log"
+  printf '%s' '{"hook_event_name":"PostToolUse","cwd":"/tmp","tool_name":"Read","tool_input":{"file_path":"README.md"}}' \
+    | "$SCRIPT" running
+  printf '%s' '{"hook_event_name":"Stop","cwd":"/tmp","last_assistant_message":"finished"}' \
+    | "$SCRIPT" done
+
+  # Both sends must land before order can be judged: a backgrounded `running`
+  # arrives well after the script that started it returned.
+  local i
+  for i in $(seq 1 100); do
+    [ "$(wc -l <"$cli_log" 2>/dev/null || echo 0)" -ge 2 ] && break
+    sleep 0.1
+  done
+
+  # Non-vacuity: the native branch exits before the bash fallback's zellij send,
+  # so a silent fall-through would leave a payload here.
+  [ ! -s "$RECORD" ]
+
+  local expected actual
+  expected="$(printf 'running\ndone')"
+  actual="$(cat "$cli_log" 2>/dev/null || true)"
+  [ "$actual" = "$expected" ] || {
+    printf 'expected:\n%s\n\nactual:\n%s\n' "$expected" "$actual"
+    return 1
+  }
+}


### PR DESCRIPTION
Closes #15.

## What

`notify.sh`'s native-CLI dispatch backgrounded `running` while sending the edges
(`done`/`pending`/`idle`) synchronously. The two paths race, so a delayed `running` could
reach the sidebar *after* the `done` that logically followed it — and since the plugin is
latest-wins, the stale `running` took the pane and the spinner stuck.

This **restores the producer's existing in-order contract rather than introducing new
behavior.** The script's header already claims to be "In-order and non-erroring", the bash
path's tail comment already records this exact failure from an earlier backgrounded
implementation ("let a `Stop→done` pipe be overtaken by the preceding `PostToolUse→running`
— the stale spinner stuck until the next event"), and `CONTEXT.md` → *Status contract* puts
the guarantee on the producer: "the pipe delivers in order and no producer stamps a
sequence, so there is nothing to reorder." The native branch was the one path that broke it.

The change is to send every status synchronously:

```bash
if command -v zj-radar >/dev/null 2>&1; then
    printf '%s' "$input" \
        | zj-radar notify claude --status "$status" >/dev/null 2>&1 \
        || true
    exit 0
fi
```

## Why the old mitigations don't cover it

The dispatch-split comment called the backgrounded `running` self-healing. Neither half
holds on this path:

- **"The next event overwrites it"** — `done` is the last hook of a turn. There may be no
  next event, so a stale `running` can sit indefinitely.
- **"The stale-Running grace clock catches a straggler"** — that clock is armed by the pane
  returning to a shell prompt. Claude Code stays the pane's foreground process while idle at
  its input prompt, so the return-to-shell edge never fires and the clock never starts.

Those claims (and the stdin-read rationale that justified itself by the backgrounding) are
updated in place.

## The trade

`running` is the hot path — it rides `UserPromptSubmit` and `Pre`/`PostToolUse` — so it now
blocks the hook for the duration of the send. That worst case is already bounded inside the
CLI: `crates/cli/src/notify.rs` caps a blocked `zellij pipe` via `pipe_send_timeout()`, so
removing the wrapper-level background process does not reintroduce an unbounded hang. On a
healthy local Zellij server the send is milliseconds. Bounded latency on the hot path is the
right price for a `done` edge that cannot be clobbered.

No sequence numbers, queue, locks, or wire-protocol change — the ordering guarantee only
needs the producer not to reorder itself.

## Test

`plugins/zj-radar-claude/tests/helper.bash` strips every real `zj-radar` off `PATH`, so the
existing `notify.bats` cases only ever exercise the bash fallback — the native branch was
untested. The new case installs a fake native CLI into `$FAKEBIN` that records its
`--status` **after** a ~1s delay on `running`, so the log reflects *arrival* order rather
than call order, then drives the real wrapper sequentially and asserts the recorded order.

It asserts order, not merely that both events occurred, and two guards keep it from passing
vacuously: the dispatch must resolve the fake (`command -v zj-radar` == `$FAKEBIN/zj-radar`),
and the fake `zellij` recorder must stay empty — proving the native branch ran rather than a
silent fall-through to the bash path.

Verified red before the fix, green after:

```text
# before
expected:          actual:
running            done
done               running
```

## Checks

| Check | Result |
|---|---|
| `bats -f "stuck-spinner guard" plugins/zj-radar-claude/tests/notify.bats` | fails on unmodified `notify.sh`, passes after |
| `bats plugins/zj-radar-claude/tests` | 46/46 |
| `shellcheck plugins/zj-radar-claude/scripts/notify.sh` | clean |
| `just ci` | green (exit 0) |
| `just test-e2e` | 12/13 |

The one E2E failure (`rail_paints_every_column_of_its_pane`) is environmental and
pre-existing: it fails identically on an untouched `418dfe8`, and the harness prints
`WARNING: harness targets zellij 0.44.x but found zellij 0.45.0`. `notify_sh_end_to_end_updates_sidebar`
— the E2E case that actually drives this script — passes.

Not related to #13; that one is about classifying long-lived interactive commands. This is a
separate producer-side ordering bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
