### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "zj-radar"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "assertables",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "zj-radar-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "proptest",
  "serde",
@@ -3368,7 +3368,7 @@ dependencies = [
 
 [[package]]
 name = "zj-radar-plugin"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "insta",
  "portable-pty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/core", "crates/cli", "crates/plugin"]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/marktoda/zj-radar"
@@ -22,7 +22,7 @@ rust-version = "1.95"
 # would let an older published CLI resolve a newer, incompatible core and stop
 # compiling. Bump this in lockstep with [workspace.package] version — the
 # release checklist (RELEASING.md) walks through it.
-zj-radar-core = { path = "crates/core", version = "=0.3.1" }
+zj-radar-core = { path = "crates/core", version = "=0.4.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 unicode-width = "0.2"

--- a/plugins/zj-radar-claude/.claude-plugin/plugin.json
+++ b/plugins/zj-radar-claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zj-radar-claude",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Broadcast Claude Code agent status to the zj-radar Zellij sidebar (working/waiting/done), with zero settings.json editing.",
   "author": { "name": "Mark Toda" },
   "homepage": "https://github.com/marktoda/zj-radar"


### PR DESCRIPTION
0.4.0 bump in the three synced sites (workspace version, exact core pin, plugin.json) per RELEASING.md step 1, plus the lockfile.

Release flow after merge: `just ci` + MSRV green on the release commit → publish core → publish cli → signed tag `v0.4.0` → wait for the funnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)