### PR TITLE
fix: pre-release hardening — run-pane interactive identity, sweep exemption, canonical animating

### DIFF
--- a/crates/core/src/command.rs
+++ b/crates/core/src/command.rs
@@ -115,6 +115,12 @@ struct Pending {
     kind: Kind,
     since_tick: u64,
     promotable: bool,
+    /// The peeled exe basename (`effective_program`), stamped at intake — the
+    /// interactive re-judge matches on THIS, not the display string, so its
+    /// correctness is structural rather than held by the display-shape guard
+    /// test. (The sweep over already-promoted *observations* still derives it
+    /// from the display — see `set_interactive_extras`.)
+    program: String,
 }
 
 /// Tracks per-pane command activity for terminal panes that have no agent
@@ -533,36 +539,33 @@ impl CommandStore {
         // mean back-to-the-prompt; agents are owned by the push pipe (see
         // AGENT_NAMES). Either way we never open a command lifecycle for them.
         let in_ignore_set = IGNORE_NAMES.contains(&name) || AGENT_NAMES.contains(&name);
+        let interactive = self.interactive.contains(name);
 
-        if !is_foreground || in_ignore_set {
+        // An interactive argv takes the intake arm below whatever the
+        // foreground flag says: the flag only encodes "the root has a child"
+        // (see `is_shell_prompt`), so a childless interactive ROOT
+        // (`zellij run -- nvim`) reports `is_foreground=false` — and that
+        // report is the editor alive, not a return to the prompt. Dropping it
+        // here would skip the quiet pending, and the held pane's exit would
+        // insert the blank Done row the activity model promises never happens.
+        // Shell panes can't reach this override: their childless root IS the
+        // shell, which the ignore set already catches.
+        if (!is_foreground && !interactive) || in_ignore_set {
             // The foreground command (if any) has ended: clear pending and, if a
             // command was Running, mark it *tentatively* done. `on_timer`
             // confirms the Done after the debounce window — so a momentary
             // foreground drop (a child subprocess, a TUI handoff) doesn't flip
             // the row to Done and straight back.
             self.pending.remove(&pane_id);
-            if self
-                .store
-                .get(pane_id)
-                .is_some_and(|s| s.status == Status::Running)
-            {
-                self.pending_done.entry(pane_id).or_insert(tick);
-            }
+            self.arm_tentative_done(pane_id, tick);
             // Otherwise leave resolved unchanged (idle stays idle).
         } else {
-            let interactive = self.interactive.contains(name);
             if interactive {
                 // An interactive command (editor/pager/TUI) is the pane's fg:
                 // any PRIOR Running command has ended, exactly as in the ignore
                 // branch above — opening nvim after `cargo build` finished must
                 // still flip the build row to Done.
-                if self
-                    .store
-                    .get(pane_id)
-                    .is_some_and(|s| s.status == Status::Running)
-                {
-                    self.pending_done.entry(pane_id).or_insert(tick);
-                }
+                self.arm_tentative_done(pane_id, tick);
             } else {
                 // A real foreground command is running: it is no longer
                 // leaving, so cancel any tentative-done.
@@ -596,8 +599,24 @@ impl CommandStore {
                     kind,
                     since_tick: tick,
                     promotable: !interactive,
+                    program: name.to_string(),
                 },
             );
+        }
+    }
+
+    /// Start the tentative-done debounce for a pane whose Running command has
+    /// left the foreground: `on_timer` confirms the Done after the debounce
+    /// window, so a momentary drop (a child subprocess, a TUI handoff) doesn't
+    /// flip the row to Done and straight back. `or_insert` keeps the FIRST
+    /// observation tick — re-reports must not restart the window.
+    fn arm_tentative_done(&mut self, pane_id: u32, tick: u64) {
+        if self
+            .store
+            .get(pane_id)
+            .is_some_and(|s| s.status == Status::Running)
+        {
+            self.pending_done.entry(pane_id).or_insert(tick);
         }
     }
 
@@ -907,9 +926,11 @@ impl CommandStore {
             .collect();
         let mut changed = false;
         // Re-judge every pending against the new set — symmetric, so removing
-        // an extra un-quiets its pending and the next tick promotes it.
+        // an extra un-quiets its pending and the next tick promotes it. The
+        // match key is the intake-stamped `program`, the same peeled name the
+        // intake classification used.
         for p in self.pending.values_mut() {
-            let quiet = first_token(&p.command).is_some_and(|t| self.interactive.contains(t));
+            let quiet = self.interactive.contains(&p.program);
             if p.promotable == quiet {
                 p.promotable = !quiet;
                 changed = true;
@@ -923,11 +944,18 @@ impl CommandStore {
         // removing the config entry later re-promotes symmetrically. (The
         // observation's `repo` is already a basename; `on_exit`'s
         // `basename(cwd)` is idempotent over it.)
+        //
+        // A row with an armed tentative-done is exempt: its command already
+        // left the foreground (the pane is back at the prompt), so demoting it
+        // would ghost a quiet pending that no future CommandChanged clears —
+        // the shell-return edge already fired. The armed confirm flips it
+        // Running→Done on schedule, which is the true outcome.
         let to_demote: Vec<u32> = self
             .store
             .observations()
-            .filter(|(_, s)| {
+            .filter(|(id, s)| {
                 s.status == Status::Running
+                    && !self.pending_done.contains_key(id)
                     && first_token(&s.msg).is_some_and(|t| self.interactive.contains(t))
             })
             .map(|(id, _)| id)
@@ -942,6 +970,10 @@ impl CommandStore {
                     kind: s.kind,
                     since_tick: s.last_change_tick,
                     promotable: false,
+                    // Observations don't carry the peeled name; re-derive it
+                    // from the display (the same key that matched `to_demote`,
+                    // held by the display-shape guard test).
+                    program: first_token(&s.msg).unwrap_or_default().to_string(),
                 };
                 self.pending.entry(pane_id).or_insert(quiet);
             }

--- a/crates/core/src/command/tests.rs
+++ b/crates/core/src/command/tests.rs
@@ -1208,6 +1208,32 @@
     }
 
     #[test]
+    fn childless_interactive_root_still_records_quiet_pending() {
+        // `zellij run -- nvim`: the editor IS the pane root, and a childless
+        // root reports `is_foreground=false` (the flag only encodes "the root
+        // has a child" — see `is_shell_prompt`). That report is the editor
+        // alive, not a return to the prompt: the quiet pending must form
+        // anyway, or the held pane's exit inserts the blank Done row the
+        // activity model promises never happens (`docs/activity-model.md` §5).
+        let mut s = CommandStore::default();
+        s.on_command_changed(1, &argv(&["nvim"]), false, Some("/w/proj"), 0);
+        assert_eq!(
+            s.quiet_identity(1),
+            Some(("nvim", Kind::Command)),
+            "muted label available while the run-pane editor is open"
+        );
+        assert!(!s.needs_ticks(), "an open editor never pins the timer");
+        s.on_timer(Tick(DEBOUNCE_TICKS), EpochSecs(100));
+        assert!(s.get(1).is_none(), "quiet pending never promotes to Running");
+
+        s.on_exit(1, Some(0), Tick(50), EpochSecs(1000));
+        let obs = s.get(1).unwrap();
+        assert_eq!(obs.status, Status::Done);
+        assert_eq!(obs.msg, "nvim", "exit labeled — never a blank row");
+        assert_eq!(obs.repo, "proj");
+    }
+
+    #[test]
     fn interactive_commands_are_not_prompts_and_not_agents() {
         // The prompt contract is untouched: opening an editor must not read
         // as "returned to shell" (which exit-clears pushed agent statuses) and
@@ -1225,6 +1251,29 @@
         s.on_command_changed(1, &argv(&["zsh"]), true, None, 5);
         assert_eq!(s.quiet_identity(1), None, "back at the prompt — label gone");
         assert!(s.get(1).is_none(), "no row was ever created");
+    }
+
+    #[test]
+    fn sweep_skips_a_row_already_leaving_the_foreground() {
+        // gdb promoted to Running, then returned to the shell — its
+        // tentative-done is armed. A config.v1 naming gdb interactive that
+        // lands inside the debounce window must NOT sweep the row: the pane is
+        // back at the prompt, so demoting to Idle and reconstructing a quiet
+        // pending would ghost a muted `gdb` label that nothing ever clears
+        // (the shell-return CommandChanged already fired — edge-triggered,
+        // never replayed). Let the armed confirm flip Running→Done normally.
+        let mut s = CommandStore::default();
+        s.on_command_changed(1, &argv(&["gdb"]), true, None, 0);
+        s.on_timer(Tick(DEBOUNCE_TICKS), EpochSecs(100));
+        assert_eq!(s.get(1).unwrap().status, Status::Running);
+        s.on_command_changed(1, &argv(&["zsh"]), true, None, DEBOUNCE_TICKS + 1);
+
+        s.set_interactive_extras(["gdb"]);
+        assert_eq!(s.quiet_identity(1), None, "no ghost label for a prompt pane");
+        assert_eq!(s.get(1).unwrap().status, Status::Running, "left for the confirm");
+
+        s.on_timer(Tick(DEBOUNCE_TICKS * 2 + 1), EpochSecs(200));
+        assert_eq!(s.get(1).unwrap().status, Status::Done, "real completion lands");
     }
 
     #[test]

--- a/crates/plugin/src/reference_tests.rs
+++ b/crates/plugin/src/reference_tests.rs
@@ -499,18 +499,22 @@ fn build(input: &str) -> (Vec<TabRow>, Vec<crate::rollup::LedgerLine>, RenderOpt
     //        3. panes_changed with exits vec containing the exit code — calls on_exit,
     //           which sets status Done/Error and exit_code on the resolved entry.
 
-    // Collect command-exit panes so we can feed them as a batch to panes_changed.
+    // Command-observer intake, one loop for both DSL shapes: `interactive
+    // "<argv>"` records a quiet pending (identity for the muted label, never
+    // promoted — the later timer step can't touch it) and `exit <N>|?` panes
+    // register the pending the exits batch below completes. Argv comes from
+    // splitting the msg so the CommandStore compacts it back into the display
+    // message (e.g. "cargo build" stays "cargo build").
     let mut command_exits: Vec<(u32, Option<i32>)> = Vec::new();
-
-    // Interactive panes (`interactive "<argv>"`): the command-observer path
-    // with an interactive fg command. A quiet pending is recorded (identity
-    // for the muted label) and never promoted — no timer step needed.
     for spec in &tabs {
         for pane in &spec.panes {
-            if pane.interactive {
+            if pane.interactive || pane.exit_code.is_some() {
                 let argv: Vec<String> =
                     pane.msg.split_whitespace().map(|s| s.to_string()).collect();
                 radar.command_changed(pane.pane_id, &argv, true, 0);
+                if let Some(code) = pane.exit_code {
+                    command_exits.push((pane.pane_id, code));
+                }
             }
         }
     }
@@ -567,24 +571,6 @@ fn build(input: &str) -> (Vec<TabRow>, Vec<crate::rollup::LedgerLine>, RenderOpt
                 // (or, at 0, deliberately do not earn) the `· Nm` wait tag.
                 let apply_epoch = LEDGER_NOW_EPOCH_S.saturating_sub(pane.waiting_m * 60);
                 radar.status_pipe(&wire, 0, apply_epoch, NamingMode::Off);
-            }
-        }
-    }
-
-    // Command-origin path for panes with an `exit <N>|?` trailer.
-    // Step 1: command_changed (tick=0) — registers each pane as a pending command.
-    // Step 2: timer(tick=DEBOUNCE_TICKS) — promotes all pending commands to Running.
-    // Step 3: panes_changed with exits — on_exit sets Done/Error + exit_code.
-    for spec in &tabs {
-        for pane in &spec.panes {
-            if let Some(code) = pane.exit_code {
-                // Build argv from the msg string so the CommandStore compacts it
-                // into the display message (e.g. "cargo build" stays "cargo build").
-                let argv: Vec<String> = pane.msg.split_whitespace()
-                    .map(|s| s.to_string())
-                    .collect();
-                radar.command_changed(pane.pane_id, &argv, true, 0);
-                command_exits.push((pane.pane_id, code));
             }
         }
     }

--- a/crates/plugin/src/render.rs
+++ b/crates/plugin/src/render.rs
@@ -1524,22 +1524,19 @@ fn render_body(rows: &[TabRow], ledger: &[LedgerLine], opts: &RenderOpts) -> Vec
     // working" tally computed later in `render_bottom`; the two live in
     // separate pipeline stages (body vs. bottom region) and sharing one
     // number across that seam would cost more plumbing than the one `filter`
-    // it saves. The tab detail's kind gates it to *animating* work: a rail
-    // whose only Running rows are services (steady `▸`, no Fast cadence)
-    // must not draw a sweep that would only teleport once per Slow fire —
-    // motion promises bounded work (`docs/activity-model.md` §1). The
-    // job-over-service tie-break makes the detail-kind check exact: whenever
-    // any Running job exists in a tab, the detail IS a job. The footer tally
-    // deliberately stays Status-only — "1 working" for an up dev server is
-    // honest English, and a count is not an animation.
-    let working = rows.iter().any(|r| {
-        r.display.status == Status::Running
-            // A Running tab always carries a detail in production (`roll_up`
-            // sets one whenever an active pane exists), so the None arm is
-            // unreachable — defaulting it to "animate" keeps the sweep the
-            // fail-visible side of that invariant.
-            && r.display.detail.as_ref().is_none_or(|d| !d.kind.is_service())
-    });
+    // it saves. Two gates: the tab's HEADLINE is Running (a needs-you tab
+    // with a working sibling keeps a calm rule — attention outranks motion),
+    // and `TabDisplay::animating` — the canonical cadence term
+    // (`TrackedObservation::animating`), so the sweep only marches for work
+    // the timer actually animates: a rail whose only Running rows are
+    // services (steady `▸`, no Fast cadence) must not draw a sweep that
+    // would only teleport once per Slow fire — motion promises bounded work
+    // (`docs/activity-model.md` §1). The footer tally deliberately stays
+    // Status-only — "1 working" for an up dev server is honest English, and
+    // a count is not an animation.
+    let working = rows
+        .iter()
+        .any(|r| r.display.status == Status::Running && r.display.animating);
 
     let mut flat: Vec<Line> = Vec::new();
 

--- a/crates/plugin/src/render/tests.rs
+++ b/crates/plugin/src/render/tests.rs
@@ -80,6 +80,11 @@ fn display(
             }]
         })
         .unwrap_or_default();
+    // Mirror `roll_up`: a Running tab animates unless the work is a service
+    // (steady mark, no fast cadence). A detail-less Running fixture animates —
+    // in production a Running status implies an animating observation existed.
+    let animating =
+        status == Status::Running && detail.as_ref().is_none_or(|d| !d.kind.is_service());
     TabDisplay {
         status,
         progress: ProgressCounts {
@@ -89,6 +94,7 @@ fn display(
         },
         detail,
         panes,
+        animating,
     }
 }
 
@@ -306,6 +312,7 @@ fn rendered_rail_tracks_targets_for_each_emitted_line() {
                 pe(10, Kind::Claude, Status::Pending, "approve"),
                 pe(11, Kind::Claude, Status::Running, "tests"),
             ],
+            animating: true,
         }),
         tab(2, "plain", display(Status::Idle, 0, 0, None)),
     ];
@@ -811,6 +818,7 @@ fn multi_pending_detail_never_exceeds_width() {
         },
         detail: Some(detail),
         panes: vec![],
+        animating: false,
     })];
     for width in [14usize, 16, 17, 20, 24] {
         let s = render(&rows, &ro(width, 0));
@@ -1174,6 +1182,13 @@ fn display_multi(panes: Vec<PaneDisplay>) -> TabDisplay {
             ..pd("r", "b", msg.clone(), *pane_status) }),
         _ => None,
     });
+    // Mirror `roll_up`: any Running non-service pane animates the tab.
+    let animating = panes.iter().any(|p| match p {
+        PaneDisplay::Tracked { kind, status, .. } => {
+            *status == Status::Running && !kind.is_service()
+        }
+        _ => false,
+    });
     TabDisplay {
         status,
         progress: ProgressCounts {
@@ -1183,6 +1198,7 @@ fn display_multi(panes: Vec<PaneDisplay>) -> TabDisplay {
         },
         detail,
         panes,
+        animating,
     }
 }
 
@@ -1281,6 +1297,7 @@ fn multi_pane_untracked_only_summary_names_panes() {
             PaneDisplay::untracked(1, "shell"),
             PaneDisplay::untracked(2, "logs"),
         ],
+        animating: false,
     });
     let rows = [row];
     let s = render(&rows, &tight(&rows, ro(30, 0)));
@@ -1307,6 +1324,7 @@ fn multi_pane_mixed_untracked_summary_names_panes() {
             pe(1, Kind::Codex, Status::Running, "tests"),
             PaneDisplay::untracked(2, "shell"),
         ],
+        animating: true,
     });
     let rows = [row];
     let s = render(&rows, &tight(&rows, ro(30, 0)));
@@ -3760,6 +3778,7 @@ fn pending_pane_with_task_renders_identity_plus_question_line() {
             pe_task(10, Kind::Claude, Status::Pending, "approve git push?", "migrate schema"),
             pe_task(11, Kind::Codex, Status::Running, "editing retry.rs", "write tests"),
         ],
+        animating: true,
     });
     let rendered = render_rail(&[row], &[], &ro_comfortable(32, 40));
     let grid = strip_sgr(&rendered.ansi); // use the file's existing ANSI-strip helper

--- a/crates/plugin/src/rollup.rs
+++ b/crates/plugin/src/rollup.rs
@@ -211,6 +211,13 @@ pub struct TabDisplay {
     pub progress: ProgressCounts,
     pub detail: Option<PrimaryDetail>,
     pub panes: Vec<PaneDisplay>,
+    /// Any pane in this tab holds tick-driven motion —
+    /// [`TrackedObservation::animating`], the same canonical term both stores'
+    /// cadence predicates use, so the service exclusion can never half-apply
+    /// between cadence and paint. Render reads this for the header sweep
+    /// instead of re-deriving it from `detail` (which would lean on the
+    /// job-over-service tie-break for correctness).
+    pub animating: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -245,6 +252,7 @@ pub fn roll_up<'a, 'q>(
     let mut done = 0usize;
     let mut total = 0usize;
     let mut pending = 0usize;
+    let mut animating = false;
     let mut pane_displays = Vec::with_capacity(panes.len());
 
     let interactive = |pane_id: u32| {
@@ -296,6 +304,7 @@ pub fn roll_up<'a, 'q>(
                 .unwrap_or_else(|| PaneDisplay::untracked(pane.id, &pane.title));
             pane_displays.push(display);
         }
+        animating = animating || s.animating();
         // Most-urgent active pane wins; on equal severity a bounded *job*
         // outranks a *service* (a spinning build summarizes the tab better
         // than a dev server that is merely up — `docs/activity-model.md` §3);
@@ -332,6 +341,7 @@ pub fn roll_up<'a, 'q>(
         },
         detail: best,
         panes: pane_displays,
+        animating,
     }
 }
 

--- a/docs/activity-model.md
+++ b/docs/activity-model.md
@@ -177,11 +177,15 @@ silently re-creates the trap.
 One state-machine change carries the whole model. In `CommandStore`, a
 `Pending` entry gains `promotable: bool`:
 
-- **Intake** of an interactive-classified foreground command: arm the
+- **Intake** of an interactive-classified command: arm the
   tentative-Done for any prior Running row (opening nvim after `cargo build`
   finished still flips the build to Done), clear the exit dedup (a re-run's
   exit must apply fresh), and insert a **non-promotable pending** carrying
-  the classified identity.
+  the classified identity. The `is_foreground` flag is NOT consulted for an
+  interactive argv: a childless interactive ROOT (`zellij run -- nvim`)
+  reports `false`, and that report is the editor alive, not a prompt return —
+  shell panes can't reach the override because their childless root IS the
+  shell, which the ignore set catches.
 - **Promotion** (`on_timer`) filters on `promotable` — the Running row never
   materializes.
 - **`on_exit` is unchanged** — the surviving pending's identity labels the
@@ -214,10 +218,13 @@ editor closes. The simpler "drop all command-origin Running rows and let
 re-promotion recover" is unsound: re-reports are incidental, not guaranteed
 (the `DEBOUNCE_TICKS` comment in `command.rs` — a dropped edge means nothing
 ever calls `on_command_changed` again), so a legit build row could vanish
-permanently. The sweep matches on the display's first whitespace token,
-which equals the exe
-basename by construction of every display path — pinned by a guard test
-(§7), since three functions hold that invariant.
+permanently. A row whose tentative-Done is already armed is exempt — its
+command has left the foreground, so sweeping it would ghost a quiet label no
+future edge clears; the armed confirm flips it Done instead. Pendings
+re-judge on the intake-stamped peeled program name (structural); only the
+observation sweep matches on the display's first whitespace token, which
+equals the exe basename by construction of every display path — pinned by a
+guard test (§7).
 
 Why identity-preserving suppression rather than the simpler ignore-branch
 (measured cost: ~15 lines — one field, one intake arm, two predicate


### PR DESCRIPTION
Adversarially-verified findings from a full review of the v0.3.1..HEAD release diff, fixed ahead of the 0.4.0 tag.

## Bugs

- **Blank Done row for a held run-pane editor.** A childless interactive root (`zellij run -- nvim`) reports `is_foreground=false` — the flag only encodes "the root has a child" — and intake dropped it as a prompt return, so the quiet pending never formed and the held pane's exit inserted the blank Done row `docs/activity-model.md` §5 promises never happens. Interactive argvs now take the intake arm regardless of the flag; shell panes can't reach the override because their childless root IS the shell, which the ignore set catches. New test pins the run-pane shape end to end (the existing one modeled nvim as a shell's child, `is_foreground=true`).
- **Sweep ghost pending.** `set_interactive_extras` swept rows whose tentative-Done was already armed: a `config.v1` landing inside the debounce window demoted a row whose command had already returned to the prompt and reconstructed a quiet pending nothing ever clears. Armed rows are now exempt; the confirm flips them Running→Done on schedule.

## Hardening / simplification

- **Canonical `animating`.** Render's header sweep re-derived the cadence predicate by hand (detail-kind check leaning on the job-over-service tie-break plus a defensive None arm) next to core's `TrackedObservation::animating`. `TabDisplay` now carries `animating`, computed in `roll_up` from the canonical term, so the service exclusion can never half-apply between cadence and paint. Behavior identical — the rail-reference spec caught and rejected a wider reading on the first attempt.
- **Structural interactive re-judge.** `Pending` stamps the peeled program name at intake; the re-judge matches on that instead of the display's first token. The display-shape guard test narrows to the one remaining site (the observation sweep, which is snapshot-schema-bound).
- **Dedup.** `arm_tentative_done` helper replaces the 7-line fragment duplicated across two branches; the reference-test interactive/exit driver loops merged into one intake loop.

## Verified won't-fix

- Fully-synchronous notify.sh dispatch (PR #16's stuck-spinner fix; PR #18 already bounded the hot path at 2 s).
- Config-race swallowed Done (quiet treatment is exactly what the config asked for).
- Quiet pendings staying out of the shared snapshot (late-created instances reconverge via the Done TTL).

Full suite green: `just ci` + live E2E (13/13) on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)