### PR TITLE
docs: full accuracy sweep vs v0.4.0 (+ runnable doctor remedy)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,9 @@ Entry point for AI agents (and humans skimming) working in zj-radar. Keep this
 thin — it points at the real docs rather than duplicating them.
 
 zj-radar is a native [Zellij](https://zellij.dev) sidebar (Rust → `wasm32-wasip1`)
-plus a host-side `zj-radar` CLI and a Claude Code producer plugin.
+plus a host-side `zj-radar` CLI and producer adapters for Claude Code (a bundled
+Claude plugin) and Codex (hooks installed by `zj-radar setup codex`) — both
+first-class producers.
 
 ## Read first
 
@@ -14,6 +16,9 @@ plus a host-side `zj-radar` CLI and a Claude Code producer plugin.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — project shape, full build/test/lint
   details, PR expectations.
 - [`docs/design.md`](docs/design.md) — the canonical living design.
+- [`docs/activity-model.md`](docs/activity-model.md) — the status/kind semantics:
+  attention classes (Job/Service/Companion), interactive-command suppression,
+  cadence rules.
 
 ## Commands
 
@@ -29,28 +34,41 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
 The `wasm32-wasip1` target is requested by `rust-toolchain.toml` and
-auto-installs on first build (see [`docs/TOOLCHAIN.md`](docs/TOOLCHAIN.md)). Most
-of the core lives in `crates/core` and is host-testable — no wasm build needed
-for typical work.
+auto-installs on first build (see [`docs/TOOLCHAIN.md`](docs/TOOLCHAIN.md)). The
+domain logic (`RadarState`, render, runtime, rollup, ledger, sessions) lives in
+`crates/plugin`, with the shared wire/classification layer in `crates/core` —
+both are host-testable (`zellij-tile` is `cfg(target_arch = "wasm32")`-scoped),
+so no wasm build is needed for typical work.
 
 ## Non-negotiable rules
 
 - **Do not run `rustfmt` / `cargo fmt`.** The code is intentionally hand-formatted
   (e.g. aligned one-line multi-field structs). A `cargo fmt` diff will be rejected.
   Match the surrounding code.
-- **Push-driven, never poll-driven.** The plugin must not issue blocking host
-  queries (`get_pane_running_command`, etc.); status arrives via `zellij pipe`
-  broadcasts. Polling melted the predecessor plugin — see
+- **Push-driven, never poll-driven.** No polling, and no per-event or per-tick
+  blocking host queries (`get_pane_running_command`, etc.); status arrives via
+  `zellij pipe` broadcasts. The single exception is the once-per-pane
+  `Effect::ResolveCwd` naming bootstrap (one blocking `get_pane_cwd` per
+  freshly-opened pane — pane-creation rate, never re-polled). Polling melted
+  the predecessor plugin — see
   [`docs/smart-tabs-postmortem.md`](docs/smart-tabs-postmortem.md).
 - **Rail lockstep.** Emitted ANSI and the click-target map stay in exact 1:1 line
   correspondence (`CONTEXT.md` → *Lockstep*). Keep it structural, not
   discipline-held.
-- `docs/rail-reference.md` is an executable spec — it is `include_str!`'d by
-  `crates/plugin/src/reference_tests.rs`. Edit it through that test, not casually.
+- Some files are welded to tests — edit them through the test, not casually:
+  `docs/rail-reference.md` is an executable spec (`include_str!`'d by
+  `crates/plugin/src/reference_tests.rs`);
+  `plugins/zj-radar-claude/hooks/hooks.json` timeouts must clear the pipe-send
+  cap plus 2s (`crates/plugin/src/hooks_manifest_tests.rs`); and
+  `docs/configuration.md`'s pipe names and cmd verbs are pinned by tests in
+  `crates/plugin/src/config.rs` and `crates/plugin/src/control.rs`.
 
 ## Adding a producer or agent
 
-The only external interface is the versioned `zj_radar.status.v1` pipe payload.
+The producer interface is the versioned `zj_radar.status.v1` pipe payload. (The
+plugin's other external contracts: the `zj_radar.cmd.v1` keybind-verb pipe and
+`zj_radar.config.v1` live-override pipe — both in `docs/configuration.md` — and
+the cross-process presence-file format, `crates/plugin/src/presence.rs`.)
 New instrumented agent → `enum Agent` variant in `crates/cli/src/agents/` +
 `Agent::derive`; the `source_round_trips_through_kind` guard test tells you what
 else to wire. Observed (uninstrumented) commands like `cargo test` are classified

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,7 +8,9 @@ zj-radar's architecture, focusing on the key interfaces and state flows.
 The rendered sidebar: the pinned left column listing every tab with per-tab agent
 status. The **rail seam** is the renderer's single deep interface —
 `render_rail(rows, ledger, opts) -> RenderedRail` (with `onboarding(opts) -> RenderedRail`
-as the sibling face for the no-agents-yet state). Everything a caller needs to draw and to resolve a
+as the sibling face for the no-agents-yet state, and
+`needs_permission(opts, grant_hint) -> RenderedRail` as the third face for the
+not-yet-granted state). Everything a caller needs to draw and to resolve a
 click crosses this one seam; layout planning (overflow folding, card spacing,
 multi-pane tree expansion) is implementation *behind* it, not interface.
 
@@ -22,19 +24,26 @@ character grid, so layout and color are orthogonal and testable apart.
 ## RenderedRail
 
 The rail seam's output: the emitted `ansi` paired with a same-height
-**target map**. `target_at_line(line)` resolves a physical line to a `RailTarget`
-(a tab to switch to, or a pane to show); header / gap / idle-strip lines resolve
-to `None`. The runtime caches the last `RenderedRail` and resolves mouse clicks
+**target map** and a same-height **hotspot map**. `target_at_line(line)`
+resolves a physical line to a `RailTarget` (a tab to switch to, a pane to
+show, or a session to switch to); header / gap / idle-strip lines resolve to
+`None`. `hotspot_at(line, col)` resolves column-aware: each hotspot entry is
+`Option<(start_col, HotspotAction)>`, and only the glyph's own display cells
+trigger it — a `HotspotAction::DismissPresence` (`✕` on a stale session-badge
+line) or `HotspotAction::Acknowledge` (`✓` on an unacknowledged status-origin
+Pending). The runtime caches the last `RenderedRail` and resolves mouse clicks
 against it — so the rail the user sees *is* the rail clicks are scored against.
 
 ## RailTarget
 
-What a clickable line resolves to: a tab to switch to (`tab_position`) or a
-specific pane to show (`pane_id`) — for an expanded multi-pane row's tree
-lines, or for a single-pane tab's line-2 detail line(s), which target that
-tab's one tracked pane. Header, gap, and idle-strip lines have no
-`RailTarget`. The runtime turns a `RailTarget` into a `SwitchTab` / `ShowPane`
-effect on click.
+What a clickable line resolves to: a tab to switch to (`tab_position`), a
+specific pane to show (`pane_id`), or a peer session to switch to
+(`session: Option<String>`, carrying the peer's attention tab). Pane targets
+cover an expanded multi-pane row's tree lines *and* a single-pane tab's pane
+line and line-2 detail line(s), which target that tab's one tracked pane.
+Header, gap, and idle-strip lines have no `RailTarget`. The runtime turns a
+`RailTarget` into a `SwitchTab` / `ShowPane` / `SwitchSession` effect on
+click.
 
 ## RadarState
 
@@ -66,6 +75,16 @@ were looking at, leaving every other tab stale. That focus-driven recede is gone
 `RadarState::note_focus` still records the focused terminal, but *only* so the
 notifier can suppress the pane you're watching — it never mutates a status.
 
+Pruning has a **one-manifest grace** (`absent_once`): a tracked pane's first
+absence from the pane manifest is held, not pruned — Zellij's break-pane
+family reports session state while a moved pane is extracted and in no tab,
+so a single absence can't distinguish a close from a mid-move flash. A pane
+still absent on the *next* manifest is confirmed gone and prunes then, filed
+in the ledger under the tab identity captured at first absence (by the
+confirming manifest the live index no longer carries it). Level-triggered:
+the grace set is recomputed from the current manifest every `panes_changed`,
+so a reappearing pane simply drops out.
+
 The runtime owns host concerns: permission flow, timers, rendered-rail caching,
 and turning repo-owned outcomes into Zellij effects. The rail owns layout and
 click-target lockstep. `RadarState` owns the domain facts between those seams.
@@ -89,15 +108,25 @@ handler by construction.
 
 **Cadence** is a related but distinct axis — how often the one-shot timer
 re-fires, not whether it notifies. Two speeds (`PluginRuntime::desired_cadence`):
-Fast (1 Hz) while there's tick-windowed work — `needs_fast_ticks` (a spinning
-glyph), an un-carried completion edge (a status-pipe recede/notify deferred to
-the timer because its own focus can't be trusted), a command `Done` awaiting
-its `DONE_TTL_TICKS` recede, or an active ping flash. Slow (1/60 Hz — once a
-minute) once none of that holds but a ledger entry is still un-saturated
-(`ledger_any_unsaturated`): nothing is animating, but a displayed age is still
-changing. Fully disarmed (`None`) once every ledger age has hit `1h+` — the
-saturation cutoff (`## Ledger`) is exactly what lets the timer stop for good
-instead of ticking forever to redraw an age that will never change again.
+Fast (1 Hz) while there's tick-windowed work — the permission flow still live
+(`permission.is_waiting()` / `selectable()`), `timer_should_continue` (a
+spinning glyph via `needs_fast_ticks`, an un-carried completion edge — a
+status-pipe recede/notify deferred to the timer because its own focus can't be
+trusted — a command `Done` awaiting its `DONE_TTL_TICKS` recede, or an active
+ping flash), or a pending cross-session cycle selection awaiting its
+idle-commit (`sessions.wants_fast_cadence()`). Slow (1/60 Hz — once a minute)
+once none of that holds but a minute-granular age is still changing — a
+ledger entry (`ledger_any_unsaturated`) or a pending row's `· Nm` wait tag
+(`pending_wait_unsaturated`) short of the `1h+` saturation cutoff — **and
+unconditionally while `own_session_name` is non-empty**: a known name means a
+presence file is published, and the Slow tick's heartbeat is the only writer
+keeping its mtime fresh for peers (`## Cross-session presence`). Full disarm
+(`None`) therefore survives in exactly two shapes: *pre-name* (no `ModeUpdate`
+has delivered a session name yet, and every age has saturated) and *denied*
+(a permission-denied rail disarms unconditionally — without
+`ReadApplicationState` no clearing event ever arrives, so a snapshot-loaded
+stale `Running` would otherwise pin Fast ticks forever behind a static
+needs-permission face).
 
 ## Render gate
 
@@ -221,21 +250,24 @@ is not naming policy.
 
 ## Lockstep
 
-The load-bearing invariant of the rail: the emitted ANSI and the click-target map
-stay in exact 1:1 line correspondence. `line_count() == ansi newline count`, and
-every drawn line maps to the intended target (or a deliberate `None`). Lockstep is
-why click-to-switch lands on the row the user pointed at. Lockstep is now
-structural, not discipline-held: `render_rail` builds a single `Vec<Line>` where
-each line carries its own `RailTarget`, and `ansi`/`targets`/line-count all derive
-from that one list via `RenderedRail::from_lines`. There is no separate height
-predictor — a row's footprint is `block.len()` of the very lines it renders — so
-the emitted ANSI and the click-target map cannot drift.
+The load-bearing invariant of the rail: the emitted ANSI, the click-target
+map, and the hotspot map stay in exact 1:1 line correspondence — three
+parallel vectors (`ansi`, `targets`, `hotspots`). `line_count() == ansi
+newline count`, and every drawn line maps to the intended target and hotspot
+(or a deliberate `None`). Lockstep is why click-to-switch lands on the row the
+user pointed at — and why a `✕`/`✓` glyph hotspot fires only on its own cells.
+Lockstep is now structural, not discipline-held: `render_rail` builds a single
+`Vec<Line>` where each line carries its own `RailTarget` and optional
+`(start_col, HotspotAction)`, and `ansi`/`targets`/`hotspots`/line-count all
+derive from that one list via `RenderedRail::from_lines`. There is no separate
+height predictor — a row's footprint is `block.len()` of the very lines it
+renders — so the emitted ANSI and the click maps cannot drift.
 
 ## Status contract
 
 The real external seam between producers and the plugin: the versioned
 `zj_radar.status.v1` pipe payload (`{v, source, pane, status, repo, branch,
-msg, task}`). Producers (the Claude plugin, the Codex CLI) are adapters that
+msg, task, ack}`). Producers (the Claude plugin, the Codex CLI) are adapters that
 broadcast it; the plugin defends itself at parse time (sanitize, truncate, drop
 oversized/malformed). Ordering is latest-wins — the pipe delivers in order and no
 producer stamps a sequence, so there is nothing to reorder. Unknown fields are
@@ -243,7 +275,27 @@ tolerated and ignored, so older producers still parse: a legacy `seq` and the
 former `on_focus` clear-on-focus hint (dropped when focus stopped driving state)
 both round-trip harmlessly. `task` (optional): sticky task label — empty/absent
 leaves the stored label unchanged, non-empty replaces it; the plugin clears it
-on idle and on return-to-shell.
+on idle and on return-to-shell. `ack` (optional, default false): "the user has
+already seen this" — state converges as usual but the notifier stays silent.
+
+The pipe is no longer strictly producer→plugin one-way: the plugin is itself a
+caller. The rail's acknowledge gesture broadcasts a synthetic `status.v1`
+payload (Pending → Done, `ack: true`) rather than mutating local state, so the
+dismissal converges across every tab's instance through the exact same intake
+a real producer's broadcast uses (`Effect::BroadcastStatus`).
+
+**Bounded sends.** `zellij pipe` is a backpressure channel: the client process
+is held until *every* loaded plugin instance consumes the message, and an
+instance wedged at Zellij's permission prompt holds it forever — unbounded
+sends at hook rate once turned one wedged rail into an EMFILE crash of the
+whole session. Every caller therefore sends through the self-limiting `sh`
+subtree built by `core/pipe.rs::self_limiting_pipe_argv`: a detached
+sleep+kill watchdog rides inside the spawned subtree and reaps its own hung
+client even if the caller is killed mid-send. Deadlines are status-keyed —
+`DEFAULT_PIPE_TIMEOUT_SECS` (5s) for the once-per-turn edges,
+`RUNNING_PIPE_TIMEOUT_SECS` (2s) for `running` heartbeats (a dropped heartbeat
+is replaced by the next tool event; a dropped edge loses real state). The
+plugin's own ack broadcast goes through the same argv.
 
 ## Information source
 
@@ -267,20 +319,39 @@ a `Kind`-keyed `Status`:
   row: they record a quiet pending whose identity labels exits and the muted
   pane label (`docs/activity-model.md`).
 
-The two modalities also interact at *exit*: a pushed producer (an agent) fires no
-hook when it quits, so its last status (`done`/`pending`/`error`) would otherwise
-linger forever. When the observed layer sees that pane return to a shell prompt
-(`command::is_shell_prompt` — no foreground command, or a shell/prompt program),
-`RadarState` clears the stale pushed status to idle (`StatusStore::clear_on_prompt_return`).
-The clear ignores a `Running` status — a live turn re-asserts `Running` via its
-hooks, so a transient foreground flicker can't be mistaken for the agent exiting.
-Because it rides the shared `CommandChanged` signal (not per-client focus), every
-tab's instance clears in lockstep.
+The two modalities also interact at *exit* — the **producer-death model**. A
+pushed producer (an agent) fires no hook when it quits, so its last status
+would otherwise linger forever. The model: (agent argv present, `exited` =
+false) = alive; `exited` = dead. Three paths converge on it:
+
+- **Prompt return.** When the observed layer sees the pane return to a shell
+  prompt (`command::is_shell_prompt` — no foreground command, or a
+  shell/prompt program), `RadarState` clears a stale terminal status
+  (`done`/`pending`/`error`) to idle
+  (`StatusStore::clear_on_prompt_return`). A `Running` status is *not*
+  cleared immediately — a live turn's foreground can flicker through the
+  shell mid-turn — it instead arms a **stale-Running grace clock**
+  (`RUNNING_SUSPECT_GRACE_TICKS`, ~15 Fast ticks). If the clock outlives the
+  window, `expire_stale_running` clears the row: the producer died mid-turn
+  and will never send the clearing broadcast.
+- **Live-again evidence.** The agent's exe reappearing as the pane's
+  foreground command cancels the grace clock
+  (`cancel_running_suspect`) — the flicker resolved as a flicker. Other
+  commands don't vouch: a command run in the shell an agent died in must not
+  keep its ghost alive.
+- **Definitive death.** The pane manifest's `exited` flag is producer death,
+  full stop — an agent-rooted pane (`zellij run -- claude`) never shows a
+  shell prompt for the first path to see. `StatusStore::clear_on_exit`
+  clears even a `Running` immediately, no grace clock.
+
+All three ride shared signals (`CommandChanged`, the pane manifest, the
+shared timer — not per-client focus), so every tab's instance clears in
+lockstep.
 
 Both modalities emit a `source` string that must be a subset of `Kind`
 (`Kind::from_source`). Both halves are guarded: the agent half by
 `source_round_trips_through_kind` (in `crates/cli/src/agents`), the command half by
-`classify_source_round_trips_through_kind` (in `crates/core/src/command.rs`) — each pins that its
+`classify_source_round_trips_through_kind` (in `crates/core/src/command/tests.rs`) — each pins that its
 classifier's `source` token round-trips back to the same `Kind`, never the
 `Other` sentinel.
 
@@ -293,7 +364,7 @@ never derived from tab names — a single tab can hold several agent panes.
 The **roll-up seam** is `rollup::roll_up(panes, resolve, quiet) -> TabDisplay`
 (in `crates/plugin/src/rollup.rs`): a deep, pure module that owns its output
 vocabulary (`TabDisplay`, `PaneDisplay`,
-`PrimaryDetail`, `ProgressCounts`, `Outcome`) — the renderer *consumes* these, so
+`PrimaryDetail`, `ProgressCounts`, `ExitOutcome`) — the renderer *consumes* these, so
 presentation depends on the roll-up, not the reverse. `resolve(pane_id) ->
 Option<&TrackedObservation>` is the main thing crossing in: the "status pipe wins
 over command" precedence across observation sources stays in `RadarState`
@@ -303,15 +374,17 @@ from the command store's quiet pendings); `roll_up` owns its precedence — show
 only where no live observation outranks it, contributing nothing to counts or
 severity. On equal severity, a bounded job outranks a service for the primary
 detail (`docs/activity-model.md` §3).
-`Outcome`'s display methods
-(`full`/`minimal`/`role` — glyphs and width-driven forms) live in `render`; the
-enum here is pure semantics.
+`ExitOutcome`'s display methods
+(`full`/`minimal`/`role`/`renders_tag` — glyphs and width-driven forms) live in
+`render`; the enum here is pure semantics. (Not to be confused with the
+runtime's `Outcome`, which names its `{render, effects}` return value.)
 
 ## Setup analysis
 
 How `zj-radar setup` learns the current state of the world. The **setup-analysis
-seam** is `analyze(&Env) -> Facts`, one per target (`analyze_zellij`,
-`analyze_codex` in `crates/cli/src/setup/analyze.rs`): a pure derivation fed a thin
+seam** is a pure analyze function per target —
+`analyze_zellij(&ZellijEnv) -> ZellijFacts` and `analyze_codex(&CodexEnv) ->
+CodexFacts` in `crates/cli/src/setup/analyze.rs` — each fed a thin
 `Env` of already-read values (file contents, fs stat booleans) by the IO shell.
 `Facts` (`ZellijFacts`, `CodexFacts`) is the single home for every derived fact —
 "is our alias present?" (managed vs unmanaged kept distinct), has-rail, granted,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,11 @@ zj-radar is a three-member Cargo workspace:
 
 | Path | What it is |
 |------|------------|
-| `crates/core/` | Pure shared library (`zj_radar_core`): the versioned wire schema and status/command classification (`command`, `kind`, `observation`, `payload`, `status`, `wire`). No `clap`, no `zellij-tile`. |
+| `crates/core/` | Pure shared library (`zj_radar_core`): the versioned wire schema and status/command classification (`command`, `kind`, `observation`, `payload`, `pipe`, `status`, `wire`). No `clap`, no `zellij-tile`. |
 | `crates/cli/` | The native `zj-radar` CLI (`notify`, `setup`, `run`). `build.rs` embeds the wasm via `include_bytes!`. |
 | `crates/plugin/` | The Zellij sidebar wasm plugin (`zj_radar_plugin`, Rust → `wasm32-wasip1`). A thin Zellij adapter (`lib.rs`/`main.rs`, wasm-only) over host-testable modules (runtime, stores, model, renderer). |
 | `plugins/zj-radar-claude/` | The Claude Code producer plugin (hooks + bundled `notify.sh`). |
-| `docs/` | Living design docs. Start with [`CONTEXT.md`](CONTEXT.md) (domain glossary) and [`docs/design.md`](docs/design.md). |
+| `docs/` | Living design docs. Start with [`CONTEXT.md`](CONTEXT.md) (domain glossary), [`docs/design.md`](docs/design.md), and [`docs/activity-model.md`](docs/activity-model.md) (how pane activity maps to the statuses the rail shows). |
 
 Two ideas are load-bearing — read [`CONTEXT.md`](CONTEXT.md) before changing the
 core:
@@ -37,7 +37,8 @@ core:
   job builds with exactly that toolchain, so language/stdlib features newer
   than 1.95 will fail the PR. Dev otherwise tracks `stable`.
 - For the full suite: `just`, plus `bats`, `shellcheck`, and `jq` (bash hook
-  tests) and `zellij` on `PATH` (live E2E).
+  tests) and `zellij` ≥ 0.44.3 on `PATH` (live E2E — the version the plugin's
+  `zellij-tile` pin targets; the harness warns on other versions).
 - Optional: Nix. `nix develop` drops you into a shell with everything pinned;
   `nix flake check` runs the same checks the `hermetic` CI job uses.
 
@@ -65,7 +66,7 @@ Run a single test with `cargo test <name>` (scope it with e.g.
 it with `just review` (`cargo insta review`).
 
 - The shared core (`status`, `payload`, `command`, `kind`, `observation`,
-  `wire`) lives in `crates/core`; the sidebar's own modules (`render`, `rollup`,
+  `pipe`, `wire`) lives in `crates/core`; the sidebar's own modules (`render`, `rollup`,
   `radar_state`, `config`, `theme`, `session_files`, …) live in
   `crates/plugin/src`. Neither carries a `zellij-tile` dependency on the native
   target, so both run host-side — no wasm needed for most work.
@@ -74,8 +75,17 @@ it with `just review` (`cargo insta review`).
   CI fails on unreviewed snapshot drift.
 - **E2E is serial by design** (`--test-threads=1`): each test spawns its own
   Zellij session and parallel sessions contend at startup. It runs nightly on
-  both OSes, on PRs that touch the plugin/core/producer paths (ubuntu only),
-  and as a release gate — not on every push.
+  both OSes, on PRs that touch what it exercises (plugin/core/producer paths,
+  plus `Cargo.lock`, `justfile`, the flake files, and the workflow itself —
+  ubuntu only), as a release gate, and on demand via `workflow_dispatch` — not
+  on every push.
+- **Some docs and assets are test inputs**, wired in via `include_str!`:
+  `docs/rail-reference.md` is an executable spec (`reference_tests.rs`), the
+  pipe names/verbs in `docs/configuration.md` are guard-tested (`config.rs`,
+  `control.rs`), the plugin pins `notify.sh`'s pipe name (`lib.rs`),
+  `hooks.json` timeouts are checked for headroom (`hooks_manifest_tests.rs`),
+  and `examples/radar-sidebar.kdl` is validated by `layout.rs`. Editing or
+  renaming any of these can fail `just test` — that's by design.
 
 ## Lint & formatting
 
@@ -88,8 +98,17 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 > run `cargo fmt` / `cargo fmt --all` — it would reformat the whole codebase and
 > the diff will be rejected. Match the formatting of the surrounding code.
 
-`shellcheck` runs over `plugins/zj-radar-claude/scripts/notify.sh` in CI; run it
-locally if you touch the script.
+`just test-bash` shellchecks every shipped shell script
+(`plugins/zj-radar-claude/scripts/notify.sh`, `scripts/install.sh`,
+`scripts/funnel.sh`) and runs the bats suites in `plugins/zj-radar-claude/tests`
+and `scripts/tests`; run it locally if you touch any of them.
+
+Dependency advisories are checked by a nightly `cargo deny check advisories
+licenses sources` CI job (config in `deny.toml`) — deliberately not a PR gate,
+since the advisory DB updates daily and would fail PRs for problems they didn't
+introduce. Reproduce locally with `cargo deny check`
+([`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny) is available in
+the Nix dev shell; otherwise install it separately).
 
 ## Dev loop
 
@@ -116,7 +135,12 @@ details.
    or `rail-reference.md` scenario; new wire/parse behavior → a unit/proptest.
 5. Update docs (`README.md`, `docs/`, `CONTEXT.md`) when behavior or interfaces
    change.
-6. Don't commit generated artifacts (`target/`) or editor/tool state.
+6. **Hermetic build:** any new `include_str!`/`include_bytes!` of a non-Rust
+   file must be whitelisted in `flake.nix`'s source filter, or the crane build
+   can't see the file. Only the `hermetic` CI job (`nix flake check`, nightly
+   and on PRs targeting `main`) exercises that filter — plain `cargo` builds
+   won't catch the miss.
+7. Don't commit generated artifacts (`target/`) or editor/tool state.
 
 ## Adding a producer or an agent
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ or dismiss a dead peer session (details below).
   <img alt="Zellij plugin" src="https://img.shields.io/badge/zellij-plugin-8A2BE2">
   <img alt="Claude Code" src="https://img.shields.io/badge/Claude%20Code-supported-orange">
   <img alt="Codex" src="https://img.shields.io/badge/Codex-supported-black">
-  <img alt="Status" src="https://img.shields.io/badge/status-alpha-yellow">
+  <img alt="Status" src="https://img.shields.io/badge/status-beta-blue">
 </p>
 
 <p align="center">
@@ -50,12 +50,16 @@ wrapping your agents. It's a status rail for the session you already run.
 - See which Claude Code / Codex tabs are **working, done, errored, or waiting for you**.
 - **Jump directly** to the tab that needs attention (bind `attention-next` — see [binding keys to commands](https://github.com/marktoda/zj-radar/blob/main/docs/configuration.md#binding-keys-to-commands)).
 - Keep your existing Zellij workflow — **no new terminal, no tmux wrapper, no agent orchestrator**.
-- **Push-driven** updates via `zellij pipe`; no pane polling, no blocking host queries.
+- **Push-driven** updates via `zellij pipe`; no pane polling, no per-output host queries.
 - Works with **Claude Code** today, **Codex** via the native CLI, and any
   [custom producer](https://github.com/marktoda/zj-radar/blob/main/docs/producers.md#writing-your-own-producer) that can send JSON.
 - Running more than one Zellij session? A **cross-session badge** shows every
   other session's live status-origin pane counts, with click-to-switch and a
   `session-next`/`session-prev` cycle — see below.
+- Observed commands get **per-class presentation**: long jobs spin with a `· 4m`
+  run tag, dev servers hold a steady `▸`, and editors/pagers/TUIs never spin —
+  just a muted identity label. See
+  [`docs/activity-model.md`](https://github.com/marktoda/zj-radar/blob/main/docs/activity-model.md).
 
 ## Quick start
 
@@ -70,9 +74,9 @@ wrapping your agents. It's a status rail for the session you already run.
 curl --proto '=https' --tlsv1.2 -LsSf \
   https://github.com/marktoda/zj-radar/releases/latest/download/install.sh | sh
 
-# 2. Install the sidebar: the wasm, the `radar` alias in config.kdl, the rail
-#    in your default layout, and Zellij's permission grant — each behind its
-#    own y/N prompt. (--download fetches the wasm for this CLI's version)
+# 2. Install the sidebar: the wasm + `radar` alias in config.kdl, the rail
+#    in your default layout, and Zellij's permission grant — three y/N
+#    prompts, one per step. (--download fetches the wasm for this CLI's version)
 zj-radar setup zellij --download
 
 # 3. Start (or restart) Zellij — the sidebar comes up live. (Declined the
@@ -106,10 +110,11 @@ Custom producers are in **[`docs/producers.md`](https://github.com/marktoda/zj-r
 ## How it works
 
 zj-radar is **push-driven, not poll-driven**: status arrives via an explicit
-`zellij pipe` broadcast from per-agent hooks. The plugin never issues blocking
-host queries (`get_pane_running_command`, etc.). This is a deliberate, hard
-constraint — the predecessor plugin (`smart-tabs`) melted a many-agent session
-by polling every pane on every output event; see
+`zellij pipe` broadcast from per-agent hooks. The plugin never polls: the one
+blocking host call it makes (`get_pane_cwd`, to bootstrap a new pane's tab
+name) fires at most once per pane, at pane-creation rate. This is a deliberate,
+hard constraint — the predecessor plugin (`smart-tabs`) melted a many-agent
+session by polling every pane on every output event; see
 [`docs/smart-tabs-postmortem.md`](https://github.com/marktoda/zj-radar/blob/main/docs/smart-tabs-postmortem.md).
 
 The wire format is a single versioned JSON payload (`zj_radar.status.v1`), so a
@@ -197,6 +202,7 @@ plugins {
         notify_error true
         notify_pending true
         notify_when_focused false  // suppress when the pane is focused
+        interactive_commands ""    // extra editors/pagers/TUIs to keep quiet (extends the built-in set)
     }
 }
 ```
@@ -214,13 +220,15 @@ The full option table, keybindings for runtime config, and `attention-next` /
 
 ## Producers
 
-A producer broadcasts agent status to the sidebar. zj-radar ships two and
+A producer broadcasts agent status to the sidebar. zj-radar ships three and
 documents the wire format so you can write your own:
 
 - **Claude Code** — a Claude plugin that auto-registers status hooks (no
   `settings.json` editing).
 - **Codex / native CLI** — `zj-radar notify` + `zj-radar setup codex`.
-- **Custom** — broadcast a `zj_radar.status.v1` JSON payload from anything.
+- **Custom** — `zj-radar notify generic --status/--msg/--task/--source` from
+  any script (no JSON needed), or broadcast a `zj_radar.status.v1` JSON
+  payload from anything.
 
 See **[`docs/producers.md`](https://github.com/marktoda/zj-radar/blob/main/docs/producers.md)** for install steps, the payload
 schema, and a copy-paste smoke test.
@@ -232,6 +240,8 @@ schema, and a copy-paste smoke test.
 | [`docs/install.md`](https://github.com/marktoda/zj-radar/blob/main/docs/install.md) | Full sidebar install: CLI + manual setup, layout templates, permissions, remote-URL caveat, Nix / home-manager. |
 | [`docs/producers.md`](https://github.com/marktoda/zj-radar/blob/main/docs/producers.md) | Claude Code, Codex, and writing your own producer (payload schema + smoke test). |
 | [`docs/configuration.md`](https://github.com/marktoda/zj-radar/blob/main/docs/configuration.md) | Density/naming/header/glyphs, runtime config, and keybindings. |
+| [`docs/activity-model.md`](https://github.com/marktoda/zj-radar/blob/main/docs/activity-model.md) | Attention/activity semantics: jobs vs services vs interactive programs, and how each renders. |
+| [`docs/rail-reference.md`](https://github.com/marktoda/zj-radar/blob/main/docs/rail-reference.md) | The executable render spec — `include_str!`'d by the plugin's reference tests. |
 | [`docs/troubleshooting.md`](https://github.com/marktoda/zj-radar/blob/main/docs/troubleshooting.md) | The two-template rule, first-run prompt coordination, and reload quirks. |
 | [`docs/design.md`](https://github.com/marktoda/zj-radar/blob/main/docs/design.md) | The canonical living design. |
 | [`docs/smart-tabs-postmortem.md`](https://github.com/marktoda/zj-radar/blob/main/docs/smart-tabs-postmortem.md) | Why the polling predecessor was scrapped (the push-driven origin story). |
@@ -242,6 +252,9 @@ schema, and a copy-paste smoke test.
   overflow folding, theme-derived card surfaces, runtime config.
 - ✅ **Cross-session badge** — see [Cross-session badge](#cross-session-badge)
   above; click-to-switch and `session-next`/`session-prev` cycling.
+- ✅ **Activity model** — observed commands classified as job / service /
+  interactive, each with its own presentation (spinner + run tag, steady `▸`,
+  muted label); see [`docs/activity-model.md`](https://github.com/marktoda/zj-radar/blob/main/docs/activity-model.md).
 - ✅ **Claude Code producer** — ships as a Claude plugin (`plugins/zj-radar-claude`).
 - ✅ **`zj-radar` CLI** — native, jq-free `notify` (Claude + Codex) and
   conflict-aware `setup`; see [`docs/producers.md`](https://github.com/marktoda/zj-radar/blob/main/docs/producers.md#codex-and-the-native-cli).
@@ -289,7 +302,7 @@ The hero GIF is reproducible — its VHS tape and recording script live in
 
 | Path | What it is |
 |------|------------|
-| `crates/core/` | Pure shared library (`zj_radar_core`): the versioned wire schema + status/command classification (`command`, `kind`, `observation`, `payload`, `status`, `wire`). No `clap`, no `zellij-tile` — fully host-testable. |
+| `crates/core/` | Pure shared library (`zj_radar_core`): the versioned wire schema + status/command classification + self-limiting pipe sends (`command`, `kind`, `observation`, `payload`, `pipe`, `status`, `wire`). No `clap`, no `zellij-tile` — fully host-testable. |
 | `crates/cli/` | Host-side `zj-radar` CLI (package `zj-radar`). `build.rs` embeds the wasm at compile time via `include_bytes!`. Built with `-p zj-radar`. |
 | `crates/plugin/` | The Zellij sidebar **wasm plugin** (`zj_radar_plugin`, Rust → `wasm32-wasip1`): the rail renderer, roll-up, radar-state, tab naming, runtime, and the thin `register_plugin!` wasm wiring. Built with `-p zj-radar-plugin`. |
 | `plugins/zj-radar-claude/` | A **Claude Code plugin** that broadcasts agent status via hooks — no `settings.json` editing. |
@@ -297,11 +310,11 @@ The hero GIF is reproducible — its VHS tape and recording script live in
 | `demo/` | The reproducible VHS tape + script behind the hero GIF. |
 
 The shared wire/classification core (`command`, `kind`, `observation`, `payload`,
-`status`, `wire`) lives in `crates/core`. The sidebar's own modules (`radar_state`,
-`rollup`, `render`, `tab_namer`, `config`, `theme`, `session_files`, `runtime`,
-`status_store`, `notify_rules`) live in `crates/plugin/src` — but they too carry no
-`zellij-tile` dependency and are fully host-testable. Only `crates/plugin/src/lib.rs`
-touches the Zellij host API, and that surface is gated behind
+`pipe`, `status`, `wire`) lives in `crates/core`. The sidebar's own modules
+(`radar_state`, `rollup`, `render`, `runtime`, `tab_namer`, and friends) live in
+`crates/plugin/src` — but they too carry no `zellij-tile` dependency and are
+fully host-testable. Only `crates/plugin/src/lib.rs` (plus `main.rs`'s one-line
+`register_plugin!`) touches the Zellij host API, and that surface is gated behind
 `#[cfg(target_arch = "wasm32")]` (the dependency itself is scoped to the wasm target
 in `crates/plugin/Cargo.toml`). See [`docs/TOOLCHAIN.md`](https://github.com/marktoda/zj-radar/blob/main/docs/TOOLCHAIN.md).
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,6 +26,11 @@ before the tag**. The order below matters; each step gates the next.
    version is `rust-version` in the root `Cargo.toml`; bump it there if the
    dependency floor rose).
 
+   Also glance at the latest nightly canaries: the `hermetic` and `deny` jobs
+   in `ci.yml`, and `funnel.yml`'s run against `latest`. A red nightly means
+   the release would inherit a known problem (or the funnel script itself is
+   broken, which blocks step 6).
+
 3. **Push main.** Docs reference release URLs; they 404 until the tag exists,
    so push + publish + tag should happen in one sitting.
 
@@ -39,14 +44,19 @@ before the tag**. The order below matters; each step gates the next.
    cargo publish -p zj-radar
    ```
 
-   Core's API is allowed to break between 0.1.x releases (it's internal); the
+   Core's API is allowed to break between 0.x releases (it's internal); the
    exact pin is what protects previously published CLIs. Never loosen it to a
    caret/minor range.
 
-   Publishing before the tag opens a short window where crates.io serves the
-   new version but its GitHub release assets don't exist yet — `cargo binstall`
-   falls back to a source build until `release.yml` finishes. Harmless, but
-   don't announce until step 6 passes.
+   Publishing before the tag opens a window where crates.io serves the new
+   version but its GitHub release assets don't exist yet — and that window is
+   **not** harmless. A `cargo install zj-radar` from crates.io embeds no wasm
+   (the CLI's `build.rs` has no sibling plugin crate to build), so on such an
+   install `zj-radar run`'s first-use fetch and `setup zellij --download` hit
+   the version-pinned release URL (`CARGO_PKG_VERSION`) and 404 until the tag's
+   assets exist. `cargo binstall` falls back to a source build with the same
+   hole. Keep the window minutes long: publish and tag in the same sitting
+   (steps 4–5 back to back), and don't announce until step 6 passes.
 
 5. **Tag and push the tag:**
 
@@ -59,10 +69,16 @@ before the tag**. The order below matters; each step gates the next.
    a tag message.
 
    `release.yml` builds the wasm (nix) + portable CLI tarballs, checksums
-   everything, and creates the GitHub release — but only after its gates pass:
-   the fast deterministic + bash suites re-run on the tagged commit, and the
-   live E2E suite runs on both OSes (via the reusable `e2e.yml`). A red gate
-   means nothing publishes; fix, delete the tag, re-tag.
+   everything, and creates the GitHub release. The builds start in parallel
+   with the gates — the fast deterministic + bash suites re-running on the
+   tagged commit, and the live E2E suite on both OSes (via the reusable
+   `e2e.yml`) — but only the publish job waits on all of them
+   (`needs: [build-wasm, build-cli, test, e2e]`), so a red gate still means
+   nothing publishes; fix, delete the tag, re-tag.
+
+   To dry-run the pipeline first, cut an RC: any tag containing `-`
+   (e.g. `v0.5.0-rc.1`) is auto-marked a prerelease and never becomes
+   `latest`, so the curl|sh installer's `/latest/` URL is unaffected.
 
 6. **Verify the release assets.** The `verify-funnel` job in `release.yml`
    does this automatically after the release is created: it runs the README

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,18 @@ rather than a public issue. You should hear back within a few days.
 
 The main supply-chain surface is distribution: the `curl | sh` installer and its
 per-artifact `.sha256` checksum sidecars, and the CLI's checksum verification of
-the downloaded sidebar wasm (`zj-radar setup zellij --download`). Reports about
+the downloaded sidebar wasm — the same code path behind
+`zj-radar setup zellij --download` *and* `zj-radar run`'s first-use wasm fetch
+on a crates.io-installed CLI. Be aware the verification **fails open** by
+design: a missing `.sha256` sidecar, or no local sha256 tool
+(`sha256sum`/`shasum`), downgrades to a warning and installs anyway, with TLS +
+GitHub release storage as the floor; only an actual digest mismatch aborts
+(`crates/cli/src/setup/download.rs`, `scripts/install.sh`). Reports about
 weaknesses in that path are especially welcome. There is no bug bounty.
+
+Dependency advisories are monitored by a nightly
+`cargo deny check advisories licenses sources` CI job (config in `deny.toml`);
+a failure automatically files a tracking issue.
 
 ## Pipe trust model
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -117,8 +117,10 @@ enum Command {
         /// Show what would change; write nothing.
         #[arg(long)]
         dry_run: bool,
-        /// Skip the confirmation prompt.
-        #[arg(long)]
+        /// Skip the confirmation prompt. The doctor's remedy hints print the
+        /// short form (`setup zellij -y`), so the alias must exist for them
+        /// to be copy-pasteable.
+        #[arg(long, short = 'y')]
         yes: bool,
         /// Check setup status without writing files. Conflicts with
         /// `--uninstall`: silently running the doctor instead of uninstalling

--- a/crates/core/src/command.rs
+++ b/crates/core/src/command.rs
@@ -588,7 +588,7 @@ impl CommandStore {
 
             let cwd_str = cwd.unwrap_or("").to_string();
             // Interactive commands record a QUIET pending: the identity is kept
-            // — it labels a held pane's exit (`nvim ✓`, never a blank Done row)
+            // — it labels a held pane's exit (`● $ nvim`, never a blank Done row)
             // and feeds the muted pane label — but `on_timer` never promotes it
             // to a Running row, and it never arms the fast cadence.
             self.pending.insert(

--- a/crates/core/src/payload.rs
+++ b/crates/core/src/payload.rs
@@ -116,8 +116,8 @@ pub struct StatusPayload {
     /// `Other`). Optional; sanitized and capped at [`MAX_SOURCE_CHARS`].
     pub source: String,
     /// The user has already seen this status: converge state as usual, but the
-    /// notifier must stay silent for it. Set by the rail's right-click
-    /// acknowledge (whose whole point is "stop flagging this" — its synthetic
+    /// notifier must stay silent for it. Set by the rail's `✓` acknowledge
+    /// hotspot (whose whole point is "stop flagging this" — its synthetic
     /// `done` echo must not itself pop a notification); producers reporting
     /// real events leave it absent. Optional; absent on the wire when `false`.
     pub ack: bool,

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -34,6 +34,15 @@ the target:
 nix develop -c cargo build --release --target wasm32-wasip1 -p zj-radar-plugin
 ```
 
+## Nix flake outputs
+
+```sh
+nix develop                # dev shell: pinned Rust (+ wasm32-wasip1 std), just, bats, shellcheck, jq, zellij, cargo-deny
+nix build .#zj-radar       # the wasm plugin → result/bin/zj_radar.wasm
+nix build .#zj-radar-cli   # the native CLI (embeds that wasm) → result/bin/zj-radar
+nix flake check            # hermetic clippy + tests + wasm build — what CI's `hermetic` job runs
+```
+
 ## Dev loop
 
 ```sh
@@ -43,8 +52,9 @@ just dev          # build wasm + CLI, launch a FRESH sandboxed zj-radar-dev-<hhm
 Uses the ambient Rust toolchain (`rust-toolchain.toml` auto-installs the
 wasm target on first build). In the Nix shell, prefix with `nix develop -c`.
 
-Zellij 0.44 does not safely hot-reload plugins that were created by a layout:
-`start-or-reload-plugin` opens a second pane instead. The dev loop therefore
+Zellij does not safely hot-reload plugins that were created by a layout
+(observed on the 0.44 line — the supported floor is ≥ 0.44.3, not a pinned
+minor): `start-or-reload-plugin` opens a second pane instead. The dev loop therefore
 never reloads in place — every iteration is a fresh, uniquely named
 `zj-radar-dev-<hhmmss>` session (exited leftovers are swept; live sessions are
 never killed), launched from a plain terminal (`zj-radar run` refuses to nest inside

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,8 +19,16 @@ plugins {
 }
 ```
 
+If `setup zellij` wrote your alias, it sits between `// zj-radar: managed
+plugin alias begin`/`end` marker comments — and a later `setup zellij` strips
+and re-emits that whole region containing only `naming "managed"`, so keys you
+add inside the markers are lost. Put custom keys on a hand-owned alias outside
+the markers, or drive them over the `config.v1` pipe below.
+
 Layouts should continue to reference `plugin location="radar"`. Unknown keys are
-ignored and invalid values fall back to the default (parsing never fails):
+ignored and parsing never fails: an unrecognized value keeps the field as it
+was — the default on first load, the *current* value on a live `config.v1`
+override — so a typo never resets a setting:
 
 | Key | Values | Default | Effect |
 |-----|--------|---------|--------|
@@ -28,20 +36,30 @@ ignored and invalid values fall back to the default (parsing never fails):
 | `naming` | `off` · `managed` · `force` | `managed` | Auto-rename tabs from agent repo / pane title. `managed` only touches default or self-applied names; `force` overrides manual names. The self-applied memory lives in plugin memory, so after a Zellij server restart previously auto-applied names read as manual — use `force`, or rename the tab back to its default (`Tab #N`) to re-enable managed naming. |
 | `header` | `true` · `false` | `true` | Show the ` RADAR` identity header + tab count. |
 | `glyphs` | `plain` · `nerd` | `plain` | Status glyph set (`nerd` needs a Nerd Font). |
-| `jump_hint` | `alt-n` · anything else | hidden | Footer advertises ` alt-[n] jump`. Opt in only when Alt+digit actually reaches Zellij on your machine: the binds must exist in your Zellij config (`zj-radar run` sessions bake Alt-1..9 → `GoToTab`, but don't set this — window managers commonly claim Alt+digit system-wide, and macOS terminals type `¡` unless option-as-alt is on). The rail never advertises a chord it can't verify. |
+| `jump_hint` | `alt-n` (or `alt`) · `hidden` (or `off`) | `hidden` | Footer advertises ` alt-[n] jump`. Opt in only when Alt+digit actually reaches Zellij on your machine: the binds must exist in your Zellij config (`zj-radar run` sessions bake Alt-1..9 → `GoToTab`, but don't set this — window managers commonly claim Alt+digit system-wide, and macOS terminals type `¡` unless option-as-alt is on). The rail never advertises a chord it can't verify. |
 | `notify` | `true` · `false` | `true` | Master switch for OS desktop notifications (macOS `osascript`, Linux `notify-send`). |
 | `notify_done` | `true` · `false` | `true` | Notify when a pane transitions into `done`. |
 | `notify_error` | `true` · `false` | `true` | Notify when a pane transitions into `error`. |
 | `notify_pending` | `true` · `false` | `true` | Notify when a pane transitions into `pending` (needs input). |
 | `notify_when_focused` | `true` · `false` | `false` | When `false`, suppress notifications for the focused pane (background panes only). |
-| `interactive_commands` | comma/space-separated exe names | *(empty)* | Extra commands treated as *interactive* (an editor/pager/TUI that waits on you): the pane never shows a spinning running row — just a muted identity label. Extends the built-in set (`vi(m)`/`nvim`/`emacs`/`nano`/`hx`/`less`/`man`/`htop`/`btop`/`lazygit`/`tig`/`k9s`/`fzf`/`ranger`/`yazi`/`mc`/…). Applies live: adding a name demotes an already-running row immediately. See [`activity-model.md`](activity-model.md). |
+| `interactive_commands` | comma/space-separated exe names | *(empty)* | Extra commands treated as *interactive* (an editor/pager/TUI that waits on you): the pane never shows a spinning running row — just a muted identity label. Extends the built-in set (`vi(m)`/`nvim`/`emacs`/`nano`/`hx`/`less`/`more`/`man`/`top`/`htop`/`btop`/`lazygit`/`tig`/`k9s`/`fzf`/`ranger`/`yazi`/`mc`/…). Applies live: adding a name demotes an already-running row immediately — except a row whose command has already left the foreground with a done-confirm armed, which still flips Running→Done on schedule. See [`activity-model.md`](activity-model.md). |
+
+Three further keys — `role`, `grant_hint`, and `defer_permission` — are also
+parsed, but they are set by `zj-radar run`'s own generated layouts; don't set
+them by hand.
 
 Notifications fire only on transitions **into** an attention status and, by
 default, only for **background** panes — the focused pane is suppressed unless
-`notify_when_focused` is `true`. Delivery is best-effort: the plugin runs
-`osascript` on macOS, else `notify-send` (libnotify) on Linux; if neither is on
-`PATH` it is a silent no-op. This is why the plugin requests Zellij's
-`RunCommands` permission — solely to hand the notification to the OS.
+`notify_when_focused` is `true`. A status arriving with the payload's `ack`
+flag never notifies (the user has already seen it — see
+[`producers.md`](producers.md)), and although the sidebar runs one instance per
+tab, each event is dispatched by exactly one instance, elected through a shared
+claim file — you get one notification, not one per tab. Delivery is
+best-effort: the plugin runs `osascript` on macOS, else `notify-send`
+(libnotify) on Linux; if neither is on `PATH` it is a silent no-op. This is why
+the plugin requests Zellij's `RunCommands` permission — to hand the
+notification to the OS, and to spawn the `zellij pipe` re-broadcast behind the
+`✓` acknowledge gesture described below.
 
 ## Runtime config
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -10,9 +10,12 @@ removal — see `smart-tabs-postmortem.md` — and the focus-removal refactor)
 > issuing blocking host calls on the server's single main thread — full writeup in
 > `smart-tabs-postmortem.md`). This invalidates the earlier plan to *keep* smart-tabs for base
 > tab naming. **zj-radar now owns all tab display, including naming** (see §6.1). The hard
-> architectural constraint that follows: zj-radar must never issue blocking host queries
-> (`get_pane_running_command`, `get_pane_cwd`, …) — all signals come from pushed events
-> (`pipe`, `TabUpdate`, `PaneUpdate`, `CwdChanged`) or the hook payload.
+> architectural constraint that follows: no polling, and no per-event or per-tick blocking
+> host queries (`get_pane_running_command`, …) — signals come from pushed events
+> (`pipe`, `TabUpdate`, `PaneUpdate`, `CwdChanged`) or the hook payload. The single
+> exception is the once-per-pane `Effect::ResolveCwd` naming bootstrap: one blocking
+> `get_pane_cwd` per freshly-opened pane, at pane-creation rate — never re-polled
+> (`crates/plugin/src/runtime.rs`; `CONTEXT.md` → *Tab naming*).
 
 ## 1. Goal
 
@@ -99,17 +102,26 @@ This mirrors Cmux's real status path while fitting Zellij's plugin architecture.
 
 Thin Zellij-host glue around a deep, pure runtime module + pure stores/models/rendering.
 The per-agent adapter layer still lives *outside* the plugin (shell scripts / agent
-config). The plugin runtime has no `zellij-tile` dependency: `lib.rs` translates raw
+config). The plugin runtime has no `zellij-tile` dependency (`zellij-tile` is
+`cfg(target_arch = "wasm32")`-scoped): `lib.rs` translates raw
 Zellij events into repo-owned inputs and applies ordered host effects returned by the
 runtime.
+
+The repo is a **3-crate virtual workspace**: `crates/core` (wire payload, command
+classification, `Kind`, the bounded pipe argv — shared by producer and plugin),
+`crates/cli` (the host-side `zj-radar` binary: `notify`, `setup`, `run`), and
+`crates/plugin` (everything below — the wasm sidebar). Boxed filenames in the diagram
+live under `crates/plugin/src/`.
 
 ```
 ┌ Agent adapters (per-agent, outside the wasm) ─────────────┐
 │ Claude → plugin hook / native CLI  (running/pending/done) │
 │ Codex  → native CLI via hooks.json (running/pending/done) │
 └───────────────────────────┬───────────────────────────────┘
-   zellij pipe --name zj_radar.status.v1 -- {v,source,pane,status,repo,branch,msg}
-   (BROADCAST by name — not --plugin: see §6)
+   zellij pipe --name zj_radar.status.v1 -- {v,source,pane,status,repo,branch,msg,task,ack}
+   (BROADCAST by name — not --plugin: see §6; sent via the bounded self-limiting
+   argv — see §5. The plugin itself is also a caller: the acknowledge gesture
+   broadcasts a synthetic ack:true payload back onto this same pipe, §5)
                             │
                             ▼
 ┌ zj-radar plugin (Rust → wasm32-wasip1) ────────────────────────────────┐
@@ -121,25 +133,37 @@ runtime.
 │    owns lifecycle state, permissions, timers, snapshot decisions,      │
 │    naming, focus transitions, command activity, config pipes, and      │
 │    mouse intent                                                        │
-│    input: TabLite/PaneUpdate/PermissionProbe/status/config/timer/mouse │
+│    input: RadarTab/PaneUpdate/PermissionProbe/status/config/timer/     │
+│    mouse/cmd-verb                                                      │
 │    output: Outcome { render, effects: Vec<Effect> }                    │
 │                                                                        │
 │  session_files.rs: SessionFiles                                        │
 │    owns per-session filesystem coordination across sidebar instances:  │
-│    snapshot durability, permission marker/lock, root fallback, pruning │
+│    snapshot durability, permission marker/lock, root fallback,         │
+│    pruning, presence files, notification claims                        │
 │                                                                        │
 │  radar_state.rs/rollup.rs/tab_namer.rs: state + tab model              │
-│    StatusStore + CommandStore + roll_up(tab) + TabNamer                │
-│    (observed argv classified by crates/core's command.rs)              │
+│    StatusStore (status_store.rs) + CommandStore + roll_up(tab) +       │
+│    TabNamer (observed argv classified by crates/core's command.rs)     │
+│                                                                        │
+│  ledger.rs / sessions.rs / presence.rs: completion history ring;       │
+│    cross-session peer state + the per-session presence record (§13)    │
+│                                                                        │
+│  control.rs / config.rs / theme.rs: cmd-verb + config pipes, colors    │
+│  permission.rs / clock.rs / notify_rules.rs: grant state machine,      │
+│    timer-chain bookkeeping, desktop-notification edge rules            │
 │                                                                        │
 │  render.rs: pure rail renderer                                         │
-│    render_rail(rows, ledger, opts) -> RenderedRail (target_at_line)    │
-│    owns layout, overflow, ANSI, and click-target materialization       │
+│    render_rail(rows, ledger, opts) -> RenderedRail                     │
+│    (target_at_line / hotspot_at; onboarding + needs_permission faces)  │
+│    owns layout, overflow, ANSI, click-target + hotspot materialization │
 └────────────────────────────────────────────────────────────────────────┘
-        │ Effects: switch_tab_to(position + 1), show_pane_with_id, rename_tab,
-        │ request_permission, set_timeout, set_selectable, persist session state
-        ▼  (desktop notifications too: the plugin hands osascript/notify-send
-           invocations to the host via run_command — see §12)
+        │ Effects (runtime.rs): SwitchTab, ShowPane, RenameTab, RequestPermission,
+        │ SetTimeout(Fast|Slow), SetSelectable, PersistSnapshot,
+        │ PersistPermissionMarker, HeartbeatPermissionLock, ResolveCwd (the
+        │ once-per-pane cwd bootstrap), Notify, PersistPresence, ReadPresences,
+        │ SwitchSession, BroadcastStatus (the ack echo), CloseSelf
+        ▼  (Notify hands osascript/notify-send to the host via run_command — §12)
 ```
 
 **Design principle:** keep host-coupled code thin; push lifecycle decisions into
@@ -154,7 +178,8 @@ effects. The real external seam remains the **pipe payload schema** (versioned).
 |-----------------------------------------------|-----------|
 | Claude `UserPromptSubmit` / `PreToolUse` / `PostToolUse` | `running` (`PostToolUse` usually duplicates `PreToolUse`'s payload — the plugin no-ops identical re-broadcasts — but it is the Pending→Running recovery edge after a mid-turn permission answer, so it stays registered) |
 | Claude `Notification` (`permission_prompt` / `elicitation_dialog` matchers) | `pending` |
-| Claude `Stop`                                 | `done`    |
+| Claude `SubagentStop`                         | `running` (a finished subagent means the main turn is still going) |
+| Claude `Stop`                                 | `done` — **except** a Stop whose last assistant message ends in a question maps to `pending` (a turn that ends by asking is blocked on input, not finished; the trailing question becomes the message) |
 | Claude `SessionStart` (`source:"clear"` only) | `idle` (resets a stale row on `/clear`) |
 | Claude `SessionEnd`                           | `idle` (a closed session recedes instead of freezing its last status) |
 | Codex `UserPromptSubmit` / tool hooks / subagents | `running` |
@@ -162,8 +187,9 @@ effects. The real external seam remains the **pipe payload schema** (versioned).
 | Codex `Stop`                                  | `done`    |
 | Codex ephemeral-fork hooks (`transcript_path: null`) | ignored (the main turn keeps owning the pane) |
 | Codex legacy `agent-turn-complete`            | `done`    |
-| Adapter parse/hook failure (optional)         | `error`   |
-| Agent pane returns to its shell prompt (observed exit) | `idle` (clears a stale pushed status; see §6.2) |
+| Observed command exiting nonzero              | `error` — the only `error` source. Claude's map deliberately has no `error`: its hook vocabulary carries no reliable turn-level failure signal (`PostToolUse`'s per-tool `is_error` is normal, recoverable agent behavior), so mapping hooks to `Error` would paint healthy turns red |
+| Agent pane returns to its shell prompt (observed exit) | `idle` — terminal statuses clear at once; a `Running` instead arms the 15-tick stale grace (see §6, *Running exit grace*) |
+| Agent pane's root process exits (pane manifest `exited`) | `idle` — definitive producer death: clears even a `Running` immediately, no grace (see §6, *Running exit grace*) |
 
 > **Update (focus no longer drives state):** an earlier design cleared a pushed
 > completion when you *focused* the pane (`on_focus`). Focus is per-client and is
@@ -171,8 +197,9 @@ effects. The real external seam remains the **pipe payload schema** (versioned).
 > tab you were viewing and left every other tab stale. A finished status now clears
 > only via shared signals — a new broadcast, the observed return-to-shell exit-clear
 > (`command::is_shell_prompt` → `StatusStore::clear_on_prompt_return`), or a prune —
-> which every tab's instance receives, so all tabs converge. The `on_focus` wire
-> field is still accepted for back-compat but is inert.
+> which every tab's instance receives, so all tabs converge. The former `on_focus` wire
+> field is tolerated and ignored — the parser has no such field, so serde drops it
+> unread like any unknown key (same story as the legacy `seq`).
 
 ### 4.2 Per-pane → per-tab aggregation
 
@@ -189,8 +216,13 @@ tab), so tab state cannot come from names. The store keys by `PaneId`; `PaneUpda
   highest-severity pane; on equal severity a bounded *job* outranks a *service*
   (a spinning build beats a merely-up dev server — `activity-model.md` §3);
   remaining ties by most-recent `last_change_tick`.
-- **Pruning:** on each `PaneUpdate`, drop state for `PaneId`s no longer present, so closed
-  agents leave no ghost status.
+- **Pruning (with a one-manifest grace):** on each `PaneUpdate`, drop state for `PaneId`s
+  no longer present, so closed agents leave no ghost status — but a pane's *first* absence
+  is held, not pruned (`absent_once`): Zellij's break-pane family reports session state
+  while a moved pane is extracted and in no tab, so a single absence can't distinguish a
+  close from a mid-move flash. A pane still absent on the confirming next manifest prunes
+  then, ledgered under the tab identity captured at first absence; a reappearing pane
+  simply drops out of the grace set.
 
 ## 5. The pipe contract (producer ↔ plugin seam)
 
@@ -202,7 +234,11 @@ tab-bar; cheap for a handful of tabs).
 Zellij runs *one instance per tab*, and a broadcast only reaches instances alive when it is
 sent — it is never replayed. So a tab opened after agents were already running would spawn a
 blank instance and render every tab idle. Fix: each instance mirrors its `RadarState` stores into a
-snapshot on every store mutation, and seeds itself from it in `load()`. `SessionFiles` chooses
+snapshot on every state *edge*, and seeds itself from it in `load()`. Writes are
+edge-gated, not per-mutation: intakes report `SnapshotWrite::{Now, Deferred}` — a
+label-only Running→Running update on an animating row defers its write to ride the next
+Fast tick's flush instead of hitting disk per tool hook (an inline `Now` on the same pass
+supersedes the deferral). `SessionFiles` chooses
 the persistence root: `/cache` first, because Zellij 0.44 mounts it as the plugin-URL-scoped
 folder shared across all instances, then `/tmp/zj-radar`, then disabled persistence if neither
 root is writable. `/data` is not used because it is scoped by `<plugin_id>-<client_id>` and is
@@ -216,14 +252,39 @@ unaffected.
 
 ```json
 { "v": 1,
-  "source": "claude",                 // claude | codex | test — adapters differ; helps debugging
+  "source": "claude",                 // Kind vocabulary: claude | codex | gemini | command |
+                                      //   test | build | deploy | server | other (unknown → other);
+                                      //   the instrumented-agent set is exactly {claude, codex}
   "pane": { "type": "terminal", "id": 12 },   // typed to match Zellij's PaneId enum
   "status": "running",                // running | pending | done | error | idle
   "repo": "pinky",
   "branch": "fix/x",
   "msg": "running tests…",           // truncated last assistant message
-  "task": "fix the flaky auth test" } // optional, sent only on UserPromptSubmit
+  "task": "fix the flaky auth test",  // optional, sent only on UserPromptSubmit
+  "ack": false }                      // optional (absent = false): "user already saw this" —
+                                      //   state converges, notifier stays silent
 ```
+
+**The plugin is a producer too (the pipe is not strictly one-way).** The rail's
+acknowledge gesture (`✓` hotspot) does not mutate local state — it broadcasts a
+*synthetic* `status.v1` payload (the pane's Pending re-sent as `done` with
+`ack: true`) back onto this same pipe (`Effect::BroadcastStatus`). Every tab's
+instance — including the sender — converges through the normal `status_pipe`
+intake when the pipe echoes it back, and `ack: true` keeps the notifier silent
+in every instance the echo reaches.
+
+**Bounded sends (every caller, plugin included).** `zellij pipe` is a
+backpressure channel: the client blocks until every loaded plugin instance
+consumes the message, and an instance wedged at Zellij's permission prompt
+holds it forever — at hook rate, unbounded sends once cascaded into an EMFILE
+crash of the whole session. All senders use the self-limiting `sh` subtree
+from `crates/core/src/pipe.rs` (`self_limiting_pipe_argv`): a detached
+sleep+kill watchdog inside the spawned subtree reaps its own hung client even
+when the caller is killed mid-send. Deadlines are status-keyed —
+`DEFAULT_PIPE_TIMEOUT_SECS` (5s) for once-per-turn edges,
+`RUNNING_PIPE_TIMEOUT_SECS` (2s) for `running` heartbeats — and the bundled
+hooks' `timeout` values must clear the cap plus 2s slack (welded by
+`hooks_manifest_tests.rs`).
 
 **Plugin-side handling (defensive — the renderer/store, not the adapter, enforces these):**
 - Match `pane` to `PaneId::Terminal(id)`. Adapters derive `id` by stripping any `terminal_`
@@ -239,9 +300,10 @@ unaffected.
 - Sanitize `repo`/`branch`/`msg`: strip ANSI/control chars, convert newlines to spaces, cap
   `msg` to a fixed length before rendering.
 - Ignore payloads over a fixed size cap (e.g. 64 KB).
-- `on_focus` is accepted for back-compat but **inert** (see §4.1 update): `done` no longer
-  auto-clears on focus. A finished status persists until a new broadcast, the observed
-  return-to-shell exit-clear, or a prune — all shared signals, so all tabs converge.
+- The former `on_focus` hint is tolerated and ignored — dropped unread like any unknown
+  key (see §4.1 update): `done` no longer auto-clears on focus. A finished status persists
+  until a new broadcast, the observed return-to-shell exit-clear, or a prune — all shared
+  signals, so all tabs converge.
 
 ## 6. Plugin ↔ Zellij wiring
 
@@ -260,39 +322,56 @@ unaffected.
     Zellij's explicit permission UI. If session files are unavailable, coordination degrades to
     the old behavior rather than blocking startup.
 - **Subscriptions:** `TabUpdate`, `PaneUpdate`, `CwdChanged`, `CommandChanged`, `Timer`,
-  `Mouse`, `PermissionRequestResult`.
+  `Mouse`, `PermissionRequestResult`, `ModeUpdate` (carries `ModeInfo.session_name` — the
+  push-style session-name source §13 depends on).
 - **Tab index footgun:** `TabInfo.position` is **0-indexed**; `switch_tab_to(idx)` is
   **1-indexed** (0 treated as 1). Define `display_tab_number = position + 1` and use it for
   *both* rendering and click → `switch_tab_to(position + 1)`.
-- **Click targeting:** `render_rail()` emits both ANSI and a same-height target map. Header,
-  folded-idle strip, and external gap rows map to nothing; tab header/collapse/single-pane rows
-  map to a tab; expanded multi-pane child rows map to that pane. The runtime stores the latest
-  `RenderedRail` and returns `SwitchTab` or `ShowPane` effects on mouse clicks instead of
-  replaying layout math in the host glue.
+- **Click targeting:** `render_rail()` emits ANSI plus a same-height target map (and a
+  same-height hotspot map — `CONTEXT.md` → *Lockstep*). Header, folded-idle strip, and
+  external gap rows map to nothing; a tab's header line maps to that tab (`SwitchTab`);
+  pane lines map to their pane (`ShowPane`) — a multi-pane tab's tree lines *and* a
+  single-pane tab's pane line and line-2 detail line, which carry that tab's one tracked
+  pane's `pane_id`. There are no collapse rows: the only fold constructs are the `+N more`
+  overflow line at the bottom of an over-tall multi-pane tree and the `+N idle ▾` strip.
+  The runtime stores the latest `RenderedRail` and returns `SwitchTab` / `ShowPane` /
+  `SwitchSession` effects on mouse clicks instead of replaying layout math in the host
+  glue.
 - **Why broadcast, not `--plugin`:** broadcasting by name means adapters never create UI
   panes, never need to know the plugin's URL/config identity, and naturally reach every
   already-running sidebar instance. (A `--plugin` destination can also load the plugin if not
   running and the routing across multiple same-plugin instances is fiddly — avoid it here.)
-- **Timer is one-shot** in Zellij: re-arm each tick.
-  ```rust
-  // load():   set_timeout(1.0);
-  // update(Event::Timer(_)):  tick_elapsed(); set_timeout(1.0); return true;
-  ```
-  Optimization: only keep re-arming while there is something to tick *for* — either
-  animating work (a `Running` agent/command whose glyph spins) or an un-carried
-  completion edge (a `status_pipe` payload defers its recede + notification to the
-  timer). A backgrounded `done`/`error`/`pending` row is terminal: once its one-shot
-  settle has run it does **not** keep the loop alive, so an idle-but-lit rail stops
-  waking every second. The loop re-arms on the next pipe/PaneUpdate. (See
-  `PluginRuntime::timer_should_continue`.)
-  - **Running exit grace:** a pushed `Running` row starts its 15-tick stale
-    grace only on a `CommandChanged` whose effective argv identifies a shell
+- **Timer is one-shot** in Zellij: re-arm each tick. The shipped model is a two-speed
+  cadence plus full disarm (`Cadence::{Fast, Slow}` → `set_timeout(1.0)` /
+  `set_timeout(60.0)`, or no re-arm at all — `PluginRuntime::desired_cadence`): Fast while
+  anything tick-windowed is live (animation, an un-carried completion edge, the permission
+  flow, a pending session-cycle selection), Slow while only minute-granular ages are still
+  changing or a presence heartbeat is owed, disarmed only pre-session-name or when
+  permission is denied. A backgrounded `done`/`error`/`pending` row is terminal: once its
+  one-shot settle has run it does **not** keep the Fast loop alive, so an idle-but-lit
+  rail stops waking every second; the loop re-arms on the next pipe/PaneUpdate. The full
+  trigger lists live in `CONTEXT.md` → *Cadence*. A companion **rows-diff render gate**
+  (`last_render_key`) drops any requested repaint whose content-derived key (rows, ledger
+  lines, badge, theme) equals what the last `render()` actually drew — `CONTEXT.md` →
+  *Render gate*.
+  - **Running exit grace (the producer-death model).** The model:
+    (agent argv present, pane-manifest `exited` = false) = alive;
+    `exited` = dead. A pushed `Running` row starts its 15-tick stale
+    grace (`RUNNING_SUSPECT_GRACE_TICKS`) only on a `CommandChanged` whose
+    effective argv identifies a shell
     prompt. Zellij reports the childless pane-root shell with
     `is_foreground: false`, so that shell-name form is the real prompt-return
     edge and must clear terminal statuses/arm Running expiry. A non-shell
     wrapper argv with `is_foreground: false` remains weak evidence and never
     starts the clock: a live agent's child-process transition must not be
-    mistaken for exit.
+    mistaken for exit. The agent's argv *reappearing* as the pane's foreground
+    cancels an armed clock (`StatusStore::cancel_running_suspect`) — the
+    flicker resolved as a flicker; a clock that outlives the window is cleared
+    by `expire_stale_running` (the producer died mid-turn and will never send
+    the clearing broadcast). The pane manifest's `exited` flag bypasses all of
+    this: it is *definitive* death — an agent-rooted pane
+    (`zellij run -- claude`) never shows a shell prompt at all — so
+    `StatusStore::clear_on_exit` clears even a `Running` immediately, no grace.
 - **Layout — the integration seam.** The sidebar is a pinned, borderless left column *inside* a
   vertical split, *outside* `children`, so `swap_tiled_layout` cycling never disturbs it (same
   mechanism as the existing bars; 0.44.3 has the pop-out fix). The layout layer is the *only*
@@ -335,7 +414,11 @@ unaffected.
 smart-tabs used to auto-name every tab `git-root + program` by polling
 `get_pane_running_command()` / `get_pane_cwd()` on every dirty tick — the exact pattern that
 melted the session (`smart-tabs-postmortem.md`). zj-radar must **not** reproduce that. The
-replacement is push-only and tiered:
+replacement is push-driven and tiered — the one deliberate exception is the
+**once-per-pane cwd bootstrap** (`Effect::ResolveCwd`): a freshly-opened pane has not yet
+emitted `CwdChanged`, so the runtime requests a single blocking `get_pane_cwd` for it,
+gated to at most once per pane id — pane-creation rate, never a re-poll (the result feeds
+the normal `cwd_changed` path):
 
 - **v1 (default — no naming work in the plugin):** tab names come from the layout's `tab name=…`
   and any manual `MOD+r` renames; zj-radar reads them via `TabInfo.name` and renders them
@@ -350,7 +433,8 @@ replacement is push-only and tiered:
     recreate the poll storm.
   - *Plain tabs* — subscribe to **`CwdChanged`** (pushed) to learn a pane's cwd → git-root
     basename; read program from **`PaneInfo.title`** in the `PaneUpdate` manifest we already
-    consume. Both are push signals; no `get_pane_*` call is ever made.
+    consume. Both are push signals; the only `get_pane_*` call anywhere is the once-per-pane
+    `ResolveCwd` bootstrap above.
 
   Guardrails: only `rename_tab` when the derived name actually differs (avoid redundant
   main-thread work), and treat naming as best-effort cosmetics — a missing cwd/title just leaves
@@ -411,7 +495,8 @@ the host target):
     command debounce, tab renames, and click-to-tab/click-to-pane effects are asserted as ordered
     `Outcome` values.
 13. **Renderer target map:** `RenderedRail` line count matches emitted ANSI lines, and headers,
-    gaps, tab rows, expanded pane rows, and collapsed rows resolve to the intended target.
+    gaps, tab rows, pane rows, and the `+N more` / `+N idle ▾` fold lines resolve to the
+    intended target (or a deliberate `None`).
 14. **Snapshot renders:** no agents, mixed states, narrow-width truncation, many tabs,
     multi-agent tab.
 
@@ -454,8 +539,9 @@ v1 = through Phase 3. Phase 1 alone is already a usable sidebar.
    deliberately; collapse toggle (future) mitigates.
 4. **`zellij-tile` API churn** — pin to 0.44.x; read `PaneInfo`/`TabInfo` field ordering and the
    `PaneId` enum against the 0.44.3 tag.
-5. **Per-tab plugin instances** (N timers + N state copies) — the only-tick-while-active
-   optimization bounds the timers, and the state copies are reconciled through `SessionFiles`
+5. **Per-tab plugin instances** (N timers + N state copies) — the Fast/Slow/disarm cadence
+   (§6; `CONTEXT.md` → *Cadence*) and the rows-diff render gate bound the timers and
+   repaints, and the state copies are reconciled through `SessionFiles`
    (see §5 "Newcomer rehydration"). The trap here, learned the hard way: a broadcast is *not*
    replayed to instances spawned later, so a new tab's instance starts blank — hence the snapshot
    seed. Note `/data` is per-instance (`…/<plugin_id>-<client_id>/`) despite the docs calling it
@@ -463,9 +549,11 @@ v1 = through Phase 3. Phase 1 alone is already a usable sidebar.
    `/tmp/zj-radar` as a degraded fallback.
 6. **Repeating the smart-tabs meltdown** (`smart-tabs-postmortem.md`) — bounded *by design*:
    zj-radar is push-driven (hook `pipe` + `TabUpdate`/`PaneUpdate`/`CwdChanged`) and issues no
-   blocking `get_pane_*` queries, so high-output panes cost it nothing and there is no poll loop
-   to storm the server's main thread. The standing rule (no blocking host calls on any path)
-   keeps it that way; any future naming/program feature must stay event-sourced (§6.1).
+   per-event or per-tick blocking `get_pane_*` queries, so high-output panes cost it nothing
+   and there is no poll loop to storm the server's main thread. The standing rule — no
+   polling, no blocking host calls on any per-event/per-tick path; the single exception is
+   the once-per-pane `ResolveCwd` cwd bootstrap (§6.1) — keeps it that way; any future
+   naming/program feature must stay event-sourced (§6.1).
 
 ## 12. Out of scope (follow-ups)
 
@@ -474,18 +562,21 @@ v1 = through Phase 3. Phase 1 alone is already a usable sidebar.
   additional lines in the existing rail, not a separate panel; the floating
   dashboard non-goal stands unchanged.
 - **Aider** (and other) adapters; richer **Codex** lifecycle (running/pending) via a wrapper.
-- Collapse-to-strip toggle; per-pane breakdown within a multi-agent tab.
+- Collapse-to-strip toggle. (Per-pane breakdown within a multi-agent tab **shipped**: a
+  multi-pane tab renders one line per tracked pane as a tree under the tab header — see §3
+  and `rail-reference.md`.)
 - Moving notification logic into the plugin. **Update:** the plugin now owns OS desktop
   notifications (macOS `osascript`, Linux `notify-send`). Rationale: single plugin install provides a standard,
   user-configurable notification surface (via `notify*` KDL keys) that survives across agent
   adapters — reversing the prior assumption that notifications belong in shell adapters alone.
   This trade-off is stable: adapters delegate OS delivery to the plugin while owning their own
   pipe payload schema and lifecycle logic.
-- **Keybinds, the passive way** — the supported keyboard path is a Zellij
-  `MessagePlugin` binding that delivers a verb to the `zj_radar.cmd.v1` pipe
-  (e.g. `attention-next`), handled in `pipe()` exactly like `config.v1`. This
-  keeps the plugin a passive renderer (no `Key` subscription, no focus grab),
-  unlike a `LaunchOrFocusPlugin` panel.
+- **Keybinds, the passive way** — **shipped.** A Zellij `MessagePlugin` binding
+  delivers a verb to the `zj_radar.cmd.v1` pipe — `attention-next` /
+  `attention-prev` / `session-next` / `session-prev` (`control.rs`; operator
+  docs in `docs/configuration.md`; session cycling in §13) — handled in
+  `pipe()` exactly like `config.v1`. This keeps the plugin a passive renderer
+  (no `Key` subscription, no focus grab), unlike a `LaunchOrFocusPlugin` panel.
 - **Launchable floating mode** (`LaunchOrFocusPlugin` keybind, zero layout change) — *deliberate
   non-goal.* It's a different product: an on-demand *peek* (current tab only), not the always-on
   ambient column radar exists to be, and it overlaps `room`/session-manager. It would also force

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -31,8 +31,9 @@ There are **two install surfaces**, and they have *different* best answers:
    installer pattern against their native config/plugin surfaces.
 
 Plus a third, separate surface: **the Zellij plugin itself** (the wasm + its
-permission grant + the layout). That's now handled by `zj-radar setup zellij`
-plus an explicit layout snippet (see §4).
+permission grant + the layout). That's now handled by `zj-radar setup zellij`,
+including layout injection (see §4 — since superseded by the shipped
+`--inject`/`--layout` flow in [`install.md`](install.md)).
 
 ---
 
@@ -66,6 +67,8 @@ zj-radar-claude/
   }
 }
 ```
+(Illustrative — the shipped manifest wires eight events, not three; see
+`plugins/zj-radar-claude/hooks/hooks.json` for the real one.)
 
 Install (any of):
 - one-line marketplace: `/plugin marketplace add <gh-org/zj-radar>` then
@@ -104,6 +107,13 @@ Mirror Cmux/code-notify's proven shape:
   `--dry-run`, atomic writes, and a per-agent disable env var so a user can mute
   one agent without uninstalling.
 
+> **As shipped:** the declarative table with a `Format` enum and the per-agent
+> disable env var never materialized. The implementation is per-surface modules
+> (`crates/cli/src/setup/{claude,codex,zellij}.rs` over a shared `edit.rs`)
+> that keep the rules that mattered: strip-own-then-re-add with markers,
+> refuse-to-write on unparseable files, atomic writes, diff preview + `--yes`
+> and `--dry-run`.
+
 Shipped agent wiring:
 | Agent | File | Insert | Event → status |
 |---|---|---|---|
@@ -125,10 +135,11 @@ It maps all of them to one
 under Zellij** (gate on `$ZELLIJ`). This collapses our two shell scripts into one
 code path and keeps the "wire up with one command" promise.
 
-**Form factor:** a small native **`zj-radar` CLI binary** (Rust) with
-subcommands `notify`, `setup`, `setup --check`, and `setup --uninstall`. Native =
+**Form factor:** a small native **`zj-radar` CLI binary** (Rust). Native =
 no `jq`/`bash` runtime deps, cross-platform, easy to vendor. It ships alongside
-the wasm plugin.
+the wasm plugin. (As shipped, the subcommands are `notify | run | setup`, with
+the later-added `run` as the turnkey front door and `--check`/`--uninstall` as
+`setup` flags.)
 
 ## 4. The Zellij-plugin side of install (separate but needed)
 
@@ -146,6 +157,11 @@ snippet. It deliberately leaves layouts user-owned because real Zellij layouts
 vary too much to patch blindly. A future layout patcher can build on the same
 snippet, but it should be opt-in and previewable.
 
+> **Superseded:** that layout patcher shipped. `setup zellij` now prompts to
+> inject the rail (marker-managed, previewed, reversible via `--uninstall`),
+> with `--inject`/`--layout` for scripts; the release funnel exercises it and
+> the README documents it. See [`install.md`](install.md).
+
 The first-run **permission grant** remains a Zellij prompt. The plugin stays
 selectable only while the prompt is pending; because the sidebar is instantiated
 once per tab, per-tab prompt coordination elects one instance to request the
@@ -160,8 +176,10 @@ uncached grant and peers reuse Zellij's cached answer.
    hook-first Codex setup, `setup --check`, native CLI release artifacts, and
    `setup zellij --wasm` for the sidebar alias (§2–4).
 3. **Phase 3:** add more agents and, if still useful, a previewable layout
-   patcher. The current setup command should keep printing the snippet rather
-   than silently rewriting layouts.
+   patcher. *(Superseded: the patcher shipped as `setup zellij --inject` —
+   prompted, previewed, and reversible rather than silent; see
+   [`install.md`](install.md). The example below reflects the shipped
+   behavior.)*
 
 Net new-user story we're aiming for:
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -42,8 +42,8 @@ zj-radar setup zellij --download
   to pin a different release tag) — so the CLI and the sidebar it manages can't
   drift apart on the status contract and setup expectations they share
 - verifies it against the release's published `.sha256` checksum before installing
-  (a mismatch aborts; releases without a checksum fall back to TLS-only with a
-  warning) — needs `sha256sum` or `shasum` on `PATH`
+  (a mismatch aborts; a release without a checksum — or no `sha256sum`/`shasum`
+  on `PATH` — falls back to TLS-only with a warning)
 - copies it to `~/.config/zellij/plugins/zj_radar.wasm`
 - adds or updates a managed `radar` alias in `~/.config/zellij/config.kdl`
 - reads your default layout, then **prompts** `Inject the rail into <layout>? [y/N]`:
@@ -184,12 +184,15 @@ a given path. The sidebar requests four:
 
 - `ReadApplicationState` — read tab/pane state to draw the rail.
 - `ReadCliPipes` — receive the `zj_radar.status.v1` broadcasts from producers.
-- `ChangeApplicationState` — switch tabs on click and apply managed tab names.
+- `ChangeApplicationState` — switch tabs and focus panes on click, switch to a
+  peer session from the badge, apply managed tab names, and let the `--grant`
+  float close itself once granted.
 - `RunCommands` — deliver desktop notifications (`osascript` on macOS,
-  `notify-send` on Linux). This is the only thing the plugin runs commands
-  for; turn notifications off with `notify false` (see
-  [configuration](configuration.md)), and without this grant they are
-  silently skipped while everything else keeps working.
+  `notify-send` on Linux) and re-broadcast the `✓` acknowledge gesture over
+  `zellij pipe`. Those two are the only things the plugin runs commands for;
+  turn notifications off with `notify false` (see
+  [configuration](configuration.md)). Without this grant, both are silently
+  skipped while everything else keeps working.
 
 **By default you never meet a prompt for these:** `setup zellij` asks for your
 consent at install time and, if you agree, writes the grant into Zellij's
@@ -237,7 +240,7 @@ zellij:
 ```
 
 Each item is `ok`, `warn`, or `missing`. The check is read-only — it never
-modifies any file. Reported items (six always; a seventh only when applicable):
+modifies any file. Reported items (six always; two more only when applicable):
 
 - **zellij binary** — `zellij` is on `PATH`; warns when its version is below
   the supported floor of 0.44.3 (earlier 0.44 patches let the sidebar pop out
@@ -250,6 +253,9 @@ modifies any file. Reported items (six always; a seventh only when applicable):
 - **producer** — Codex hooks and/or Claude plugin wired up (names which).
 - **managed config** — emitted only when `config.kdl` is a symlink
   (home-manager); warns that direct edits may be overwritten.
+- **config env** — emitted only when `$ZELLIJ_CONFIG_FILE` points somewhere
+  other than the `config.kdl` setup resolved; warns that Zellij will read the
+  env-var path, not the file setup checks and edits.
 
 ## Loading straight from a release URL (caveat)
 
@@ -332,7 +338,10 @@ Everything zj-radar touches, what creates it, and what `setup zellij
 | `run`'s owned config dir (macOS `~/Library/Application Support/zj-radar/`, Linux `~/.local/share/zj-radar/`) | `zj-radar run` | not touched by `setup` — `rm -r` the directory; it holds nothing but re-materializable assets and session markers |
 | Per-session plugin state under Zellij's cache + `/tmp/zj-radar` fallback | the running plugin | self-pruning (24 h); safe to delete anytime |
 | `$CODEX_HOME/hooks.json` entries (+ optional `notify` slot in `config.toml`) | `setup codex` | **reversed** by `setup codex --uninstall` |
+| `zj-radar-claude` plugin + `zj-radar` marketplace entry, inside Claude Code's own plugin store | `setup claude` | plugin **reversed** by `setup claude --uninstall`; the marketplace entry stays — `claude plugin marketplace remove zj-radar` |
 
 So a complete removal is: `zj-radar setup zellij --uninstall && zj-radar setup
-codex --uninstall`, then delete the wasm, the `zj-radar` data dir, and the
-grant block — plus the binary itself, wherever you installed it.
+claude --uninstall && zj-radar setup codex --uninstall`, then delete the wasm,
+the `zj-radar` data dir, and the grant block — plus
+`claude plugin marketplace remove zj-radar` and the binary itself, wherever you
+installed it.

--- a/docs/producers.md
+++ b/docs/producers.md
@@ -29,7 +29,9 @@ the second installs the `zj-radar-claude` plugin *from* it — that's what the
 `zj-radar-claude@zj-radar` (`plugin@marketplace`) syntax means.
 
 Requires `jq` and `git` on `PATH` (used to parse the hook payload and derive
-repo/branch). See [`plugins/zj-radar-claude/README.md`](../plugins/zj-radar-claude/README.md)
+repo/branch) — though `jq` is needed only by the bash fallback: when the native
+`zj-radar` binary is on `PATH` the hook prefers it and exits before the `jq`
+gate. See [`plugins/zj-radar-claude/README.md`](../plugins/zj-radar-claude/README.md)
 for details. It's a no-op outside Zellij, so it's safe to leave enabled
 everywhere.
 
@@ -51,22 +53,37 @@ cargo install zj-radar
 - **`zj-radar notify <claude|codex>`** — broadcasts agent status. The Claude
   plugin's hook script automatically prefers it when it's on `PATH` (jq-free);
   otherwise the plugin falls back to its bundled `bash`+`jq` script.
-- **`zj-radar setup [codex]`** — idempotently wires Codex's
-  `~/.codex/hooks.json` to call `zj-radar notify codex`. This preserves any
-  existing Codex `notify` program (e.g. a Computer Use notifier), because hooks
-  are additive. Use `--dry-run` to preview, `--uninstall` to remove only
-  zj-radar's hooks, and `--check` to diagnose the current setup. After installing
-  or changing hooks, run `/hooks` inside Codex once to review and trust the
-  command hook. (Claude needs no `setup` — use the plugin above.)
+- **`zj-radar setup [claude|codex]`** — idempotently wires the named agent
+  (bare `setup` wires every detected agent). Codex gets hook entries in
+  `hooks.json` under `$CODEX_HOME` (or `~/.codex` when it's unset) calling
+  `zj-radar notify codex`. This preserves any existing Codex `notify` program
+  (e.g. a Computer Use notifier), because hooks are additive. Claude is wired
+  through Claude Code's own `claude plugin` CLI (marketplace add + install —
+  the same install as [above](#claude-code)) rather than by editing files.
+  Both take the same flags: `--dry-run` to preview, `--uninstall` to remove
+  only zj-radar's wiring, and `--check` to diagnose the current setup. After
+  installing or changing hooks, run `/hooks` inside Codex once to review and
+  trust the command hook.
 - **`zj-radar setup codex --legacy-notify`** — opt-in fallback for older Codex
   setups that only support the single `notify` program. It refuses to replace a
   foreign notifier unless `--force` is also passed.
 - **`zj-radar setup zellij --wasm <path>`** — copies the sidebar wasm to
-  `~/.config/zellij/plugins/zj_radar.wasm`, manages the `radar` alias in
-  `config.kdl`, and prints the layout snippet. It leaves layouts user-owned.
+  `~/.config/zellij/plugins/zj_radar.wasm` (or fetches the release matching the
+  CLI's version with `--download` instead of `--wasm`), manages the `radar`
+  alias in `config.kdl`, and offers layout injection: on a TTY it asks before
+  adding the rail to your layout, `--inject` consents non-interactively,
+  `--layout <name>` targets a specific layout, and otherwise it prints the
+  snippet to paste yourself. `--uninstall` strips both the alias and the
+  injected rail.
 
 Codex hooks report turn start, tool use, permission requests, subagents, and
-turn stop. zj-radar maps those to `running`, `pending`, and `done`.
+turn stop. zj-radar maps those to `running`, `pending`, and `done`. `setup`
+writes one entry per event across seven hook events (`UserPromptSubmit`,
+`PreToolUse`, `PermissionRequest`, `PostToolUse`, `SubagentStart`,
+`SubagentStop`, `Stop`), each with `timeout` 10 — the default send cap plus
+5 s of headroom, so Codex's hook runner never races the bounded send (see
+[below](#writing-your-own-producer)) — a `commandWindows` variant, and the
+`ZJ_RADAR_CODEX_HOOK=v1` marker that idempotency and `--uninstall` key on.
 
 ## Any script: `zj-radar notify generic`
 
@@ -86,8 +103,9 @@ zj-radar notify generic --status done --msg "deploy finished" --source deploy
   `idle` always broadcasts blank.
 - `--task`: the sticky task label (empty keeps the stored one).
 - `--source`: picks the kind mark — `test` ⚗ · `build` ⚙ · `deploy` ⇡ ·
-  `server` ❯ · `command` $ — anything else (including the default `generic`)
-  renders the neutral `⦿`.
+  `server` ❯ · `command` $, and the agent tokens `claude` ✳ · `codex` ❉ ·
+  `gemini` ✦ — anything else (including the default `generic`) renders the
+  neutral `⦿`.
 - Repo/branch come from `git` in the calling directory; the pane id from
   `$ZELLIJ_PANE_ID`. Outside Zellij it's a silent no-op (safe under `set -e`).
   `--dry-run` prints the payload instead of broadcasting.
@@ -96,7 +114,9 @@ The same lifecycle rules as agents apply: latest broadcast wins, a finished
 status clears when the pane returns to its shell prompt, and a `running` row
 whose pane sits at the prompt with no follow-up broadcast is cleared by the
 stale-Running watchdog after ~15s — so send `done`/`error` when your script
-finishes rather than leaning on the watchdog.
+finishes rather than leaning on the watchdog. A pane whose root process exits
+clears *any* status immediately, no grace clock — relevant for `zellij run`
+script panes, where the pane outlives the process but the row does not.
 
 ## Writing your own producer
 
@@ -130,12 +150,15 @@ name, never `--plugin`) a `zj_radar.status.v1` message:
 - `source`: tokens are lowercase-exact — matching is case-sensitive, so
   `"claude"` classifies as the Claude agent while `"Claude"` falls back to the
   neutral kind.
-- `task` (optional, sent only on `UserPromptSubmit`): sticky task label —
-  empty/absent leaves the stored label unchanged, non-empty replaces it; the
-  plugin clears it on idle and on return-to-shell.
+- `task` (optional): sticky task label, valid with any status — empty/absent
+  leaves the stored label unchanged, non-empty replaces it; the plugin clears
+  it on idle and on return-to-shell. (The bundled adapters happen to send it
+  only on `UserPromptSubmit`; `notify generic --task` sends it whenever you
+  like.)
 - `ack` (optional, default `false`): "the user has already seen this status" —
   the plugin converges state as usual but never fires a desktop notification
-  for it. Set by the rail's own right-click acknowledge broadcast; producers
+  for it. Set by the rail's own acknowledge gesture (the right-edge `✓`
+  hotspot); producers
   reporting real events should leave it absent (an acknowledged `done` would
   otherwise skip the completion notification the user wanted).
 - Unknown fields are ignored, so it's safe to send extras. (A former `on_focus`
@@ -148,7 +171,10 @@ chars and Unicode bidi-control characters, folds newlines to spaces, and
 silently ignores unknown fields, so extra keys never break a producer. The plugin
 also enforces field limits, so you don't have to pre-truncate: `repo`/`branch` are cut to 40 chars,
 `msg`/`task` to 60, `source` to 16 — and a payload over **64 KB** is dropped
-whole. `pane.type` must be `"terminal"`; any other pane type is rejected.
+whole. `pane.type` must be `"terminal"`; any other pane type is rejected. The
+store is bounded too: past **256** distinct pane ids the oldest observation (by
+last status change) is evicted, so a producer looping over fresh pane ids can't
+grow the state without limit.
 
 Quick smoke test (a "fake agent" — broadcast straight from your shell):
 
@@ -163,7 +189,8 @@ client process until *every* loaded plugin instance consumes the message
 blocks the client **forever** — and a producer that fires per tool-call then
 leaks one blocked process plus two Zellij-server FDs per event, until the
 server hits EMFILE and the whole session crashes. Wrap the call in a timeout
-(the bundled producers use 5 s, `ZJ_RADAR_PIPE_TIMEOUT` to override); killing
+(the bundled producers default to 5 s for status edges, 2 s for `running`
+heartbeats — see below; `ZJ_RADAR_PIPE_TIMEOUT` overrides both); killing
 the client past the deadline loses nothing — the message is already queued
 server-side.
 
@@ -186,4 +213,9 @@ bounded no-op. Hot-path events that fire per tool call deserve a *shorter*
 deadline than rare edges: an expired `running` is a dropped heartbeat the
 next event replaces, so the bundled producers key the default on status —
 `running` sends cap at 2 s, the `done`/`pending`/`idle` edges keep the full
-5 s (`ZJ_RADAR_PIPE_TIMEOUT` overrides both).
+5 s. A Rust producer should reuse the same numbers: `zj-radar-core` re-exports
+them as `RUNNING_PIPE_TIMEOUT_SECS` / `DEFAULT_PIPE_TIMEOUT_SECS` next to
+`self_limiting_pipe_argv`. `ZJ_RADAR_PIPE_TIMEOUT` overrides both defaults, and
+its parse is strict: whole seconds only, clamped to 3600 — anything else
+(`10s`, a negative, an empty string) fails closed to the default rather than
+running unbounded.

--- a/flake.nix
+++ b/flake.nix
@@ -150,7 +150,8 @@
         # `just`, `bats`, and `shellcheck` are required by the CI recipes
         # (`just test-bash` / `just test-e2e`, and the `shellcheck` step) — keep
         # them here so `nix develop -c just …` resolves on PATH. `jq` is used by
-        # the bash hook tests.
+        # the bash hook tests. `cargo-deny` reproduces the nightly advisory job
+        # (`cargo deny check`).
         packages = [
           toolchain
           pkgs.jq
@@ -158,6 +159,7 @@
           pkgs.just
           pkgs.bats
           pkgs.shellcheck
+          pkgs.cargo-deny
         ];
         shellHook = ''
           echo "zj-radar dev shell: $(rustc --version)"


### PR DESCRIPTION
## Summary

Five parallel reviewers audited every doc against the code at v0.4.0 (last full doc pass was 2026-07-06 — everything from v0.2.0 through v0.4.0 landed after it). ~95 verified findings, all applied. One small code fix rode along.

### Code (1 commit)
- **`setup zellij -y` now works** — the doctor's printed grant remedy was un-runnable (`--yes` had no short alias). Added `short = 'y'`.
- Stale comments: payload `ack` doc said "right-click acknowledge" (it's the ✓ hotspot); pre-activity-model `nvim ✓` Done shorthand.
- `cargo-deny` added to the nix dev shell so the nightly advisory job reproduces under `nix develop`.

### Docs (4 commits, by cluster)
- **README + install.md** — RunCommands also powers the ✓ ack re-broadcast; no-blocking-queries claim carves out the one-shot `get_pane_cwd` bootstrap; `--check` has two conditional items; removal recipe includes `setup claude --uninstall`; activity model surfaces in Highlights / config example / doc table; `notify generic` named; badge alpha → beta.
- **CONTEXT / design / AGENTS** — lockstep documented as three parallel vectors (+ session routing, hotspots); payload's ninth `ack` field + the plugin as pipe caller; Fast/Slow/disarm cadence incl. presence heartbeat; `absent_once` prune grace; producer-death model (grace clock / argv-cancel / `exited`-definitive); design.md module box, effects, subscriptions, and Claude lifecycle table match the code; AGENTS.md names all three versioned pipes and the welded-to-tests file set.
- **configuration + producers** — live `config.v1` typo keeps the *current* value; managed-marker rewrite caveat; `setup [claude|codex]` symmetric; the 2s/5s status-keyed deadlines stated once, consistently; codex hook shape, 256-pane cap, strict `ZJ_RADAR_PIPE_TIMEOUT` parse. Guard tests pinning this doc still pass.
- **CONTRIBUTING / RELEASING / distribution / TOOLCHAIN / SECURITY** — RELEASING's "publish before tag is harmless" corrected (crates.io CLI embeds no wasm and 404s on its version-pinned fetch until the release exists); builds don't gate, only publish does; hermetic source-filter rule + docs-as-test-inputs documented; distribution.md's shipped-vs-design sections annotated; SECURITY states `run`'s fetch surface and the fail-open sha256 behavior.

## Test plan
- `just test` (13 suites), `cargo clippy -D warnings`, wasm release build: all green locally.
- `just test-bash`: 61/63 — the two failures (`oversized hook payload`, `8 MiB cap`) fail identically on untouched `main` on this machine (no `timeout`/`gtimeout` binary locally); CI has coreutils.
- `documented_config_pipe_name_matches` / `documented_cmd_pipe_verbs_parse` guard tests verified against the edited configuration.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)