### PR TITLE
Hygiene pass: delete dead layout knobs, dedupe file-io idiom, fix stale comments

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -280,7 +280,7 @@ tab's instance clears in lockstep.
 Both modalities emit a `source` string that must be a subset of `Kind`
 (`Kind::from_source`). Both halves are guarded: the agent half by
 `source_round_trips_through_kind` (in `crates/cli/src/agents`), the command half by
-`command_source_round_trips_through_kind` (in `crates/core/src/command.rs`) — each pins that its
+`classify_source_round_trips_through_kind` (in `crates/core/src/command.rs`) — each pins that its
 classifier's `source` token round-trips back to the same `Kind`, never the
 `Other` sentinel.
 

--- a/crates/cli/src/setup/mod.rs
+++ b/crates/cli/src/setup/mod.rs
@@ -301,7 +301,7 @@ pub(crate) fn confirm_and_write(
         crate::exit::fail_report(label, e);
         return false;
     }
-    if let Err(e) = write_atomic(path, new) {
+    if let Err(e) = backup_then_write(path, new) {
         crate::exit::fail_report(label, format!("write failed — {e}"));
         return false;
     }
@@ -313,7 +313,7 @@ pub(crate) fn confirm_and_write(
 /// user's own files; `run` writes its owned dir without one. A failed backup
 /// aborts the write: the success epilogues advertise the `.bak` as the restore
 /// point, so the user's file must never be replaced without it existing.
-pub(crate) fn write_atomic(path: &std::path::Path, contents: &str) -> std::io::Result<()> {
+pub(crate) fn backup_then_write(path: &std::path::Path, contents: &str) -> std::io::Result<()> {
     if path.exists() {
         std::fs::copy(path, path_with_suffix(path, ".zj-radar.bak")).map_err(|e| {
             std::io::Error::new(
@@ -355,7 +355,7 @@ mod tests {
     }
 
     #[test]
-    fn write_atomic_aborts_when_backup_cannot_be_written() {
+    fn backup_then_write_aborts_when_backup_cannot_be_written() {
         // The success epilogues advertise the .bak as the restore point, so a
         // failed backup must abort the write, not overwrite-and-lie. Force the
         // copy to fail by occupying the .bak path with a directory.
@@ -364,7 +364,7 @@ mod tests {
         std::fs::write(&target, "original").unwrap();
         std::fs::create_dir(path_with_suffix(&target, ".zj-radar.bak")).unwrap();
 
-        let err = write_atomic(&target, "replacement").unwrap_err();
+        let err = backup_then_write(&target, "replacement").unwrap_err();
         assert!(err.to_string().contains("backup copy failed"), "err: {err}");
         assert_eq!(
             std::fs::read_to_string(&target).unwrap(),

--- a/crates/cli/src/setup/zellij.rs
+++ b/crates/cli/src/setup/zellij.rs
@@ -498,7 +498,7 @@ fn run_preseed(wasm_dest: &Path, granted: Option<bool>, yes: bool, dry_run: bool
             return false;
         }
     }
-    if let Err(e) = super::write_atomic(&perms_path, &merged) {
+    if let Err(e) = super::backup_then_write(&perms_path, &merged) {
         eprintln!("zellij: not pre-authorizing permissions — write failed ({e})");
         return false;
     }
@@ -643,7 +643,7 @@ fn run_layout_inject(layout_path: &Path, inject_flag: bool, yes: bool, dry_run: 
 }
 
 /// Write the full known-good layout (byte-pinned to `run_assets/radar.kdl`)
-/// to a path that has no layout file yet. The file is new, so `write_atomic`'s
+/// to a path that has no layout file yet. The file is new, so `backup_then_write`'s
 /// backup step is naturally skipped and there is nothing to corrupt.
 fn create_full_layout(layout_path: &Path, dry_run: bool) {
     let layout = crate::layout::full_layout();
@@ -654,7 +654,7 @@ fn create_full_layout(layout_path: &Path, dry_run: bool) {
         );
         return;
     }
-    match write_atomic(layout_path, &layout) {
+    match backup_then_write(layout_path, &layout) {
         Ok(()) => println!("zellij: created {} with the rail layout", layout_path.display()),
         Err(e) => crate::exit::fail_report("zellij", format!("layout create failed — {e}")),
     }
@@ -689,7 +689,7 @@ fn do_inject(layout_path: &Path, text: &str, facts: &crate::layout::LayoutFacts,
                 return;
             }
             // Back up then atomically write (shared setup helper).
-            match write_atomic(layout_path, &new_text) {
+            match backup_then_write(layout_path, &new_text) {
                 Ok(()) => {
                     println!(
                         "zellij: rail injected into {} (backup: {}.zj-radar.bak)",
@@ -804,7 +804,7 @@ fn run_layout_uninstall(layout_path: &Path, dry_run: bool) {
                 );
                 return;
             }
-            match write_atomic(layout_path, &new_text) {
+            match backup_then_write(layout_path, &new_text) {
                 Ok(()) => println!(
                     "zellij: rail removed from {} (backup: {}.zj-radar.bak)",
                     layout_path.display(),

--- a/crates/core/src/command/tests.rs
+++ b/crates/core/src/command/tests.rs
@@ -323,7 +323,7 @@
     }
 
     #[test]
-    fn command_source_round_trips_through_kind() {
+    fn classify_source_round_trips_through_kind() {
         // Twin of the agent-side `source_round_trips_through_kind` (see
         // CONTEXT.md "Information source"). The command path stores
         // `classify(..).1.as_source()` and the roll-up reads it back via
@@ -346,7 +346,7 @@
     }
 
     #[test]
-    fn resolved_command_source_round_trips_through_kind() {
+    fn resolved_source_round_trips_through_kind() {
         // End-to-end twin: drive a command through the store and confirm the
         // *persisted* observation `source` (not just the classifier output)
         // round-trips to the kind the classifier picked. Guards the wiring in

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -332,7 +332,7 @@ impl ZellijPlugin for State {
             // Replaces `SessionUpdate`: stock zj-radar never calls the
             // blocking `get_session_list()` host fn that's the ONLY thing
             // that repopulates `SessionUpdate`'s peer list in zellij 0.44.3
-            // (task-8-report.md's root-cause dive) — only Zellij's own
+            // (`docs/design.md`, "Why not SessionUpdate") — only Zellij's own
             // session-manager plugin does, so a user without it open would
             // see an empty cross-session badge forever. `ModeUpdate` fires
             // automatically right after this plugin loads (Zellij's
@@ -343,8 +343,8 @@ impl ZellijPlugin for State {
             // the first place; liveness itself now comes from the presence
             // files' own mtimes, turned into a per-entry stale/fresh state
             // (`sessions::STALE_AFTER_SECS`) rather than a Zellij-reported
-            // peer list — and, per task-14, a peer past that age dims
-            // rather than vanishing.
+            // peer list — and, per the never-vanish roster, a peer past
+            // that age dims rather than vanishing.
             EventType::ModeUpdate,
         ]);
         // Seed from the shared snapshot so a tab opened after agents were already
@@ -1052,13 +1052,13 @@ mod tests {
 
     #[test]
     fn click_mapping_accounts_for_gaps_comfortable() {
-        // Comfortable density, large height → spacing.gap = 1, pad_y = 0.
+        // Comfortable density, large height → spacing.gap = 1.
         // 2 idle tabs, header=2 lines.
         // Layout: header(2) | tab0 content(1) | tab0 gap(1) | tab1 content(1) | tab1 gap(1)
         // Lines:   0,1      | 2               | 3           | 4               | 5
         //
         // The gap is EXTERNAL separation, so the gap line (3) maps to None — only
-        // the owned pad_y + content rows belong to a tab. Tab 1 starts at line 4.
+        // the owned content rows belong to a tab. Tab 1 starts at line 4.
         let mut state = make_state_with_tabs(&[(0, "a", false), (1, "b", false)]);
         state.runtime.last_render_height = 100; // large → no overflow
         state.runtime.config = config::Config {
@@ -1112,7 +1112,7 @@ mod tests {
     fn click_mapping_cards_one_line_header() {
         // Cards density: the carded hero is a single " RADAR …" title line (no
         // rule), so the header occupies ONE line, not two. Cards now carries
-        // gap = 1 (trailing rail_bg row after each card) and pad_y = 0.
+        // gap = 1 (trailing rail_bg row after each card).
         // The gap rows map to None (they are external separation, not owned by
         // a tab). The click mapping must stay in lockstep with render():
         //   line 0  → header (1 line, no rule) → None
@@ -1141,7 +1141,7 @@ mod tests {
     }
 
     #[test]
-    fn click_mapping_cards_pad_y_and_post_content_row() {
+    fn click_mapping_cards_multi_line_card_and_post_content_row() {
         // Exercises the gap semantics explicitly with a multi-line card so the
         // boundary between one card's last content row and the gap row is clear.
         //   header(1) | tab0 content×2 | tab0 gap(1) | tab1 content(1) | tab1 gap(1)

--- a/crates/plugin/src/radar_state/tests.rs
+++ b/crates/plugin/src/radar_state/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::command::{DEBOUNCE_TICKS, DONE_TTL_TICKS, EpochSecs, Tick};
 use crate::kind::Kind;
 use crate::payload::StatusPayload;
-use crate::rollup::Outcome;
+use crate::rollup::ExitOutcome;
 use crate::test_fixtures::{self, pane, payload_in_repo};
 
 /// Unlike the shared `test_fixtures::tab` (id derived from position), this
@@ -758,7 +758,7 @@ fn finished_command_pane_carries_outcome_through_rows() {
     assert_eq!(row.display.status, Status::Error);
     let detail = row.display.detail.as_ref().unwrap();
     assert_eq!(detail.msg, "cargo build", "msg stays pure (tag is structural)");
-    assert_eq!(detail.outcome, Some(Outcome::Failed(Some(2))));
+    assert_eq!(detail.outcome, Some(ExitOutcome::Failed(Some(2))));
 }
 
 #[test]

--- a/crates/plugin/src/render.rs
+++ b/crates/plugin/src/render.rs
@@ -18,7 +18,7 @@ use crate::kind::Kind;
 // One minute band for every age display (its `1h+` freeze is load-bearing
 // for cadence disarm) — owned by the ledger, shared by the wait/run tags.
 use crate::ledger::minute_tag;
-use crate::rollup::{LedgerLine, Outcome, PaneDisplay, TabDisplay, TabRow};
+use crate::rollup::{ExitOutcome, LedgerLine, PaneDisplay, TabDisplay, TabRow};
 use crate::sessions::BadgeEntry;
 pub use crate::status::GlyphSet;
 use crate::status::{Role, Status};
@@ -159,23 +159,23 @@ pub struct RenderOpts {
     /// whenever `len() <= 1` (only this session, or no peer presence has
     /// crossed the shared `/cache` root yet), so every caller that never
     /// populates this (every
-    /// pre-existing test, and any host that hasn't wired Task 5/6's session
+    /// pre-existing test, and any host that hasn't wired the session
     /// plumbing) renders byte-identical to before this field existed.
     pub badge: Vec<BadgeEntry>,
 }
 
-/// Presentation for the roll-up's `Outcome` tag. The enum itself lives in
+/// Presentation for the roll-up's `ExitOutcome` tag. The enum itself lives in
 /// `rollup` (pure semantics); these methods encode the glyphs and the
 /// width-driven roomy/tight forms, which are the renderer's concern.
-impl Outcome {
+impl ExitOutcome {
     /// The roomy form. `Ok` is EMPTY — the line-1 status glyph (green ●) is the
     /// one done signal; a tag would double-mark it. Errors carry the info the
     /// line-1 `✗` can't: the exit code.
     fn full(self) -> String {
         match self {
-            Outcome::Ok => String::new(),
-            Outcome::Failed(Some(code)) => format!("exit {}", code),
-            Outcome::Failed(None) => "✗".to_string(),
+            ExitOutcome::Ok => String::new(),
+            ExitOutcome::Failed(Some(code)) => format!("exit {}", code),
+            ExitOutcome::Failed(None) => "✗".to_string(),
         }
     }
 
@@ -184,22 +184,22 @@ impl Outcome {
     /// only failures do. Lets callers ask "is there a tag?" without building
     /// the `full()` string just to test it for emptiness.
     fn renders_tag(self) -> bool {
-        !matches!(self, Outcome::Ok)
+        !matches!(self, ExitOutcome::Ok)
     }
 
     /// The irreducible short form, shown when width is too tight for `full`.
     fn minimal(self) -> &'static str {
         match self {
-            Outcome::Ok => "",
-            Outcome::Failed(_) => "✗",
+            ExitOutcome::Ok => "",
+            ExitOutcome::Failed(_) => "✗",
         }
     }
 
     /// The hue the tag reads in: success (green) / error (red).
     fn role(self) -> Role {
         match self {
-            Outcome::Ok => Role::Success,
-            Outcome::Failed(_) => Role::Error,
+            ExitOutcome::Ok => Role::Success,
+            ExitOutcome::Failed(_) => Role::Error,
         }
     }
 }
@@ -650,7 +650,7 @@ fn tab_header_line(row: &TabRow, opts: &RenderOpts, tab_target: &RailTarget) -> 
     let hotspot = row.display.panes.iter()
         .any(PaneDisplay::has_unacknowledged_status_pending)
         .then(|| HotspotAction::Acknowledge { target: tab_target.clone() });
-    let hotspot = HotspotSlot::new(opts.width, 6, hotspot);
+    let hotspot = HotspotSlot::new(opts.width, TAB_HEADER_HOTSPOT_MIN, hotspot);
     let width = hotspot.content_width();
     let now_tick = opts.now_tick;
     let st = row.display.status;
@@ -667,11 +667,6 @@ fn tab_header_line(row: &TabRow, opts: &RenderOpts, tab_target: &RailTarget) -> 
     // col 0: spine column — ALWAYS reserved so every row's glyph/number/name
     // start at fixed columns; `▌` when active, plain space otherwise.
     let bar = spine_seg(row.active, st);
-
-    // Internal left padding: `pad_x` cells after the col-0 spine/space, before
-    // the glyph. At extreme-narrow widths clamp pad_x then num so the prefix
-    // never exceeds `width`.
-    let pad_x = card_spacing(opts.density).pad_x;
 
     // col 1: status glyph (working spins; eases to a slow blink for
     // long-runners — see `spin_glyph`).
@@ -698,20 +693,18 @@ fn tab_header_line(row: &TabRow, opts: &RenderOpts, tab_target: &RailTarget) -> 
     // cue — the accent spine + brighter card — so the two stay independent.)
     let label_bold = st != Status::Idle;
 
-    // left visible prefix is "X[pad]<glyph> <num> " — bar/glyph are 1 cell each;
-    // `pad_len` is the Cards-only internal left pad (1 col, else 0).
-    // Bare minimum: bar(1, always reserved) + glyph(1) + sp(1) + num. Clamp pad first, then num.
+    // left visible prefix is "X<glyph> <num> " — bar/glyph are 1 cell each.
+    // Bare minimum: bar(1, always reserved) + glyph(1) + sp(1) + num. At
+    // extreme-narrow widths clamp num so the prefix never exceeds `width`.
     let num_full = row.number.to_string();
     let bar_width = 1;
     let bare_min = bar_width + 1 + 1; // bar + glyph + sp (before num)
-    let pad_len = pad_x.min(width.saturating_sub(bare_min + 1)); // keep 1 col for at least '1'
-    let num_budget = width.saturating_sub(bare_min + pad_len);
+    let num_budget = width.saturating_sub(bare_min);
     let num = truncate(&num_full, num_budget);
     let num_w = UnicodeWidthStr::width(num.as_str());
     // Trailing sp after num only if it fits.
-    let has_trailing_sp = bare_min + pad_len + num_w < width;
-    let pad = " ".repeat(pad_len);
-    let prefix_len = bare_min + pad_len + num_w + if has_trailing_sp { 1 } else { 0 };
+    let has_trailing_sp = bare_min + num_w < width;
+    let prefix_len = bare_min + num_w + if has_trailing_sp { 1 } else { 0 };
     // Trailing bell marker (⚑ + space, 2 cols). The prefix
     // clamp only guarantees the prefix itself fits `width`; suppress the bell at
     // extreme-narrow widths where it wouldn't fit beside the prefix, or it would
@@ -743,12 +736,22 @@ fn tab_header_line(row: &TabRow, opts: &RenderOpts, tab_target: &RailTarget) -> 
         text: label_text.into(),
     };
     let line = Line::new(
-        format!("{}{}{}{}{}\n", bar, pad, label, " ".repeat(gap), bell),
+        format!("{}{}{}{}\n", bar, label, " ".repeat(gap), bell),
         Some(tab_target.clone()),
         LineBg::Card,
     );
     hotspot.finish(line, &hue(Role::Attention))
 }
+
+// Hotspot admission minimums, one per hotspot-bearing line class: each is the
+// line's minimal meaningful visible prefix plus the 2-col separator+glyph
+// reservation `HotspotSlot::new` makes once admitted.
+/// Tab header line: bar(1) + glyph(1) + sp(1) + 1-digit num(1) = 4, + 2 slot.
+const TAB_HEADER_HOTSPOT_MIN: usize = 6;
+/// Pane identity line: tree prefix(3) + glyph(1) + sp(1) + mark(1) = 6, + 2 slot.
+const PANE_LINE_HOTSPOT_MIN: usize = 8;
+/// Session badge line: here-marker(1) + sp(1) = 2, + 2 slot.
+const BADGE_LINE_HOTSPOT_MIN: usize = 4;
 
 /// Owns the complete hotspot suffix contract: admission at a site's minimum
 /// width, reservation of separator+glyph, and release-build enforcement when
@@ -849,7 +852,7 @@ fn render_row(row: &TabRow, opts: &RenderOpts) -> Vec<Line> {
         let pane_target = RailTarget { tab_position: tab_target.tab_position, pane_id: Some(pane.pane_id()), session: None };
         let hotspot = pane.has_unacknowledged_status_pending()
             .then(|| HotspotAction::Acknowledge { target: pane_target.clone() });
-        let hotspot = HotspotSlot::new(opts.width, 8, hotspot);
+        let hotspot = HotspotSlot::new(opts.width, PANE_LINE_HOTSPOT_MIN, hotspot);
         let content_width = hotspot.content_width();
         let text = emit_pane_line(pane, &identity, detail.is_some(), opts, content_width, row.active, st, &dim_strong, &idle_color, branch);
         // `pane_target` is cloned here because a Pending/Error pane also emits
@@ -921,7 +924,7 @@ fn render_row(row: &TabRow, opts: &RenderOpts) -> Vec<Line> {
     // Unlike the multi-pane roster (where every tracked pane earns a line),
     // the single pane's line is emitted only when it says something: a
     // non-empty identity OR an outcome tag that actually renders (`Ok`'s tag
-    // is empty by design — see `Outcome::renders_tag` — so an empty-msg Ok
+    // is empty by design — see `ExitOutcome::renders_tag` — so an empty-msg Ok
     // completion earns no line at all). Idle stays header-only. The gate
     // itself lives inside `pane_lines` (`skip_silent`), judged on the very
     // identity it emits.
@@ -940,7 +943,7 @@ fn render_row(row: &TabRow, opts: &RenderOpts) -> Vec<Line> {
 /// (`exit 1`) to the irreducible glyph (`✗`). The returned string fits within
 /// `avail` columns and carries its own color escapes (each segment
 /// RESET-terminated).
-fn compose_activity(cmd: &str, outcome: Option<Outcome>, avail: usize, cmd_color: &str) -> String {
+fn compose_activity(cmd: &str, outcome: Option<ExitOutcome>, avail: usize, cmd_color: &str) -> String {
     let Some(oc) = outcome else {
         return Seg::new(cmd_color, truncate(cmd, avail)).to_string();
     };
@@ -951,7 +954,7 @@ fn compose_activity(cmd: &str, outcome: Option<Outcome>, avail: usize, cmd_color
     }
     let role = oc.role().ansi();
     let cmd = cmd.trim();
-    // Outcome with no command (e.g. an exit with no recorded command string):
+    // ExitOutcome with no command (e.g. an exit with no recorded command string):
     // show the largest form that fits.
     if cmd.is_empty() {
         let full = oc.full();
@@ -1284,17 +1287,17 @@ fn render_header(rows: &[TabRow], opts: &RenderOpts, overflow: bool, has_content
     // independent of the later title-squeeze clamp.
     let avail = width.saturating_sub(title_w);
     let combined_w = |b: &str| UnicodeWidthStr::width(primary.as_str()) + 1 + UnicodeWidthStr::width(b);
-    // (text, color, bold) run(s) that make up the right slot, in emission order.
-    let right_segs: Vec<(String, &str, bool)> = match &badge {
+    // The `Seg` run(s) that make up the right slot, in emission order.
+    let right_segs: Vec<Seg> = match &badge {
         Some(b) if combined_w(b) <= avail => {
-            vec![(primary.clone(), primary_color, false), (format!(" {b}"), Role::Attention.ansi(), true)]
+            vec![Seg::new(primary_color, primary.clone()), Seg::bold(Role::Attention.ansi(), format!(" {b}"))]
         }
         // Combined doesn't fit: the overflow marker always wins, but a plain
         // census loses to the badge — drop it and keep the badge alone.
-        Some(b) if !overflow => vec![(b.clone(), Role::Attention.ansi(), true)],
-        _ => vec![(primary.clone(), primary_color, false)],
+        Some(b) if !overflow => vec![Seg::bold(Role::Attention.ansi(), b.clone())],
+        _ => vec![Seg::new(primary_color, primary.clone())],
     };
-    let plain_right: String = right_segs.iter().map(|(t, _, _)| t.as_str()).collect();
+    let plain_right: String = right_segs.iter().map(|s| s.text.as_ref()).collect();
     let right_full_w = UnicodeWidthStr::width(plain_right.as_str());
     let right_w = right_full_w.min(width);
     // At extreme-narrow widths the gap can be 0 (no `.max(1)`) so the
@@ -1311,7 +1314,7 @@ fn render_header(rows: &[TabRow], opts: &RenderOpts, overflow: bool, has_content
     } else {
         right_segs
             .into_iter()
-            .map(|(t, c, b)| if b { Seg::bold(c, t).to_string() } else { Seg::new(c, t).to_string() })
+            .map(|s| s.to_string())
             .collect::<String>()
     };
     let mut title_line = String::new();
@@ -1367,7 +1370,7 @@ fn header_rule(width: usize, now_tick: u64, working: bool, accent: &str) -> Stri
 /// every existing single-session snapshot/test stays byte-identical (the
 /// badge is additive, never a subtraction from the render surface). A lone
 /// fresh own-entry plus only STALE peers still clears this threshold and
-/// renders (task-14: the roster's whole point is remembering) — the count
+/// renders (never-vanish roster: its whole point is remembering) — the count
 /// is over `entries`, not over fresh entries.
 ///
 /// The current session's own line carries NO click target at all — you
@@ -1408,7 +1411,7 @@ fn render_session_badge(entries: &[BadgeEntry], opts: &RenderOpts) -> Vec<Line> 
     }
     let width = opts.width;
     let idle = tc_fg(opts.theme.idle_text);
-    // A stale entry (task-14: dimmed, never dropped from the badge) recedes
+    // A stale entry (dimmed, never dropped from the badge) recedes
     // one step further than the ordinary muted `idle_text` every other line
     // uses — blended halfway toward the panel background, the same "recede
     // toward bg" idiom `DerivedColors::from_bg_fg` already uses for its own
@@ -1424,7 +1427,7 @@ fn render_session_badge(entries: &[BadgeEntry], opts: &RenderOpts) -> Vec<Line> 
         .map(|entry| {
             let hotspot = (entry.stale && !entry.is_current)
                 .then(|| HotspotAction::DismissPresence { name: entry.name.clone() });
-            let hotspot = HotspotSlot::new(width, 4, hotspot);
+            let hotspot = HotspotSlot::new(width, BADGE_LINE_HOTSPOT_MIN, hotspot);
             let content_width = hotspot.content_width();
             let mut label = entry.name.clone();
             if entry.running > 0 {
@@ -1554,7 +1557,6 @@ fn render_body(rows: &[TabRow], ledger: &[LedgerLine], opts: &RenderOpts) -> Vec
     // Body: one card block per kept row.
     for &(i, budget) in &plan {
         let row = &rows[i];
-        let row_target = target_for_row(row);
 
         // Resolve a raw line's surface through the one `LineBg::escape` map by
         // consuming the complete `Line`. Metadata such as targets and hotspots
@@ -1569,14 +1571,6 @@ fn render_body(rows: &[TabRow], ledger: &[LedgerLine], opts: &RenderOpts) -> Vec
             line.bg = LineBg::None;
             line
         };
-
-        // pad_y internal top padding — belongs to this card's click span.
-        // Cloned each iteration (`RailTarget` isn't `Copy`; `session` is a
-        // `String`) — `pad_y` can be >1, so a plain move would only survive
-        // the first pass.
-        for _ in 0..spacing.pad_y {
-            flat.push(finalize(Line::new("\n".to_string(), Some(row_target.clone()), LineBg::Card)));
-        }
 
         // content (truncated to the planned budget == today's compression).
         for line in blocks[i].iter().take(budget) {

--- a/crates/plugin/src/render/layout.rs
+++ b/crates/plugin/src/render/layout.rs
@@ -6,43 +6,24 @@
 use crate::config::Density;
 use crate::status::Status;
 
-/// The ONE source of truth for inter- and intra-card spacing, by density.
+/// The ONE source of truth for inter-card spacing, by density.
 ///
-/// Three knobs, all measured in terminal cells:
-///   - `pad_x`: columns of internal LEFT padding inserted before a card's
-///     content (so content isn't flush to the band edge).
-///   - `pad_y`: rows of internal TOP padding — blank rows painted with THIS
-///     card's own surface bg (internal breathing room). Currently 0 for all
-///     densities; retained as a knob for future tuning.
+/// One knob, measured in terminal rows:
 ///   - `gap`: rows of EXTERNAL separation after a card — blank rows painted
 ///     `rail_bg` in Cards (panel shows through), plain blank in Comfortable.
 ///     Sheds first under overflow.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct CardSpacing {
-    pub(crate) pad_x: usize,
-    pub(crate) pad_y: usize,
     pub(crate) gap: usize,
 }
 
-/// Map a density to its spacing knobs. This is the single place to tune the
-/// sidebar's vertical/horizontal rhythm.
+/// Map a density to its spacing knob. This is the single place to tune the
+/// sidebar's vertical rhythm.
 pub(crate) fn card_spacing(d: Density) -> CardSpacing {
     match d {
-        Density::Compact => CardSpacing {
-            pad_x: 0,
-            pad_y: 0,
-            gap: 0,
-        },
-        Density::Comfortable => CardSpacing {
-            pad_x: 0,
-            pad_y: 0,
-            gap: 1,
-        },
-        Density::Cards => CardSpacing {
-            pad_x: 0,
-            pad_y: 0,
-            gap: 1,
-        },
+        Density::Compact => CardSpacing { gap: 0 },
+        Density::Comfortable => CardSpacing { gap: 1 },
+        Density::Cards => CardSpacing { gap: 1 },
     }
 }
 
@@ -54,11 +35,11 @@ pub(crate) struct RowMeta {
 }
 
 /// Single source of truth for a card's full vertical footprint (top→bottom:
-/// `pad_y` internal-pad rows + the card's uncompressed content rows + `gap`
-/// external-separation rows). `render_rail()` budgets in terms of this so the
-/// emitted ANSI lines and line targets stay exact.
+/// the card's uncompressed content rows + `gap` external-separation rows).
+/// `render_rail()` budgets in terms of this so the emitted ANSI lines and
+/// line targets stay exact.
 pub(crate) fn card_block_lines(full_lines: usize, spacing: CardSpacing) -> usize {
-    spacing.pad_y + full_lines + spacing.gap
+    full_lines + spacing.gap
 }
 
 /// Returns whether a row's status is "calm" (can be compressed first).
@@ -195,13 +176,13 @@ pub(crate) fn plan_overflow(rows: &[RowMeta], body_budget: usize) -> (Vec<(usize
 ///   - the per-row planned content-line counts (same as `plan_overflow`),
 ///   - the number of idle rows folded into the strip (`strip_folded`), and
 ///   - the EFFECTIVE `CardSpacing` actually applied (luxury rows may be shed
-///     under overflow): `pad_x` is unchanged; `pad_y` and `gap` are each 1 or 0.
+///     under overflow): `gap` is 1 or 0.
 ///
 /// Luxury-shedding rule (mirrors "gaps are dropped first"): the per-card block
-/// is `pad_y + content + gap`. Under overflow we shed the cheapest separation
-/// first — drop `gap`, then drop `pad_y` — before letting `plan_overflow`
-/// compress the content itself. We pick the richest spacing whose total block
-/// footprint (plus the strip line) still fits the budget.
+/// is `content + gap`. Under overflow we shed the separation — drop `gap` —
+/// before letting `plan_overflow` compress the content itself. We pick the
+/// richest spacing whose total block footprint (plus the strip line) still
+/// fits the budget.
 pub(crate) fn plan_layout(
     rows: &[RowMeta],
     body_budget: usize,
@@ -209,7 +190,7 @@ pub(crate) fn plan_layout(
 ) -> (Vec<(usize, usize)>, usize, CardSpacing) {
     let base = card_spacing(density);
 
-    // Fast path: if every row's FULL block (pad_y + content + gap) fits, render
+    // Fast path: if every row's FULL block (content + gap) fits, render
     // everything at full fidelity with full spacing. `card_block_lines` is the
     // single footprint source shared with the budgeting below.
     let full_footprint: usize = rows
@@ -225,23 +206,14 @@ pub(crate) fn plan_layout(
         return (plan, 0, base);
     }
 
-    // Candidate spacings, richest → leanest: full, then drop gap, then drop pad_y.
-    // pad_x never sheds (it's a fixed horizontal inset, not a vertical row).
-    let candidates = [
-        base,
-        CardSpacing { gap: 0, ..base },
-        CardSpacing {
-            gap: 0,
-            pad_y: 0,
-            ..base
-        },
-    ];
+    // Candidate spacings, richest → leanest: full, then drop gap.
+    let candidates = [base, CardSpacing { gap: 0 }];
 
     // Budget the content once against the full body budget — the plan does not
-    // depend on the spacing. Then shed luxury (gap first, then pad_y) until the
-    // richest spacing whose luxury rows fit *on top of* that content: content is
-    // never re-compressed to make room for separation — gaps/pads are dropped
-    // first. If even the leanest spacing (no gap, no pad_y) overflows, apply it
+    // depend on the spacing. Then shed luxury (the gap) until the richest
+    // spacing whose luxury rows fit *on top of* that content: content is
+    // never re-compressed to make room for separation — gaps are dropped
+    // first. If even the leanest spacing (no gap) overflows, apply it
     // anyway over the (already maximally-compressed) content.
     let (plan, strip_folded) = plan_overflow(rows, body_budget);
     let content_total: usize = plan.iter().map(|(_, l)| l).sum();
@@ -249,11 +221,7 @@ pub(crate) fn plan_layout(
     let strip_line = if strip_folded > 0 { 1 } else { 0 };
     let spacing = candidates
         .into_iter()
-        .find(|s| content_total + kept * (s.pad_y + s.gap) + strip_line <= body_budget)
-        .unwrap_or(CardSpacing {
-            gap: 0,
-            pad_y: 0,
-            ..base
-        });
+        .find(|s| content_total + kept * s.gap + strip_line <= body_budget)
+        .unwrap_or(CardSpacing { gap: 0 });
     (plan, strip_folded, spacing)
 }

--- a/crates/plugin/src/render/tests.rs
+++ b/crates/plugin/src/render/tests.rs
@@ -425,7 +425,7 @@ fn active_and_waiting_row_bar_is_attention_not_accent() {
 
 #[test]
 fn empty_msg_ok_completion_emits_no_bare_mark_line() {
-    // `Outcome::Ok` renders an empty tag (`Outcome::full` — the line-1 status
+    // `ExitOutcome::Ok` renders an empty tag (`ExitOutcome::full` — the line-1 status
     // glyph is the one done signal), so with an empty msg there is nothing for
     // line 2 to say: the row must stay a single line, not emit a bare
     // "  ‹mark› " prefix with no activity. A Failed outcome DOES render a tag,
@@ -435,7 +435,7 @@ fn empty_msg_ok_completion_emits_no_bare_mark_line() {
         tab(1, "n", display(status, 1, 1, Some(d)))
     };
 
-    let ok_lines = render_row(&row(Status::Done, Some(Outcome::Ok)), &ro(30, 0));
+    let ok_lines = render_row(&row(Status::Done, Some(ExitOutcome::Ok)), &ro(30, 0));
     assert_eq!(
         ok_lines.len(),
         1,
@@ -443,7 +443,7 @@ fn empty_msg_ok_completion_emits_no_bare_mark_line() {
         ok_lines.iter().map(|l| &l.text).collect::<Vec<_>>()
     );
 
-    let failed_lines = render_row(&row(Status::Error, Some(Outcome::Failed(Some(1)))), &ro(30, 0));
+    let failed_lines = render_row(&row(Status::Error, Some(ExitOutcome::Failed(Some(1)))), &ro(30, 0));
     assert_eq!(failed_lines.len(), 2, "a Failed outcome still earns its line 2");
     assert!(failed_lines[1].text.contains("exit 1"), "line 2 carries the tag: {:?}", failed_lines[1].text);
 }
@@ -972,7 +972,7 @@ fn pe(id: u32, kind: Kind, status: Status, msg: &str) -> PaneDisplay {
 }
 
 /// Build a PaneDisplay carrying an end-result outcome, for tag tests.
-fn pe_outcome(id: u32, kind: Kind, status: Status, msg: &str, outcome: Outcome) -> PaneDisplay {
+fn pe_outcome(id: u32, kind: Kind, status: Status, msg: &str, outcome: ExitOutcome) -> PaneDisplay {
     PaneDisplay::Tracked {
         pane_id: id,
         kind,
@@ -1031,7 +1031,7 @@ fn child_prefix_is_tree_connector_with_optional_spine() {
 fn compose_activity_reserves_outcome_against_truncation() {
     let cmd_color = "\x1b[2m"; // stand-in; we assert on visible text + role
     // Wide: command and full tag both intact.
-    let wide = compose_activity("cargo build", Some(Outcome::Failed(Some(1))), 30, cmd_color);
+    let wide = compose_activity("cargo build", Some(ExitOutcome::Failed(Some(1))), 30, cmd_color);
     assert!(wide.contains("cargo build"), "command shown: {:?}", wide);
     assert!(wide.contains("exit 1"), "full tag shown: {:?}", wide);
     assert!(wide.contains(Role::Error.ansi()), "tag is red: {:?}", wide);
@@ -1039,7 +1039,7 @@ fn compose_activity_reserves_outcome_against_truncation() {
     // Narrow: command is squeezed but the outcome survives in full.
     let narrow = compose_activity(
         "cargo build integration suite",
-        Some(Outcome::Failed(Some(1))),
+        Some(ExitOutcome::Failed(Some(1))),
         14,
         cmd_color,
     );
@@ -1051,7 +1051,7 @@ fn compose_activity_reserves_outcome_against_truncation() {
     );
 
     // Extreme: only the irreducible glyph fits; command is dropped entirely.
-    let tiny = compose_activity("cargo build", Some(Outcome::Failed(Some(1))), 2, cmd_color);
+    let tiny = compose_activity("cargo build", Some(ExitOutcome::Failed(Some(1))), 2, cmd_color);
     assert!(tiny.contains('✗'), "minimal glyph survives: {:?}", tiny);
     assert!(!tiny.contains("cargo"), "command dropped at extreme width: {:?}", tiny);
 
@@ -1059,7 +1059,7 @@ fn compose_activity_reserves_outcome_against_truncation() {
     for avail in 1..=30 {
         let s = compose_activity(
             "cargo build integration",
-            Some(Outcome::Failed(Some(137))),
+            Some(ExitOutcome::Failed(Some(137))),
             avail,
             cmd_color,
         );
@@ -1075,7 +1075,7 @@ fn compose_activity_reserves_outcome_against_truncation() {
 
 #[test]
 fn done_command_line_has_no_trailing_tag_or_stray_sgr() {
-    let s = compose_activity("cargo build", Some(Outcome::Ok), 30, "\x1b[90m");
+    let s = compose_activity("cargo build", Some(ExitOutcome::Ok), 30, "\x1b[90m");
     let plain = strip_sgr(&s);
     assert_eq!(plain, "cargo build", "no ✓ and no trailing space: {plain:?}");
     assert!(!s.contains("\x1b[32m\x1b[0m"), "no empty green SGR pair: {s:?}");
@@ -1083,9 +1083,9 @@ fn done_command_line_has_no_trailing_tag_or_stray_sgr() {
 
 #[test]
 fn error_tag_is_exit_n_without_duplicate_cross() {
-    let s = strip_sgr(&compose_activity("cargo build", Some(Outcome::Failed(Some(1))), 30, "\x1b[90m"));
+    let s = strip_sgr(&compose_activity("cargo build", Some(ExitOutcome::Failed(Some(1))), 30, "\x1b[90m"));
     assert_eq!(s, "cargo build exit 1");
-    let unknown = strip_sgr(&compose_activity("make", Some(Outcome::Failed(None)), 30, "\x1b[90m"));
+    let unknown = strip_sgr(&compose_activity("make", Some(ExitOutcome::Failed(None)), 30, "\x1b[90m"));
     assert_eq!(unknown, "make ✗");
 }
 
@@ -1095,7 +1095,7 @@ fn finished_command_line2_shows_role_colored_tag() {
         let d = PrimaryDetail { kind: Kind::Build, outcome, ..pd("r", "", msg, status) };
         tab(1, "web", display(status, 1, 1, Some(d)))
     };
-    let done = render(&[mk(Status::Done, Some(Outcome::Ok), "cargo build")], &ro(30, 0));
+    let done = render(&[mk(Status::Done, Some(ExitOutcome::Ok), "cargo build")], &ro(30, 0));
     let dline = done.lines().find(|l| l.contains("cargo build")).unwrap();
     assert!(
         !dline.contains('✓') && strip_sgr(dline).trim() == "└ ● ⚙ cargo build",
@@ -1104,7 +1104,7 @@ fn finished_command_line2_shows_role_colored_tag() {
     );
 
     let err = render(
-        &[mk(Status::Error, Some(Outcome::Failed(Some(2))), "cargo build")],
+        &[mk(Status::Error, Some(ExitOutcome::Failed(Some(2))), "cargo build")],
         &ro(30, 0),
     );
     let eline = err.lines().find(|l| l.contains("cargo build")).unwrap();
@@ -1119,7 +1119,7 @@ fn finished_command_line2_shows_role_colored_tag() {
 fn multi_pane_finished_command_shows_outcome_tag() {
     let a = display_multi(vec![
         pe(1, Kind::Build, Status::Running, "cargo build"),
-        pe_outcome(2, Kind::Test, Status::Done, "cargo test", Outcome::Ok),
+        pe_outcome(2, Kind::Test, Status::Done, "cargo test", ExitOutcome::Ok),
     ]);
     let row = tab(1, "ci", a);
     let s = render(&[row], &ro(30, 0));
@@ -2019,52 +2019,31 @@ fn no_emitted_line_exceeds_width_cards() {
 
 #[test]
 fn card_spacing_per_density() {
-    // The ONE source of truth for spacing knobs, by density.
+    // The ONE source of truth for the spacing knob, by density.
     use crate::config::Density::*;
-    assert_eq!(
-        card_spacing(Compact),
-        CardSpacing {
-            pad_x: 0,
-            pad_y: 0,
-            gap: 0
-        }
-    );
-    assert_eq!(
-        card_spacing(Comfortable),
-        CardSpacing {
-            pad_x: 0,
-            pad_y: 0,
-            gap: 1
-        }
-    );
-    assert_eq!(
-        card_spacing(Cards),
-        CardSpacing {
-            pad_x: 0,
-            pad_y: 0,
-            gap: 1
-        }
-    );
+    assert_eq!(card_spacing(Compact), CardSpacing { gap: 0 });
+    assert_eq!(card_spacing(Comfortable), CardSpacing { gap: 1 });
+    assert_eq!(card_spacing(Cards), CardSpacing { gap: 1 });
 }
 
 #[test]
-fn card_block_lines_is_pad_y_plus_content_plus_gap() {
-    // The single footprint source: pad_y + full_lines + gap.
+fn card_block_lines_is_content_plus_gap() {
+    // The single footprint source: full_lines + gap.
     let opts = ro(40, 0);
     let idle_row_val = tab(1, "t", display(Status::Idle, 0, 0, None));
     let full_lines = render_row(&idle_row_val, &opts).len();
     assert_eq!(full_lines, 1);
-    // Cards: 0 pad_y + 1 content + 1 gap = 2.
+    // Cards: 1 content + 1 gap = 2.
     assert_eq!(
         card_block_lines(full_lines, card_spacing(crate::config::Density::Cards)),
         2
     );
-    // Comfortable: 0 pad_y + 1 content + 1 gap = 2.
+    // Comfortable: 1 content + 1 gap = 2.
     assert_eq!(
         card_block_lines(full_lines, card_spacing(crate::config::Density::Comfortable)),
         2
     );
-    // Compact: 0 + 1 + 0 = 1.
+    // Compact: 1 content + 0 gap = 1.
     assert_eq!(
         card_block_lines(full_lines, card_spacing(crate::config::Density::Compact)),
         1
@@ -3522,7 +3501,7 @@ fn multi_pane_collapsed_footprint_is_header_plus_expanded_plus_collapse() {
 fn single_running_pane_with_detail_is_two_content_lines() {
     // Single-pane Running tab with a non-empty detail msg → 2 content lines
     // (name row + detail row). Mirrors the row_lines assertion from
-    // lib.rs::click_mapping_cards_pad_y_and_post_content_row.
+    // lib.rs::click_mapping_cards_multi_line_card_and_post_content_row.
     let opts = ro(40, 0);
     let a = display_multi(vec![pe(10, Kind::Claude, Status::Running, "msg")]);
     let row = tab(1, "t", a);
@@ -3972,7 +3951,7 @@ fn badge_encodes_missing_attention_as_a_sentinel_not_tab_zero() {
     );
 }
 
-// -- Pinning: stale badge entries (task-14) ---------------------------------
+// -- Pinning: stale badge entries (never-vanish roster) ----------------------
 // A remembered session must never silently vanish from the badge; it dims
 // to stale instead. The renderer's job is narrow: paint it in a receded
 // color and keep its click target — `Sessions::cycle` (sessions.rs's own
@@ -4041,7 +4020,7 @@ fn stale_entry_undims_once_superseded_by_a_fresh_entry() {
 fn lone_fresh_own_entry_with_only_stale_peers_still_renders() {
     // The single-session zero-line rule counts `entries.len()`, not fresh
     // entries — a stale peer still counts toward the 2+ threshold, since the
-    // roster's whole point is remembering (task-14).
+    // roster's whole point is remembering.
     let entries = vec![
         badge_entry("work", true, 0, 0, None, false),
         stale_badge_entry("alpha", false, 0, 0, None, false, true),

--- a/crates/plugin/src/rollup.rs
+++ b/crates/plugin/src/rollup.rs
@@ -5,7 +5,7 @@
 //! operation named "Tab Roll-Up" in `CONTEXT.md`: a deep, pure module that
 //! turns a tab's panes plus a per-pane observation lookup into the `TabDisplay`
 //! the rail renders. It owns the whole render-input vocabulary — `TabDisplay`,
-//! `PaneDisplay`, `PrimaryDetail`, `ProgressCounts`, `Outcome`, plus the
+//! `PaneDisplay`, `PrimaryDetail`, `ProgressCounts`, `ExitOutcome`, plus the
 //! rail-row types `TabRow`/`LedgerLine` and the topology record
 //! `TerminalPane` — so the arrows run one way: `radar_state` builds these,
 //! `render` consumes them, and neither imports the other.
@@ -37,7 +37,7 @@ pub(crate) struct TerminalPane {
 /// (`full`/`minimal`/`role`) live in `render`, since they encode glyphs and a
 /// width-driven form; the enum here is pure semantics.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Outcome {
+pub enum ExitOutcome {
     /// Exit 0 / returned to the shell with no failure evidence.
     Ok,
     /// Nonzero exit; `Some(code)` when known, `None` for a signal/no-code exit.
@@ -54,7 +54,7 @@ pub struct PrimaryDetail {
     pub status: Status,
     pub kind: Kind,
     /// End-result tag for a finished command pane (None for agents/active).
-    pub outcome: Option<Outcome>,
+    pub outcome: Option<ExitOutcome>,
     /// Wall-clock stamp of the waiting-on-you edge (Pending only) — the
     /// renderer turns it into the `· 12m` wait tag against its own
     /// `now_epoch_s`, so no epoch threads through the roll-up itself.
@@ -71,7 +71,7 @@ pub enum PaneDisplay {
         msg: String,
         task: String,
         since_tick: u64,
-        outcome: Option<Outcome>,
+        outcome: Option<ExitOutcome>,
         /// Waiting-on-you stamp (Pending only) — see `PrimaryDetail`.
         pending_epoch_s: Option<u64>,
         /// See `PrimaryDetail::acknowledged`.
@@ -106,7 +106,7 @@ impl PaneDisplay {
     }
 
     /// Tracked only (an observation-backed row) — test vocabulary; production
-    /// code branches on `earns_pane_line`/`is_interactive` instead.
+    /// code branches on `earns_pane_line`/`status()` instead.
     #[cfg(test)]
     pub(crate) fn is_tracked(&self) -> bool {
         matches!(self, Self::Tracked { .. })
@@ -119,6 +119,9 @@ impl PaneDisplay {
         matches!(self, Self::Tracked { .. } | Self::Interactive { .. })
     }
 
+    /// Interactive only — test vocabulary, like `is_tracked`; production
+    /// code reads `status()` (an Interactive pane has no observation-status).
+    #[cfg(test)]
     pub(crate) fn is_interactive(&self) -> bool {
         matches!(self, Self::Interactive { .. })
     }
@@ -173,7 +176,7 @@ impl PaneDisplay {
         }
     }
 
-    pub(crate) fn outcome(&self) -> Option<Outcome> {
+    pub(crate) fn outcome(&self) -> Option<ExitOutcome> {
         match self {
             Self::Tracked { outcome, .. } => *outcome,
             Self::Untracked { .. } | Self::Interactive { .. } => None,
@@ -337,13 +340,13 @@ pub fn roll_up<'a, 'q>(
 /// (no tag; the line-1 status glyph is the one done signal); Error →
 /// `Failed(exit_code)` (`exit N`, or `✗` when the code is unknown). Returns
 /// `None` for active/idle panes and all agents.
-fn pane_outcome(s: &TrackedObservation) -> Option<Outcome> {
+fn pane_outcome(s: &TrackedObservation) -> Option<ExitOutcome> {
     if s.origin != ObservationOrigin::Command {
         return None;
     }
     match s.status {
-        Status::Done => Some(Outcome::Ok),
-        Status::Error => Some(Outcome::Failed(s.exit_code)),
+        Status::Done => Some(ExitOutcome::Ok),
+        Status::Error => Some(ExitOutcome::Failed(s.exit_code)),
         _ => None,
     }
 }

--- a/crates/plugin/src/rollup/tests.rs
+++ b/crates/plugin/src/rollup/tests.rs
@@ -77,7 +77,7 @@ fn severity_precedence_picks_highest_active() {
     assert_eq!(display.status, Status::Error, "error outranks done");
     let detail = display.detail.expect("an active pane sets the detail");
     assert_eq!(detail.status, Status::Error);
-    assert_eq!(detail.outcome, Some(Outcome::Failed(None)));
+    assert_eq!(detail.outcome, Some(ExitOutcome::Failed(None)));
 }
 
 #[test]
@@ -138,14 +138,14 @@ fn pending_is_only_counted_for_tracked_panes() {
 
 #[test]
 fn pane_outcome_maps_finished_commands_only() {
-    assert_eq!(pane_outcome(&command_obs(Status::Done, Some(0))), Some(Outcome::Ok));
+    assert_eq!(pane_outcome(&command_obs(Status::Done, Some(0))), Some(ExitOutcome::Ok));
     assert_eq!(
         pane_outcome(&command_obs(Status::Error, Some(2))),
-        Some(Outcome::Failed(Some(2)))
+        Some(ExitOutcome::Failed(Some(2)))
     );
     assert_eq!(
         pane_outcome(&command_obs(Status::Error, None)),
-        Some(Outcome::Failed(None))
+        Some(ExitOutcome::Failed(None))
     );
     // Active commands get no tag.
     assert_eq!(pane_outcome(&command_obs(Status::Running, None)), None);

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -25,9 +25,9 @@
 //! - [`session_name_changed`](PluginRuntime::session_name_changed) —
 //!   `Event::ModeUpdate`'s `session_name`, the push-style source that
 //!   replaced `SessionUpdate` for learning this session's own name
-//!   (task-8b-brief.md: `SessionUpdate`'s peer list never populates without
-//!   a plugin calling the blocking `get_session_list()`, which stock
-//!   zj-radar never does — see `task-8-report.md`). Liveness itself no
+//!   (`SessionUpdate`'s peer list never populates without a plugin calling
+//!   the blocking `get_session_list()`, which stock zj-radar never does —
+//!   see `docs/design.md`, "Why not SessionUpdate"). Liveness itself no
 //!   longer comes from a Zellij-reported peer list at all: it's implicit in
 //!   which presence files `session_files::read_peer_presences` returns
 //!   (its mtime gate IS the liveness signal).
@@ -652,16 +652,18 @@ impl PluginRuntime {
         if !self.permission.granted() {
             return Outcome::none();
         }
+        let dir = match verb {
+            Verb::AttentionNext | Verb::SessionNext => Direction::Next,
+            Verb::AttentionPrev | Verb::SessionPrev => Direction::Prev,
+        };
         match verb {
             Verb::AttentionNext | Verb::AttentionPrev => {
-                let dir = if verb == Verb::AttentionNext { Direction::Next } else { Direction::Prev };
                 match self.radar.next_attention_tab(dir) {
                     Some(position) => Outcome::with_effects(false, vec![Effect::SwitchTab { position }]),
                     None => Outcome::none(),
                 }
             }
             Verb::SessionNext | Verb::SessionPrev => {
-                let dir = if verb == Verb::SessionNext { Direction::Next } else { Direction::Prev };
                 let render = self.sessions.cycle(dir);
                 // A fresh tap must arm Fast immediately (not wait for the next
                 // domain change to pass through `project`), so the idle-commit
@@ -683,7 +685,8 @@ impl PluginRuntime {
     }
 
     /// Learn (or relearn) this session's own name — the push-style source
-    /// that replaced `SessionUpdate` (task-8b-brief.md): `Event::ModeUpdate`'s
+    /// that replaced `SessionUpdate` (see `docs/design.md`, "Why not
+    /// SessionUpdate"): `Event::ModeUpdate`'s
     /// `ModeInfo.session_name`. `None` is a true no-op: Zellij can in
     /// principle fire `ModeUpdate` before the session has a name, and there
     /// is nothing to do with that yet — re-projecting on every such event
@@ -757,7 +760,7 @@ impl PluginRuntime {
 
     /// JSON the host actually writes to disk on `Effect::PersistPresence` —
     /// see `own_presence` for the field derivation. Only the wasm glue
-    /// (Task 6) calls this in production; on a host build nothing here
+    /// (lib.rs) calls this in production; on a host build nothing here
     /// invokes it (that wiring is still `project`'s `own_presence`
     /// comparison), so it would otherwise read as dead code.
     #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
@@ -1032,9 +1035,9 @@ impl PluginRuntime {
             // heartbeat is the only writer keeping it fresh. Fully disarming
             // would freeze that mtime and get a still-alive idle session
             // dimmed to stale on every peer's badge 90s later (never
-            // dropped — task-14 — but still a needless false alarm) — so
-            // the chain must stay (at least) Slow-armed for as long as the
-            // name is known.
+            // dropped — the never-vanish roster — but still a needless
+            // false alarm) — so the chain must stay (at least) Slow-armed
+            // for as long as the name is known.
             || !self.own_session_name.is_empty()
         {
             // Slow ticks exist to advance minute-granular ages: ledger rows'
@@ -1124,9 +1127,8 @@ impl PluginRuntime {
     /// The sole projection from a domain [`RadarChange`] to host [`Effect`]s.
     /// `fx` is a caller-supplied seed so the `timer` handler's permission
     /// effects come first, without a post-hoc splice. Canonical order: renames
-    /// → snapshot → presence → cwd → `SetTimeout` → notify — identical to
-    /// today's `panes_changed` apart from the presence edge, so that handler
-    /// is otherwise byte-for-byte unchanged. `settle` is the per-handler stamp
+    /// → snapshot → presence → cwd → `SetTimeout` → notify (pinned by
+    /// `project_emits_effects_in_canonical_order`). `settle` is the per-handler stamp
     /// described in `## Settle` (`CONTEXT.md`): this is the sole caller of
     /// `notify_effects`, and the only *domain-change* path that arms the timer
     /// (the permission flow arms it separately in `begin_permission_flow`).
@@ -1149,8 +1151,8 @@ impl PluginRuntime {
     /// `session_name_changed` (also routed through here) learns it.
     ///
     /// Same gate also feeds `Sessions::set_own` — the single path for own
-    /// counts into the OWN badge row (task-8b-brief.md un-deads it: nothing
-    /// called it before this). Unlike `PersistPresence`, this is NOT
+    /// counts into the OWN badge row (nothing else calls it).
+    /// Unlike `PersistPresence`, this is NOT
     /// edge-gated by `last_presence`'s cache — `Sessions::set_own` already
     /// does its own badge-derived content-compare and reports whether the
     /// badge actually changed, so calling it every `project` pass (once the

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -1040,8 +1040,8 @@ fn presence_withheld_until_own_session_name_is_known() {
 fn session_cycle_commits_via_switch_session_effect_on_idle_tick() {
     let mut rt = runtime_with_granted_permission(); // own session name is "work"
     // "alpha" needs no separate liveness registration anymore — its presence
-    // report IS its liveness (task-8b-brief.md: no more `SessionUpdate` peer
-    // list to cross-check against).
+    // report IS its liveness (no more `SessionUpdate` peer list to
+    // cross-check against — see `docs/design.md`, "Why not SessionUpdate").
     rt.presences_changed(vec![
         fresh(r#"{"session_name":"alpha","running":0,"attention":1,"attention_tab_position":1}"#),
     ]);
@@ -1049,7 +1049,7 @@ fn session_cycle_commits_via_switch_session_effect_on_idle_tick() {
     let out = rt.control_pipe("session-next");
     assert!(out.render, "selection highlight renders");
 
-    // The Fast fire covering the tap itself must not commit (task-14: the
+    // The Fast fire covering the tap itself must not commit (the
     // taps-since-last-fire flag resets the deadline instead) — only the
     // NEXT, fully quiet fire may.
     let covering = rt.timer_fast(PermissionProbe::default());
@@ -1417,11 +1417,11 @@ fn a_real_pending_to_done_broadcast_still_notifies() {
 
 #[test]
 fn own_badge_row_updates_live_as_running_and_attention_move() {
-    // Task-6 flagged `Sessions::set_own` as dead code: nothing called it, so
-    // the own row of the cross-session badge never reflected the running/
+    // `Sessions::set_own` was once dead code: nothing called it, so the own
+    // row of the cross-session badge never reflected the running/
     // attention counts actually moving underneath it — it would render
-    // whatever it started at (0/0) forever. task-8b-brief.md revives it by
-    // having `project` call it every pass once the name is known; this pins
+    // whatever it started at (0/0) forever. The fix has
+    // `project` call it every pass once the name is known; this pins
     // that the own row's rendered counts actually track a later status edge,
     // not just its state at the moment the name became known.
     let mut rt = runtime_with_granted_permission(); // own session name "work"
@@ -1598,11 +1598,15 @@ fn noop_broadcast_skips_presence_and_notify_work() {
 
 #[test]
 fn project_emits_effects_in_canonical_order() {
-    // Sole home of the order contract: renames → snapshot → cwd →
+    // Sole home of the order contract: renames → snapshot → presence → cwd →
     // SetTimeout → notify. Seed a background Done so `settle` actually
-    // produces a Notify, exercising all five effect kinds in one change.
+    // produces a Notify, and a just-learned session name so the presence
+    // compare sees its first content edge (the helper leaves the name empty,
+    // which withholds `PersistPresence` entirely) — exercising all six
+    // effect kinds in one change.
     let mut rt = two_tab_runtime_with_running_commands();
     rt.radar.command_mut().on_exit(7, Some(0), Tick(rt.tick), EpochSecs(0));
+    rt.own_session_name = "main".into();
     // `TimerChain::arm` self-guards on the armed cadence; the setup helper's
     // timer tick already armed it, so force the disarmed state to let
     // `project`'s unconditional arm call actually produce a `SetTimeout`.
@@ -1621,9 +1625,10 @@ fn project_emits_effects_in_canonical_order() {
     let kind = |e: &Effect| match e {
         Effect::RenameTab { .. } => 0,
         Effect::PersistSnapshot => 1,
-        Effect::ResolveCwd { .. } => 2,
-        Effect::SetTimeout(_) => 3,
-        Effect::Notify { .. } => 4,
+        Effect::PersistPresence => 2,
+        Effect::ResolveCwd { .. } => 3,
+        Effect::SetTimeout(_) => 4,
+        Effect::Notify { .. } => 5,
         other => panic!("unexpected effect in canonical-order test: {other:?}"),
     };
     let kinds: Vec<i32> = outcome.effects.iter().map(kind).collect();
@@ -1631,12 +1636,12 @@ fn project_emits_effects_in_canonical_order() {
     sorted.sort_unstable();
     assert_eq!(
         kinds, sorted,
-        "effects must appear in canonical order (renames < snapshot < cwd < timer < notify); got {:?}",
+        "effects must appear in canonical order (renames < snapshot < presence < cwd < timer < notify); got {:?}",
         outcome.effects
     );
-    // All five kinds must actually be present, otherwise the ordering
+    // All six kinds must actually be present, otherwise the ordering
     // assertion above is vacuous.
-    for expected in 0..=4 {
+    for expected in 0..=5 {
         assert!(
             kinds.contains(&expected),
             "expected effect kind {expected} to be present; got {:?}",
@@ -2020,8 +2025,9 @@ fn saturated_history_with_known_name_keeps_slow_armed_for_the_heartbeat() {
     // Slow-fire heartbeat. Were the chain to fully disarm on a saturated
     // idle rail, that heartbeat would never fire again, the mtime would
     // freeze, and after 90s every peer would dim this still-alive session's
-    // badge to stale (never drop it — task-14 — but still a needless false
-    // alarm) — exactly the idle-but-visible case the feature exists for.
+    // badge to stale (never drop it — the never-vanish roster — but still a
+    // needless false alarm) — exactly the idle-but-visible case the feature
+    // exists for.
     // So: saturation may step the cadence down to Slow, but never to None
     // while the name is known.
     let mut rt = PluginRuntime {
@@ -2244,7 +2250,7 @@ fn idle_alive_session_heartbeats_presence_unconditionally_on_slow_fires_only() {
     // content edge to trigger `project`'s compare-and-cache `PersistPresence`
     // — but its presence file's mtime is the signal peers use to tell fresh
     // from stale (`sessions::STALE_AFTER_SECS`; liveness is no longer
-    // `SessionUpdate`-derived at all, and past task-14 it's never a hard
+    // `SessionUpdate`-derived at all, and staleness is never a hard
     // drop either — just a dim). The Slow (60s) heartbeat must therefore
     // emit `PersistPresence` unconditionally, bypassing the content-compare
     // gate; Fast (1s) fires must NOT — that would be needless per-second

--- a/crates/plugin/src/session_files.rs
+++ b/crates/plugin/src/session_files.rs
@@ -36,10 +36,11 @@ const NOTIFY_CLAIM_SWEEP_AGE: Duration = Duration::from_secs(300);
 const PERMISSION_GRANTED_MARKER: &str = "granted";
 const PERMISSION_DENIED_MARKER: &str = "denied";
 /// Horizon after which a presence file is deleted as debris at `open` time —
-/// the ONLY true forgetting a peer's roster entry is subject to (task-14,
-/// user decision: a remembered session must never silently vanish from the
-/// badge). Peers dead well before their file turns 6h old still keep
-/// showing up in every other session's badge, dimmed as stale
+/// the ONLY true forgetting a peer's roster entry is subject to (never-vanish
+/// roster, user decision: a remembered session must never silently vanish
+/// from the badge — `docs/design.md`). Peers dead well before their file
+/// turns 6h old still keep showing up in every other session's badge, dimmed
+/// as stale
 /// (`sessions::STALE_AFTER_SECS`) rather than dropped — this sweep only
 /// exists so a long string of genuinely dead sessions' files don't
 /// accumulate forever in the shared root. Generous: a detached-but-alive
@@ -156,13 +157,7 @@ impl SessionFiles {
             PermissionMarker::Granted => PERMISSION_GRANTED_MARKER,
             PermissionMarker::Denied => PERMISSION_DENIED_MARKER,
         };
-        if std::fs::write(&paths.permission_marker_tmp, raw.as_bytes()).is_ok() {
-            if std::fs::rename(&paths.permission_marker_tmp, &paths.permission_marker).is_err() {
-                let _ = std::fs::remove_file(&paths.permission_marker_tmp);
-            }
-        } else {
-            let _ = std::fs::remove_file(&paths.permission_marker_tmp);
-        }
+        write_via_tmp(&paths.permission_marker_tmp, &paths.permission_marker, raw.as_bytes());
     }
 
     /// Refresh the permission lock's mtime (rewriting it, creating if needed).
@@ -180,13 +175,7 @@ impl SessionFiles {
         let Some(paths) = &self.paths else {
             return;
         };
-        if std::fs::write(&paths.snapshot_tmp, json.as_bytes()).is_ok() {
-            if std::fs::rename(&paths.snapshot_tmp, &paths.snapshot).is_err() {
-                let _ = std::fs::remove_file(&paths.snapshot_tmp);
-            }
-        } else {
-            let _ = std::fs::remove_file(&paths.snapshot_tmp);
-        }
+        write_via_tmp(&paths.snapshot_tmp, &paths.snapshot, json.as_bytes());
     }
 
     /// Publish this session's presence for peer sessions' badges. Same atomic
@@ -195,22 +184,17 @@ impl SessionFiles {
         let Some(paths) = &self.paths else {
             return;
         };
-        if std::fs::write(&paths.presence_tmp, json.as_bytes()).is_ok() {
-            if std::fs::rename(&paths.presence_tmp, &paths.presence).is_err() {
-                let _ = std::fs::remove_file(&paths.presence_tmp);
-            }
-        } else {
-            let _ = std::fs::remove_file(&paths.presence_tmp);
-        }
+        write_via_tmp(&paths.presence_tmp, &paths.presence, json.as_bytes());
     }
 
     /// Raw JSON of every OTHER session's presence file (own pid excluded, tmp
     /// files excluded), paired with how long ago its mtime was last touched.
     /// Parsing/validation is the caller's job (`Presence::parse` skips
     /// corrupt peers) — and so, now, is staleness: this method used to treat
-    /// an old mtime as "peer is gone" and skip it outright, but task-14's
-    /// user decision is that a remembered session must never silently
-    /// vanish from the badge, so every peer file found comes back
+    /// an old mtime as "peer is gone" and skip it outright, but the
+    /// never-vanish-roster user decision (`docs/design.md`) is that a
+    /// remembered session must never silently vanish from the badge, so
+    /// every peer file found comes back
     /// unconditionally. `age_secs` is measured off THIS session's own
     /// filesystem clock reading the file's mtime — not the peer's
     /// self-reported `updated_epoch_s` inside the JSON, which a corrupt or
@@ -241,11 +225,7 @@ impl SessionFiles {
             if paths.is_own_presence_file(&name) {
                 continue;
             }
-            let age_secs = entry
-                .metadata()
-                .and_then(|m| m.modified())
-                .ok()
-                .and_then(|modified| now.duration_since(modified).ok())
+            let age_secs = age_of(entry.metadata(), now)
                 .map(|age| age.as_secs())
                 .unwrap_or(0); // metadata/clock hiccup: treat as fresh rather than drop the peer
             if let Ok(json) = std::fs::read_to_string(entry.path()) {
@@ -366,6 +346,31 @@ impl SessionFiles {
     }
 }
 
+/// The tmp-write→rename discipline every persisted file in this module uses:
+/// write the instance-scoped `tmp` file, then atomically rename it over
+/// `dest`. On any failure the tmp is removed and the existing `dest` is left
+/// untouched; errors are otherwise swallowed (persistence is best-effort —
+/// see the module doc's disabled-mode story).
+fn write_via_tmp(tmp: &Path, dest: &Path, bytes: &[u8]) {
+    if std::fs::write(tmp, bytes).is_ok() {
+        if std::fs::rename(tmp, dest).is_err() {
+            let _ = std::fs::remove_file(tmp);
+        }
+    } else {
+        let _ = std::fs::remove_file(tmp);
+    }
+}
+
+/// How long ago (relative to `now`) the file behind `meta` was last modified.
+/// `None` on any metadata/clock hiccup — including an mtime in the future —
+/// so each caller decides its own conservative fallback (treat as fresh,
+/// don't reclaim, don't prune).
+fn age_of(meta: std::io::Result<std::fs::Metadata>, now: SystemTime) -> Option<Duration> {
+    meta.and_then(|m| m.modified())
+        .ok()
+        .and_then(|modified| now.duration_since(modified).ok())
+}
+
 /// Remove spent notify claims so a long-lived session doesn't accrete one file
 /// per notification event forever. Runs on each claim attempt — notifications
 /// are edge-rate (not output-rate), so the readdir is negligible.
@@ -380,12 +385,7 @@ fn prune_stale_claims(paths: &SessionPaths, now: SystemTime) {
         if !name.starts_with(&prefix) {
             continue;
         }
-        let stale = entry
-            .metadata()
-            .and_then(|m| m.modified())
-            .ok()
-            .and_then(|modified| now.duration_since(modified).ok())
-            .is_some_and(|age| age > NOTIFY_CLAIM_SWEEP_AGE);
+        let stale = age_of(entry.metadata(), now).is_some_and(|age| age > NOTIFY_CLAIM_SWEEP_AGE);
         if stale {
             let _ = std::fs::remove_file(entry.path());
         }
@@ -398,11 +398,7 @@ fn prune_stale_claims(paths: &SessionPaths, now: SystemTime) {
 /// the recreate race we defer to it (returns false) — consistent with
 /// preferring at least one reachable prompt/toast over a deadlock.
 fn reclaim_if_stale(lock: &Path, now: SystemTime, ttl: Duration) -> bool {
-    let stale = std::fs::metadata(lock)
-        .and_then(|m| m.modified())
-        .ok()
-        .and_then(|modified| now.duration_since(modified).ok())
-        .is_some_and(|age| age > ttl);
+    let stale = age_of(std::fs::metadata(lock), now).is_some_and(|age| age > ttl);
     if !stale {
         return false;
     }
@@ -504,12 +500,7 @@ fn prune_stale_files(paths: &SessionPaths, now: SystemTime, max_age: Duration) {
             if paths.is_own_presence_file(&name) {
                 continue;
             }
-            let stale = entry
-                .metadata()
-                .and_then(|m| m.modified())
-                .ok()
-                .and_then(|modified| now.duration_since(modified).ok())
-                .is_some_and(|age| age > PRESENCE_MAX_AGE);
+            let stale = age_of(entry.metadata(), now).is_some_and(|age| age > PRESENCE_MAX_AGE);
             if stale {
                 let _ = std::fs::remove_file(entry.path());
             }
@@ -518,12 +509,7 @@ fn prune_stale_files(paths: &SessionPaths, now: SystemTime, max_age: Duration) {
         if !is_owned_session_file(&name) || paths.is_current_session_file(&name) {
             continue;
         }
-        let stale = entry
-            .metadata()
-            .and_then(|m| m.modified())
-            .ok()
-            .and_then(|modified| now.duration_since(modified).ok())
-            .is_some_and(|age| age > max_age);
+        let stale = age_of(entry.metadata(), now).is_some_and(|age| age > max_age);
         if stale {
             let _ = std::fs::remove_file(entry.path());
         }
@@ -1027,9 +1013,9 @@ mod tests {
 
     #[test]
     fn read_peer_presences_never_drops_an_old_mtime_peer_and_reports_its_age() {
-        // task-14, user decision: a remembered session must never silently
-        // vanish from the badge. This method used to skip a peer once its
-        // file's mtime drifted past a liveness TTL; now it must keep
+        // Never-vanish roster, user decision: a remembered session must
+        // never silently vanish from the badge. This method used to skip a
+        // peer once its file's mtime drifted past a liveness TTL; now it must keep
         // returning that peer unconditionally — dropping only ever happens
         // at `open`'s much-longer `PRESENCE_MAX_AGE` sweep — and report an
         // honest age so the caller (`sessions::Sessions`) can mark it stale

--- a/crates/plugin/src/sessions.rs
+++ b/crates/plugin/src/sessions.rs
@@ -5,7 +5,8 @@
 //! rows-derived-on-render doctrine (`CONTEXT.md`) rather than caching a
 //! badge that could drift from `peers`/`own`.
 //!
-//! task-14 (user decision): a remembered session must NEVER silently vanish
+//! Never-vanish roster (user decision — `docs/design.md`, "Liveness
+//! heartbeat + staleness"): a remembered session must NEVER silently vanish
 //! from the badge. `session_files::read_peer_presences` no longer filters
 //! anything by mtime — every peer file it finds comes back, forever (until
 //! the 6h open-time sweep, the only true forgetting). Liveness is instead a
@@ -82,7 +83,7 @@ pub(crate) struct CommitTarget {
 
 /// A pending (not yet committed) cycle selection. `name` identifies the
 /// selected session directly rather than its position in the derived order —
-/// `update_live`/`update_presences` can reorder that list between the
+/// `update_presences`/`set_own` can reorder that list between the
 /// `cycle()` tap and the commit `tick()` (e.g. a new session sorting ahead of
 /// the selected one), and a positional index would then silently retarget
 /// whatever session ended up at the old index. Re-resolved by name against
@@ -184,8 +185,8 @@ impl Sessions {
 
     /// Advance (or start) the cycle selection and arm its tap-since-fire
     /// flag (see `SelectionState`'s doc). Re-derives the shared ordering
-    /// fresh each call, so a selection started before a
-    /// `update_live`/`update_presences` change always steps relative to the
+    /// fresh each call, so a selection started before an
+    /// `update_presences`/`set_own` change always steps relative to the
     /// current membership, never a stale snapshot. The pending selection's
     /// *name* is re-resolved against that fresh order (not trusted as a
     /// stale index) before advancing from it.
@@ -194,7 +195,7 @@ impl Sessions {
     /// index/position below is computed against `selectable` (fresh entries
     /// only), never the full `order`. Alt+[/] must never land on a
     /// likely-dead session: `switch_session`ing onto one that's actually
-    /// gone would have Zellij resurrect it as an empty zombie (task-14).
+    /// gone would have Zellij resurrect it as an empty zombie.
     pub(crate) fn cycle(&mut self, dir: Direction) -> bool {
         let before = self.badge();
         let order = self.ordered();
@@ -287,7 +288,7 @@ impl Sessions {
     /// Whether a cycle selection is pending — the runtime keeps the Fast
     /// timer cadence armed while true, so the idle-commit in `tick()` fires
     /// promptly rather than waiting for the next Slow tick. Only the wasm
-    /// runtime (Task 5) reads this in production; pinned by a host test
+    /// runtime reads this in production; pinned by a host test
     /// (`wants_fast_cadence_tracks_pending_selection_through_commit_and_cancel`).
     #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
     pub(crate) fn wants_fast_cadence(&self) -> bool {
@@ -587,8 +588,8 @@ mod tests {
         // "aardvark" joins and sorts ahead of "alpha" in the rest bucket. A
         // positional-index selection (old index 1) would now point at
         // "aardvark" instead of "alpha". `update_presences` REPLACES the
-        // peer set wholesale (same as `update_live` used to for `live`), so
-        // this is the same "membership changed under the selection" shape.
+        // peer set wholesale, so this is the same "membership changed under
+        // the selection" shape.
         s.update_presences(vec![presence("aardvark", 1, 0), presence("alpha", 1, 0), presence("beta", 1, 0)]);
 
         s.tick(); // the fire covering the tap: skip, clears the flag
@@ -694,7 +695,7 @@ mod tests {
         assert_eq!(work_entries[0].attention, 0, "own's own-known counts must win over a peer claiming the same name");
     }
 
-    // -- Pinning: persistent roster (task-14) --------------------------------
+    // -- Pinning: persistent (never-vanish) roster ---------------------------
     // A remembered session must never silently vanish from the badge. Peers
     // past `STALE_AFTER_SECS` mark stale (dimmed by the renderer, unreachable
     // via `cycle()`) instead of disappearing; only the open-time

--- a/crates/plugin/tests/e2e/main.rs
+++ b/crates/plugin/tests/e2e/main.rs
@@ -1072,14 +1072,14 @@ fn rail_paints_every_column_of_its_pane() {
 /// `SessionUpdate`'s peer list (`peer_sessions_cache`) when some plugin
 /// calls the blocking host fn `get_session_list()`, which only Zellij's own
 /// `session-manager` plugin does — zj-radar's plugin never does, by design
-/// (CLAUDE.md: "push-driven, never poll-driven"). See task-8-report.md for
-/// the full root-cause dive (this test used to fail with a STOP-CONDITION
-/// panic pointing at exactly that). task-8b-brief.md's amendment drops
+/// (CLAUDE.md: "push-driven, never poll-driven"). See `docs/design.md`,
+/// "Why not SessionUpdate", for the full root-cause dive (this test used to
+/// fail with a STOP-CONDITION panic pointing at exactly that). The fix drops
 /// `SessionUpdate` from the design entirely: liveness is now the presence
 /// files' own mtimes, turned into a per-entry fresh/stale state
-/// (`sessions::STALE_AFTER_SECS`) rather than a read-time drop (task-14),
-/// and this session's own name comes from `ModeUpdate` instead — both
-/// push-style, neither needing any other plugin to be running.
+/// (`sessions::STALE_AFTER_SECS`) rather than a read-time drop (the
+/// never-vanish roster), and this session's own name comes from `ModeUpdate`
+/// instead — both push-style, neither needing any other plugin to be running.
 #[test]
 #[ignore = "e2e: requires zellij + built wasm; run via `just test-e2e`"]
 fn session_next_switches_to_the_session_with_attention() {
@@ -1150,8 +1150,8 @@ fn session_next_switches_to_the_session_with_attention() {
         "A's badge never showed {needle:?}. Either B never learned its own session name from \
          `Event::ModeUpdate` (so `project` withheld `Effect::PersistPresence`), or B's presence \
          file (written under the shared /cache root) never reached A (A's `Effect::ReadPresences` \
-         is Fast-tick-gated — see the rail above for whether A even looks fast-armed). Since \
-         task-14, a stale peer still renders (dimmed) rather than being dropped, so a bare \
+         is Fast-tick-gated — see the rail above for whether A even looks fast-armed). Under \
+         the never-vanish roster, a stale peer still renders (dimmed) rather than being dropped, so a bare \
          name with the wrong (or missing) counts, not an absent line, is the sign of a genuine \
          presence-plumbing failure here. See the printed rail above.",
     );

--- a/docs/rail-reference.md
+++ b/docs/rail-reference.md
@@ -41,7 +41,7 @@
    count/elapsed slot to keep lines clean. `done/total` may return later. ⟦D1⟧
 8. **Empty/initial is not a marketing screen.** No "AI agent activity" legend —
    just render the tab list; an unnamed/first tab shows a placeholder name.
-   Now true end-to-end (Task 14): the zero-tab onboarding face itself dropped
+   Now true end-to-end: the zero-tab onboarding face itself dropped
    the status-glyph legend down to a one-line ` scanning… no agents yet`. That
    face is a separate code path from this doc's harness (see §A's note below)
    — `render_rail` and `aggregate` are what this file pins.
@@ -73,7 +73,7 @@
 ▌└ ● ⚙ activity message            ← last pane row uses the └ elbow connector
 ```
 
-**Needs-you badge (Task 16).** The header's right slot appends `{n}!` — bold,
+**Needs-you badge.** The header's right slot appends `{n}!` — bold,
 loud (`Attention` role) — space-joined after the census whenever `n =
 rows.iter().filter(|r| r.display.status.needs_you()).count()` is nonzero (i.e.
 any tab is `Pending` or `Error`). At narrow widths, priority to keep is
@@ -81,7 +81,7 @@ overflow marker > badge > plain census: a tight budget drops the census
 first and shows the bare badge (`n!` with no leading `·N`); the overflow
 marker itself is never dropped for the badge's sake.
 
-**Header heartbeat sweep (Task 20).** In Compact/Comfortable density only (the
+**Header heartbeat sweep.** In Compact/Comfortable density only (the
 densities with the `═` rule — Cards drops the rule entirely, so it never
 carries the heartbeat), whenever any row is Running *animating* work (its
 detail is a job, not a service — a rail whose only Running rows are steady-`▸`


### PR DESCRIPTION
Follow-up to #14 — executes the findings of a fourth review pass over the subsystems earlier passes hadn't covered (runtime effects, render layout machinery, session files, sessions, CLI setup). The review found **zero logic defects**; everything here is hygiene, and the rendered rail is proven bit-identical (all insta + executable-spec tests pass with no snapshot changes).

- **Delete dead layout knobs**: `CardSpacing.pad_x`/`pad_y` have been 0 for every density since the Cards column was reclaimed — collapsed to `gap`, removing the pad-shed rung, the pad_y render loop, and the clamp math in `tab_header_line` whose comment falsely claimed a "Cards-only 1-col pad" (the one place structure and commentary disagreed).
- **One file-io idiom**: `session_files.rs`'s tmp-write→rename dance (×3) and mtime-age computation (×5) factored into `write_via_tmp` / `age_of`.
- **Dead pointers removed**: ~26 comment citations of gitignored planning artifacts (task-8b/task-14/"Task N") now restate their decision inline or point at `docs/design.md`.
- **Stale comments fixed**: `sessions.rs` naming the removed `update_live`; `project()`'s refactor-era "identical to today's panes_changed" narration.
- **Guard gap closed**: `project_emits_effects_in_canonical_order` now pins `PersistPresence`'s position (the doc'd order previously included it; the test didn't).
- **Naming**: `rollup::Outcome` → `ExitOutcome` (three `Outcome` types were grep-colliding); setup's `write_atomic` → `backup_then_write` (near-anagram of `fsutil::atomic_write` with a different contract); HotspotSlot's magic minimums 6/8/4 named with derivations; the `command_source_*` guard-test names updated to the `classify` era (CONTEXT.md citation updated); `render_header`'s anonymous `(String, &str, bool)` runs now use `Seg`; `is_interactive` joined `is_tracked` as `#[cfg(test)]` vocabulary.
- **Verb→Direction mapping** unified into one match.

Gates: unit suites 123/522/228 green, clippy `-D warnings` clean, wasm builds with zero warnings, bats 61/61, live E2E 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)