### PR TITLE
refactor: second-pass self-review — deepen the reap, dedupe, de-fork

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -424,8 +424,9 @@ function — which nothing in this stack does, and which would violate the
 push-driven doctrine (`CONTRIBUTING.md`; `smart-tabs-postmortem.md`) if it
 did. `SessionUpdate` was dropped entirely (task-8b): liveness is judged from
 a presence file's mtime. That judgment rests on a write-side guarantee: a
-live session rewrites its presence file at least every 60s (`timer`'s
-`PRESENCE_HEARTBEAT_S` level trigger, bypassing the normal content-edge
+live session rewrites its presence file at least every 60s (`project`'s
+`PRESENCE_HEARTBEAT_S` level trigger — any pass through `project` re-emits
+the write once the last one is that old, bypassing the normal content-edge
 gate), so file age reliably means what it says. `read_peer_presences`
 returns every peer file it finds, unconditionally, paired with that file's
 mtime age; `Sessions` (`sessions.rs`) grades that age per entry:
@@ -441,7 +442,9 @@ makes every file look old for up to one heartbeat) is harmless, since the
 live session's next heartbeat republishes and the entry returns fresh.
 Right-click dismiss remains the manual reap for a stale-not-yet-dead entry;
 a 6h open-time sweep at plugin `load()` remains the backstop for debris the
-reap can't touch. The session's own name arrives the same push-style way its
+reap can't touch (malformed/unparseable files, which never produce a name
+to dismiss by — an own-name corpse is NOT in that bucket, since the on-disk
+dismiss spares the live file by path identity and reaps the corpse). The session's own name arrives the same push-style way its
 liveness does: `Event::ModeUpdate`'s `ModeInfo.session_name`, not a
 session-list lookup.
 

--- a/crates/cli/src/agents.rs
+++ b/crates/cli/src/agents.rs
@@ -172,7 +172,7 @@ pub fn baseline_msg(status: Status, msg: &str) -> String {
     }
 }
 
-fn basename(path: &str) -> Option<&str> {
+pub(crate) fn basename(path: &str) -> Option<&str> {
     if path.is_empty() {
         return None;
     }

--- a/crates/cli/src/notify.rs
+++ b/crates/cli/src/notify.rs
@@ -99,14 +99,6 @@ fn git_repo_branch(cwd: &str) -> (String, String) {
     (repo, branch)
 }
 
-// Bytes of stdin we're willing to buffer: the shared producer cap
-// (`core::pipe::MAX_STDIN_BYTES`, also notify.sh's `head -c` bound). Generous —
-// 8 MiB dwarfs any real hook payload (even a Write tool's full file `content`)
-// — so it never truncates a legitimate input; it only bounds a degenerate
-// multi-MB/GB stream. Note this is the *input* cap, distinct from the plugin's
-// 64 KB *wire* cap on the broadcast payload the CLI produces.
-use crate::pipe::MAX_STDIN_BYTES;
-
 fn read_stdin() -> String {
     use std::io::IsTerminal;
     let stdin = std::io::stdin();
@@ -118,7 +110,7 @@ fn read_stdin() -> String {
         eprintln!("zj-radar: no piped stdin; using empty payload");
         return String::new();
     }
-    read_capped(stdin.lock(), MAX_STDIN_BYTES)
+    read_capped(stdin.lock(), crate::pipe::MAX_STDIN_BYTES)
 }
 
 /// Read up to `cap` bytes as UTF-8, ignoring IO/UTF-8 errors (the caller derives

--- a/crates/cli/src/setup/analyze.rs
+++ b/crates/cli/src/setup/analyze.rs
@@ -27,6 +27,9 @@ pub(crate) struct ZellijPaths {
     pub config_path: PathBuf,
     pub wasm_dest:   PathBuf,
     pub layout_path: PathBuf,
+    /// The layout NAME `layout_path` was resolved from (`resolve_layout_name`),
+    /// carried so reports name exactly the layout the read inspected.
+    pub layout_name: String,
 }
 
 /// The one IO gathering point behind [`ZellijEnv`]: read every input
@@ -37,8 +40,9 @@ pub(crate) fn read_zellij_env(config_dir: &Path, layout_name: Option<&str>) -> (
     let config_path = zellij_config_path(config_dir);
     let wasm_dest = zellij_wasm_dest(config_dir);
     let config_text = std::fs::read_to_string(&config_path).ok();
-    let layout_path =
-        crate::setup::detect::resolve_layout_path(config_dir, layout_name, config_text.as_deref());
+    let layout_name =
+        crate::setup::detect::resolve_layout_name(layout_name, config_text.as_deref());
+    let layout_path = crate::setup::detect::resolve_layout_path(config_dir, &layout_name);
     let env = ZellijEnv {
         layout_text:            std::fs::read_to_string(&layout_path).ok(),
         permissions_text:       crate::run::zellij_permissions_text(),
@@ -50,7 +54,7 @@ pub(crate) fn read_zellij_env(config_dir: &Path, layout_name: Option<&str>) -> (
         zellij_version:         zellij_version_output(),
         config_text,
     };
-    (env, ZellijPaths { config_path, wasm_dest, layout_path })
+    (env, ZellijPaths { config_path, wasm_dest, layout_path, layout_name })
 }
 
 /// Every derived fact about the current Zellij setup state, in one place. Both

--- a/crates/cli/src/setup/check.rs
+++ b/crates/cli/src/setup/check.rs
@@ -213,11 +213,9 @@ pub(crate) fn check_zellij(layout_name: Option<&str>) -> bool {
     // No resolvable config dir = nothing to inspect; the refusal is the report.
     let Some(config_dir) = zellij_config_dir_or_report() else { return true };
     let (env, paths) = read_zellij_env(&config_dir, layout_name);
-    // The inspected layout's NAME is the resolved path's stem — the same place
-    // `zellij_config_file_item` gets its path, so the report and the read
-    // can't name different layouts.
-    let inspected_layout = paths.layout_path.file_stem().map(|s| s.to_string_lossy().into_owned());
-    let mut items = zellij_check_items(&analyze_zellij(&env), inspected_layout.as_deref().unwrap_or("default"));
+    // The inspected layout's NAME comes back on `paths` — the same resolution
+    // the read used, so the report and the read can't name different layouts.
+    let mut items = zellij_check_items(&analyze_zellij(&env), &paths.layout_name);
     if let Some(item) =
         zellij_config_file_item(std::env::var_os("ZELLIJ_CONFIG_FILE"), &paths.config_path)
     {

--- a/crates/cli/src/setup/claude.rs
+++ b/crates/cli/src/setup/claude.rs
@@ -19,8 +19,11 @@ pub(crate) const CLAUDE_PLUGIN: &str = "zj-radar-claude";
 /// same fork-follows knob as `--download`). The one derivation behind the
 /// qualified plugin id (`zj-radar-claude@<name>`) and the uninstall
 /// epilogue's `marketplace remove <name>`, so the three can't drift on a fork.
+/// Uses the crate's empty-segment-guarded [`crate::agents::basename`], so a
+/// degenerate slug (trailing slash, empty) falls back to the slug whole
+/// rather than yielding an empty name (`zj-radar-claude@`).
 fn claude_marketplace_name(repo_slug: &str) -> &str {
-    repo_slug.rsplit('/').next().unwrap_or(repo_slug)
+    crate::agents::basename(repo_slug).unwrap_or(repo_slug)
 }
 
 /// Read Claude Code's installed-plugins manifest
@@ -33,12 +36,8 @@ pub(crate) fn claude_installed_plugins_text() -> Option<String> {
         .and_then(|h| std::fs::read_to_string(h.join(".claude/plugins/installed_plugins.json")).ok())
 }
 
-pub(crate) fn setup_claude(uninstall: bool, dry_run: bool, yes: bool) {
-    use std::io::IsTerminal;
+pub(crate) fn setup_claude(uninstall: bool, dry_run: bool, yes: bool, is_tty: bool) {
     let wired = crate::run::claude_producer_wired(claude_installed_plugins_text().as_deref());
-    // Tty-ness resolved once at the boundary (the `inject_mode` pattern);
-    // `confirm` below takes it as a parameter.
-    let is_tty = std::io::stdin().is_terminal();
     if uninstall {
         uninstall_claude(wired, dry_run, yes, is_tty);
     } else {
@@ -148,5 +147,8 @@ mod tests {
         assert_eq!(claude_marketplace_name("fork-owner/zj-radar-fork"), "zj-radar-fork");
         // Degenerate slug without a slash: use it whole rather than panic.
         assert_eq!(claude_marketplace_name("zj-radar"), "zj-radar");
+        // Trailing slash must not yield an empty name (`zj-radar-claude@` and
+        // a dangling `marketplace remove `): fall back to the slug whole.
+        assert_eq!(claude_marketplace_name("marktoda/zj-radar/"), "marktoda/zj-radar/");
     }
 }

--- a/crates/cli/src/setup/codex.rs
+++ b/crates/cli/src/setup/codex.rs
@@ -44,7 +44,6 @@ fn codex_installed(codex_on_path: bool) -> bool {
 }
 
 pub(crate) fn setup_codex(uninstall: bool, opts: CodexSetupOpts) {
-    use std::io::IsTerminal;
     if codex_home_dir().is_none() {
         crate::exit::fail_report(
             "codex",
@@ -52,13 +51,10 @@ pub(crate) fn setup_codex(uninstall: bool, opts: CodexSetupOpts) {
         );
         return;
     }
-    // Tty-ness resolved once at the boundary (the `inject_mode` pattern);
-    // the confirm step below takes it as a parameter.
-    let is_tty = std::io::stdin().is_terminal();
     if opts.legacy_notify {
-        setup_codex_notify(uninstall, opts.dry_run, opts.yes, opts.force, is_tty);
+        setup_codex_notify(uninstall, opts.dry_run, opts.yes, opts.force, opts.is_tty);
     } else {
-        setup_codex_hooks(uninstall, opts.dry_run, opts.yes, is_tty);
+        setup_codex_hooks(uninstall, opts.dry_run, opts.yes, opts.is_tty);
     }
 }
 

--- a/crates/cli/src/setup/detect.rs
+++ b/crates/cli/src/setup/detect.rs
@@ -71,18 +71,12 @@ pub(crate) fn resolve_layout_name(explicit: Option<&str>, config_text: Option<&s
 }
 
 /// The layout FILE `setup`/`--check` should operate on:
-/// `<config_dir>/layouts/<name>.kdl` for the resolved layout name (see
-/// [`resolve_layout_name`]). One resolution shared by the install path and the
-/// doctor, so both inspect the layout Zellij actually loads (and the one a
-/// `--layout` install just wrote).
-pub(crate) fn resolve_layout_path(
-    config_dir: &Path,
-    explicit: Option<&str>,
-    config_text: Option<&str>,
-) -> PathBuf {
-    config_dir
-        .join("layouts")
-        .join(format!("{}.kdl", resolve_layout_name(explicit, config_text)))
+/// `<config_dir>/layouts/<name>.kdl` for a name [`resolve_layout_name`]
+/// resolved. One resolution shared by the install path and the doctor
+/// (`read_zellij_env`), so both inspect the layout Zellij actually loads
+/// (and the one a `--layout` install just wrote).
+pub(crate) fn resolve_layout_path(config_dir: &Path, layout_name: &str) -> PathBuf {
+    config_dir.join("layouts").join(format!("{layout_name}.kdl"))
 }
 
 pub(crate) fn strip_managed_zellij_alias(lines: &mut Vec<String>) {

--- a/crates/cli/src/setup/mod.rs
+++ b/crates/cli/src/setup/mod.rs
@@ -116,6 +116,7 @@ pub(crate) struct ZellijSetupOpts<'a> {
     layout:      Option<&'a str>,
     dry_run:     bool,
     yes:         bool,
+    is_tty:      bool,
 }
 
 pub(crate) struct CodexSetupOpts {
@@ -123,6 +124,7 @@ pub(crate) struct CodexSetupOpts {
     force:         bool,
     dry_run:       bool,
     yes:           bool,
+    is_tty:        bool,
 }
 
 /// The single operation a `setup` invocation performs. Resolving this once makes
@@ -233,6 +235,13 @@ pub fn run(options: SetupOptions<'_>) {
     }
 
     let uninstall = mode == Mode::Uninstall;
+    // Tty-ness resolved ONCE at the invocation boundary (the `inject_mode`
+    // pattern); every consent step in the targets below takes it as a
+    // parameter rather than probing stdin again mid-chain.
+    let is_tty = {
+        use std::io::IsTerminal;
+        std::io::stdin().is_terminal()
+    };
     if want_zellij {
         let wasm_source = if uninstall {
             WasmSource::None
@@ -254,6 +263,7 @@ pub fn run(options: SetupOptions<'_>) {
                 layout:  options.layout,
                 dry_run: options.dry_run,
                 yes:     options.yes,
+                is_tty,
             },
         );
     }
@@ -265,11 +275,12 @@ pub fn run(options: SetupOptions<'_>) {
                 force:         options.force,
                 dry_run:       options.dry_run,
                 yes:           options.yes,
+                is_tty,
             },
         );
     }
     if want_claude {
-        setup_claude(uninstall, options.dry_run, options.yes);
+        setup_claude(uninstall, options.dry_run, options.yes, is_tty);
     }
 }
 
@@ -305,17 +316,17 @@ pub(crate) fn confirm(prompt: &str, yes: bool, is_tty: bool) -> bool {
     }
     print!("{prompt} [y/N] ");
     let _ = std::io::stdout().flush();
-    confirm_answer(std::io::stdin().lock())
+    let mut line = String::new();
+    let _ = std::io::BufRead::read_line(&mut std::io::stdin().lock(), &mut line);
+    consented(&line)
 }
 
-/// The read-and-parse half of [`confirm`], over any reader: `y`/`yes` (case
-/// folded) consent; anything else — including EOF — declines. Split out so
-/// answered-y, answered-n, and EOF-decline stay unit-tested (the tty gate
-/// above keeps the real stdin out of reach in tests).
-fn confirm_answer(mut reader: impl std::io::BufRead) -> bool {
-    let mut line = String::new();
-    let _ = reader.read_line(&mut line);
-    matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+/// The parse half of [`confirm`]: `y`/`yes` (case folded) consent; anything
+/// else — including the empty string an EOF'd read leaves — declines. Split
+/// out so answered-y, answered-n, and EOF-decline stay unit-tested (the tty
+/// gate above keeps the real stdin out of reach in tests).
+fn consented(answer: &str) -> bool {
+    matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes")
 }
 
 /// The shared "commit an edit" tail for every `setup_*` step: prompt (unless
@@ -402,19 +413,18 @@ mod tests {
     }
 
     #[test]
-    fn confirm_answer_accepts_only_y_or_yes() {
-        use std::io::Cursor;
+    fn consented_accepts_only_y_or_yes() {
         // Answered y (any case, either spelling) → consent.
-        assert!(confirm_answer(Cursor::new("y\n")));
-        assert!(confirm_answer(Cursor::new("Y\n")));
-        assert!(confirm_answer(Cursor::new("yes\n")));
-        assert!(confirm_answer(Cursor::new("  YES  \n")));
+        assert!(consented("y\n"));
+        assert!(consented("Y\n"));
+        assert!(consented("yes\n"));
+        assert!(consented("  YES  \n"));
         // Answered n (or anything else) → decline.
-        assert!(!confirm_answer(Cursor::new("n\n")));
-        assert!(!confirm_answer(Cursor::new("no\n")));
-        assert!(!confirm_answer(Cursor::new("yep\n")));
-        // EOF with no answer declines — the default must be the safe "no".
-        assert!(!confirm_answer(Cursor::new("")));
+        assert!(!consented("n\n"));
+        assert!(!consented("no\n"));
+        assert!(!consented("yep\n"));
+        // EOF leaves the buffer empty — the default must be the safe "no".
+        assert!(!consented(""));
     }
 
     #[test]

--- a/crates/cli/src/setup/zellij.rs
+++ b/crates/cli/src/setup/zellij.rs
@@ -235,20 +235,17 @@ pub(crate) fn setup_zellij(uninstall: bool, opts: ZellijSetupOpts<'_>) {
     let force       = opts.force;
     let inject_flag = opts.inject;
     let layout_name = opts.layout;
-    // Tty-ness resolved once at the boundary; every consent step below
-    // (`inject_mode`, `confirm`) takes it as a parameter rather than probing
-    // stdin again mid-chain.
-    let is_tty = {
-        use std::io::IsTerminal;
-        std::io::stdin().is_terminal()
-    };
+    // Tty-ness resolved once by the `setup::run` dispatcher; every consent
+    // step below (`inject_mode`, `confirm`) takes it as a parameter rather
+    // than probing stdin again mid-chain.
+    let is_tty      = opts.is_tty;
     let Some(config_dir) = zellij_config_dir_or_report() else { return };
 
     // One reader, shared with `check` (`read_zellij_env`): current state into
     // Facts. The env's config text is reused below for the `edit_zellij`
     // splice; the resolved paths are what every write below aims at.
     let (env, paths) = read_zellij_env(&config_dir, layout_name);
-    let ZellijPaths { config_path, wasm_dest, layout_path } = paths;
+    let ZellijPaths { config_path, wasm_dest, layout_path, .. } = paths;
     let location = zellij_plugin_location(&wasm_dest);
     let facts = analyze_zellij(&env);
 
@@ -601,8 +598,10 @@ fn run_layout_inject(layout_path: &Path, inject_flag: bool, yes: bool, dry_run: 
                         "No layout at {} — create it with the rail layout?",
                         layout_path.display()
                     );
-                    // Prompt mode implies !yes && is_tty (see `inject_mode`).
-                    if confirm(&prompt, yes, is_tty) {
+                    // Prompt mode implies !yes && is_tty (see `inject_mode`),
+                    // so pass a literal false: `inject_mode` stays the sole
+                    // authority on `yes` for this flow.
+                    if confirm(&prompt, false, is_tty) {
                         create_full_layout(layout_path, dry_run);
                     } else {
                         print_missing_layout_fallback(layout_path);
@@ -630,7 +629,8 @@ fn run_layout_inject(layout_path: &Path, inject_flag: bool, yes: bool, dry_run: 
         }
         InjectMode::Prompt => {
             let prompt = format!("Inject the rail into {}?", layout_path.display());
-            if !confirm(&prompt, yes, is_tty) {
+            // Prompt mode implies !yes (see above) — literal false, as ever.
+            if !confirm(&prompt, false, is_tty) {
                 print_paste_snippet(&facts);
                 return;
             }

--- a/crates/cli/tests/cli_setup.rs
+++ b/crates/cli/tests/cli_setup.rs
@@ -1,12 +1,6 @@
 //! Integration tests for `zj-radar setup` — codex hooks.json wiring, the
 //! zellij install/uninstall/doctor flows, and the claude plugin-CLI flow.
 //!
-//! Codex coverage:
-//!   1. one real run → writes hooks.json with the ZJ_RADAR_CODEX_HOOK=v1
-//!      marker, without touching a foreign notify slot.
-//!   2. dry-run does NOT write hooks.json; positive control: real run DOES write.
-//!   3. idempotency: two real runs → identical hooks.json; first run is non-vacuous.
-//!
 //! Codex tests isolate via CODEX_HOME pointing to a tempdir. The
 //! `codex_installed()` guard inside setup accepts a pre-existing hooks.json, so
 //! we seed the tempdir with an empty `{}` to satisfy it without needing a fake
@@ -28,7 +22,7 @@ fn isolated_codex_home() -> TempDir {
     dir
 }
 
-// ── Test 1: real run installs hooks without touching a foreign notify slot ──
+// ── real run installs hooks without touching a foreign notify slot ──────────
 
 #[test]
 fn setup_codex_installs_hooks_without_touching_foreign_notify() {
@@ -100,7 +94,7 @@ fn setup_dry_run_does_not_write_hooks_json() {
     );
 }
 
-// ── Test 2: idempotency ─────────────────────────────────────────────────────
+// ── idempotency ─────────────────────────────────────────────────────────────
 
 #[test]
 fn setup_codex_hooks_is_idempotent() {
@@ -136,7 +130,7 @@ fn setup_codex_hooks_is_idempotent() {
     );
 }
 
-// ── Test 2b: codex hook guidance mentions disabled hooks when config says so ──
+// ── codex hook guidance mentions disabled hooks when config says so ───────────
 //
 // `print_codex_hook_guidance` writes the `hooks appear disabled` warning to
 // STDERR (it's a warning) and the `run \`/hooks\`` line to STDOUT — always,
@@ -201,7 +195,7 @@ fn setup_codex_guidance_silent_on_disabled_warning_when_hooks_enabled() {
     );
 }
 
-// ── Test 3: `--wasm` and `--download` are mutually exclusive ─────────────────
+// ── `--wasm` and `--download` are mutually exclusive ─────────────────────────
 // The guard must short-circuit before any download or config write.
 
 #[test]
@@ -394,7 +388,7 @@ fn isolated_zellij_config(layout_text: &str) -> TempDir {
     dir
 }
 
-// ── Test 4pre: --inject with NO layout file creates the full layout ──────────
+// ── --inject with NO layout file creates the full layout ─────────────────────
 // A stock Zellij ships no layout file at all — this is most first installs.
 // The old behavior printed a fragment snippet with nothing to paste it into
 // (a dead end); with --inject consent, the full known-good layout is created.
@@ -447,7 +441,7 @@ fn setup_zellij_yes_never_creates_a_layout_file() {
     );
 }
 
-// ── Test 4a: --inject writes the rail into the layout and creates a .bak ──────
+// ── --inject writes the rail into the layout and creates a .bak ───────────────
 
 #[test]
 fn setup_zellij_inject_writes_rail_and_bak() {
@@ -489,7 +483,7 @@ fn setup_zellij_inject_writes_rail_and_bak() {
     );
 }
 
-// ── Test 4a2: --inject with existing swaps skips swap blocks, prints advisory ──
+// ── --inject with existing swaps skips swap blocks, prints advisory ────────────
 
 #[test]
 fn setup_zellij_inject_with_existing_swaps_skips_swaps_and_advises() {
@@ -548,7 +542,7 @@ layout {
     );
 }
 
-// ── Test 4b: --yes without --inject → Snippet: layout unchanged, prints snippet ─
+// ── --yes without --inject → Snippet: layout unchanged, prints snippet ──────────
 
 #[test]
 fn setup_zellij_yes_without_inject_prints_snippet_and_does_not_modify() {
@@ -581,7 +575,7 @@ fn setup_zellij_yes_without_inject_prints_snippet_and_does_not_modify() {
     );
 }
 
-// ── Test 4c: --uninstall reverses injection ────────────────────────────────────
+// ── --uninstall reverses injection ─────────────────────────────────────────────
 
 #[test]
 fn setup_zellij_uninstall_reverses_injection() {
@@ -626,7 +620,7 @@ fn setup_zellij_uninstall_reverses_injection() {
     );
 }
 
-// ── Test 4c2: --uninstall deletes a layout that setup created whole ───────────
+// ── --uninstall deletes a layout that setup created whole ─────────────────────
 // The no-layout `--inject` path writes `full_layout()` as a new file — no
 // markers, but it references the `radar` alias. Uninstall strips the alias, so
 // leaving that layout behind would strand the next plain Zellij launch on a
@@ -660,7 +654,7 @@ fn setup_zellij_uninstall_deletes_layout_setup_created_whole() {
     );
 }
 
-// ── Test 4c3: --uninstall never deletes an edited marker-less layout ──────────
+// ── --uninstall never deletes an edited marker-less layout ────────────────────
 // Same starting point, but the user has edited the file since: no longer
 // byte-identical to `full_layout()`, so it must survive — with an advisory
 // naming the dead `radar` alias reference instead of a silent strand.
@@ -707,7 +701,7 @@ fn setup_zellij_uninstall_advises_on_edited_whole_created_layout() {
     );
 }
 
-// ── Test 4d: --dry-run prints what would change, writes nothing ────────────────
+// ── --dry-run prints what would change, writes nothing ─────────────────────────
 
 #[test]
 fn setup_zellij_inject_dry_run_prints_and_does_not_write() {
@@ -741,7 +735,7 @@ fn setup_zellij_inject_dry_run_prints_and_does_not_write() {
     );
 }
 
-// ── Test 5: zellij producer hint on the success tail ─────────────────────────
+// ── zellij producer hint on the success tail ─────────────────────────────────
 //
 // `print_producer_hint_if_needed` runs at the tail of a successful `setup
 // zellij` install, on both the `Outcome::Unchanged` arm (config already up to
@@ -840,7 +834,7 @@ fn setup_zellij_unchanged_arm_silent_when_producer_wired() {
     );
 }
 
-// ── Test 6: the grant hint is skipped when permissions.kdl already grants ─────
+// ── the grant hint is skipped when permissions.kdl already grants ─────────────
 //
 // The install path used to build its `ZellijFacts` with `permissions_text:
 // None`, so `granted` was always None and the first-launch grant walkthrough
@@ -1485,7 +1479,7 @@ fn setup_claude_skips_when_binary_missing() {
 fn setup_claude_without_consent_runs_nothing() {
     // Piped stdin means no tty at the boundary probe, so `confirm` takes the
     // safe "no" without reading (answered-y/-n and EOF-decline live in
-    // `confirm_answer`'s unit tests) — the invariant here is that the unmet
+    // `consented`'s unit tests) — the invariant here is that the unmet
     // prompt never lets the plugin CLI run, and says how to consent (-y).
     let shim = ShimDir::new();
     shim.add_recorder("claude");

--- a/crates/core/src/command.rs
+++ b/crates/core/src/command.rs
@@ -8,10 +8,10 @@ use crate::status::Status;
 use std::collections::{HashMap, HashSet};
 
 /// Debounce window: a pending fg command must survive this many ticks before
-/// being promoted to Running. Floored at 2 (~2s at the plugin's 1s tick) so an
+/// being promoted to Running. Kept at 2 (~2s at the plugin's 1s tick) so an
 /// instant `cd`/`ls`-style command that returns to the shell prompt within the
-/// window never earns a line (spec §3.2) — 1 tick left too narrow a margin
-/// against real-world scheduling jitter between the fg command and its
+/// window never earns a line (spec §3.2) — a 1-tick debounce left too narrow a
+/// margin against real-world scheduling jitter between the fg command and its
 /// immediate return.
 ///
 /// This does NOT fully close the "running cd" symptom: promotion fires purely
@@ -178,11 +178,15 @@ fn is_option_arg(s: &str) -> bool {
     s.starts_with('-') && s != "-"
 }
 
+/// First non-option arg at/after `start`. Also skips the stdin-marker
+/// residual: `is_option_arg` deliberately exempts a bare `-`, so it is the one
+/// dashed token this scan would otherwise surface — skip it and keep scanning
+/// rather than hand stdin-marker noise back as a verb or target.
 fn first_non_option(args: &[String], start: usize) -> Option<(usize, &str)> {
     args.iter()
         .enumerate()
         .skip(start)
-        .find_map(|(idx, arg)| (!is_option_arg(arg)).then_some((idx, arg.as_str())))
+        .find_map(|(idx, arg)| (!is_option_arg(arg) && arg != "-").then_some((idx, arg.as_str())))
 }
 
 fn known_subcommand<'a>(args: &'a [String], known: &[&str]) -> Option<(usize, &'a str)> {
@@ -191,14 +195,9 @@ fn known_subcommand<'a>(args: &'a [String], known: &[&str]) -> Option<(usize, &'
     })
 }
 
-/// First non-option arg at/after `start`, usable as a display target. Strips
-/// the stdin-marker residual: `is_option_arg` deliberately exempts a bare `-`,
-/// so it is the one dashed token `first_non_option` can return — drop it here
-/// rather than display stdin-marker noise as a target.
+/// First non-option arg at/after `start`, usable as a display target.
 fn target_after(args: &[String], start: usize) -> Option<&str> {
-    first_non_option(args, start)
-        .map(|(_, arg)| arg)
-        .filter(|t| *t != "-")
+    first_non_option(args, start).map(|(_, arg)| arg)
 }
 
 fn raw_display(parts: &[&str]) -> String {

--- a/crates/core/src/command/tests.rs
+++ b/crates/core/src/command/tests.rs
@@ -154,10 +154,13 @@
             // suffix counts, so `python-config` keeps the first-arg treatment
             // (its arg is NOT basenamed like a script would be).
             (&["python-config", "a/b"], "python-config a/b"),
-            // Deliberate post-refactor behavior: the uniform target dash-guard
-            // drops a bare "-" target (old cargo nextest / go test kept it).
+            // Deliberate post-refactor behavior: `first_non_option` skips a
+            // bare "-" stdin marker and keeps scanning (old cargo nextest /
+            // go test displayed it), so a real target after it still shows.
             (&["go", "test", "-"], "go test"),
             (&["cargo", "nextest", "-"], "cargo nextest"),
+            (&["go", "test", "-", "./..."], "go test ./..."),
+            (&["cat", "-", "notes.txt"], "cat notes.txt"),
         ];
         for (args, want) in cases {
             assert_eq!(&display(&argv(args)), want, "display for {args:?}");

--- a/crates/core/src/pipe.rs
+++ b/crates/core/src/pipe.rs
@@ -48,7 +48,9 @@ const _: () = assert!(RUNNING_PIPE_TIMEOUT_SECS < DEFAULT_PIPE_TIMEOUT_SECS);
 /// `head -c`. Hook payloads are small JSON (well under a megabyte); the cap
 /// only bounds a runaway or hostile writer. Lives beside the send deadlines
 /// because it is the same family: a producer limiting itself so a misbehaving
-/// peer cannot wedge or bloat the hook path.
+/// peer cannot wedge or bloat the hook path. This is the *input* cap, distinct
+/// from the plugin's 64 KB *wire* cap on the broadcast payload the producer
+/// derives from that input.
 pub const MAX_STDIN_BYTES: u64 = 8 * 1024 * 1024;
 
 // $1 = deadline seconds, $2 = pipe name, $3 = payload — positional parameters,

--- a/crates/plugin/src/clock.rs
+++ b/crates/plugin/src/clock.rs
@@ -2,11 +2,15 @@
 //!
 //! A single free function rather than a trait/object: `RadarState` and the
 //! stores beneath it take `now_epoch_s: u64` as a plain argument, so their
-//! tests pass literal epochs with no clock to mock — and `PluginRuntime::timer`
-//! follows the same discipline (its virtual-time harness, `runtime/tests.rs`'s
-//! `FireSim`, passes its own advancing epoch). Only `PluginRuntime`
-//! (`runtime.rs`) and the wasm glue (`lib.rs`) call this — at every entry
-//! point that owns an epoch, plus render (age formatting).
+//! tests pass literal epochs with no clock to mock. Of the runtime's entry
+//! points, `PluginRuntime::timer` follows the stores' pass-the-epoch
+//! discipline (its virtual-time harness, `runtime/tests.rs`'s `FireSim`,
+//! passes its own advancing epoch); the other entry points capture the
+//! clock internally — deliberate: none of them needs virtual time, and
+//! threading an epoch parameter through every event handler would buy
+//! nothing. Only `PluginRuntime` (`runtime.rs`) and the wasm glue
+//! (`lib.rs`) call this — at every entry point that owns an epoch, plus
+//! render (age formatting).
 
 /// Wall-clock seconds since the Unix epoch. Proven to work in wasm32-wasip1
 /// (session_files.rs uses SystemTime). Free function so RadarState/store tests

--- a/crates/plugin/src/ledger.rs
+++ b/crates/plugin/src/ledger.rs
@@ -84,12 +84,15 @@ impl LedgerEntry {
     /// control chars that would otherwise reach the render grid.
     /// `from_observation` never builds a blank field; disk-loaded entries are
     /// held to the same never-blank policy — an all-control-chars value
-    /// scrubs to nothing and falls back to a fixed token instead ("turn
-    /// done" for the label: the same token a live agent turn with an empty
-    /// msg gets, rather than a third vocabulary).
+    /// scrubs to nothing and falls back to a fixed token instead. The label
+    /// fallback is deliberately origin-neutral ("done", not "turn done"):
+    /// origin is not retained on a disk-loaded entry, so this seam cannot
+    /// know whether the entry was an agent turn or a command completion —
+    /// only `from_observation`, which still holds the observation, may pick
+    /// an origin-specific token.
     pub(crate) fn sanitized(mut self) -> LedgerEntry {
         self.tab_name = sanitized_or(&self.tab_name, MAX_TAB_NAME_CHARS, "tab");
-        self.label = sanitized_or(&self.label, MAX_MSG_CHARS, "turn done");
+        self.label = sanitized_or(&self.label, MAX_MSG_CHARS, "done");
         self
     }
 }
@@ -253,11 +256,11 @@ mod tests {
         assert_eq!(e.label, "did things");
 
         // A label that is NOTHING BUT control chars scrubs to empty — fall
-        // back to the same "turn done" token a live agent turn with an empty
-        // msg gets (`from_observation`), so a ledger row never renders
-        // without an identity and the fallback vocabulary stays singular.
+        // back to an origin-NEUTRAL "done": origin is not retained on a
+        // disk-loaded entry, so this seam must not guess "turn done" (an
+        // agent-turn claim) for what may have been a command completion.
         let e = entry(1, LedgerOutcome::Done, "\x1b[2J\x07", 5).sanitized();
-        assert_eq!(e.label, "turn done");
+        assert_eq!(e.label, "done");
     }
 
     #[test]

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -336,10 +336,10 @@ impl ZellijPlugin for State {
             // no other plugin required) and carries `ModeInfo.session_name`,
             // which is all this plugin ever needed from `SessionUpdate` in
             // the first place; liveness itself now comes from the presence
-            // files' own mtimes, turned into a per-entry stale/fresh state
-            // (`sessions::STALE_AFTER_SECS`) rather than a Zellij-reported
-            // peer list — and, per the never-vanish roster, a peer past
-            // that age dims rather than vanishing.
+            // files' own mtimes, graded per entry rather than read from a
+            // Zellij-reported peer list: fresh (≤90s,
+            // `sessions::STALE_AFTER_SECS`) → stale/dimmed (90–300s) →
+            // reaped past `sessions::DEAD_AFTER_SECS` (300s).
             EventType::ModeUpdate,
         ]);
         // Seed from the shared snapshot so a tab opened after agents were already

--- a/crates/plugin/src/render.rs
+++ b/crates/plugin/src/render.rs
@@ -338,14 +338,16 @@ impl LineBg {
     /// per-row `finalize` closure is the caller; the row-less rail surfaces
     /// never come through here — they are all `LineBg::Rail` by
     /// construction and take the one-line identity in [`paint_if_cards`]
-    /// instead. `rail` is the precomputed panel-base escape. `None` out
-    /// means the line is never painted.
-    fn escape(self, row: &TabRow, theme: &DerivedColors, rail: &str) -> Option<String> {
+    /// instead. `rail` is the precomputed panel-base escape, borrowed
+    /// straight through (`Cow::Borrowed`) rather than re-allocated per
+    /// inter-card separator line per frame. `None` out means the line is
+    /// never painted.
+    fn escape<'a>(self, row: &TabRow, theme: &DerivedColors, rail: &'a str) -> Option<std::borrow::Cow<'a, str>> {
         match self {
             LineBg::None => Option::None,
-            LineBg::Rail => Some(rail.to_string()),
-            LineBg::Card => Some(card_tint(row, theme)),
-            LineBg::ActiveChild => Some(tc_bg(theme.surface_agent)),
+            LineBg::Rail => Some(std::borrow::Cow::Borrowed(rail)),
+            LineBg::Card => Some(std::borrow::Cow::Owned(card_tint(row, theme))),
+            LineBg::ActiveChild => Some(std::borrow::Cow::Owned(tc_bg(theme.surface_agent))),
         }
     }
 }
@@ -358,6 +360,10 @@ impl LineBg {
 /// Rail line per frame for a value the caller already holds. Outside Cards
 /// density the line passes through untouched.
 fn paint_if_cards(line: Line, cards: bool, width: usize, rail: &str) -> Line {
+    debug_assert!(
+        matches!(line.bg, LineBg::Rail | LineBg::None),
+        "row-less surface emitted a row-owned line class"
+    );
     match line.bg {
         LineBg::Rail if cards => line.painted(width, rail),
         _ => line,
@@ -1500,15 +1506,10 @@ fn render_session_badge(entries: &[BadgeEntry], opts: &RenderOpts) -> Vec<Line> 
                     } else {
                         Seg::new(&idle, clamped)
                     };
-                    // Only the current line ever holds a `•` here (`marker`
-                    // above); peers carry the alignment space, which paints
-                    // the same in any color.
-                    let marker_seg = if entry.is_current {
-                        Seg::new(accent, marker)
-                    } else {
-                        Seg::new(&idle, marker)
-                    };
-                    format!("{} {}", marker_seg, label_seg)
+                    // Peers' alignment space paints identically in any
+                    // color — byte-stable output.
+                    let marker_color = if entry.is_current { accent } else { &idle };
+                    format!("{} {}", Seg::new(marker_color, marker), label_seg)
                 },
             );
             let target = (!entry.is_current)
@@ -1612,12 +1613,17 @@ fn render_body(rows: &[TabRow], ledger: &[LedgerLine], opts: &RenderOpts) -> Vec
         // Resolve a raw line's surface through the one `LineBg::escape` map by
         // consuming the complete `Line`. Metadata such as targets and hotspots
         // rides inside the value, so Cards finalization cannot forget it when
-        // `Line` grows another lockstep field.
+        // `Line` grows another lockstep field. Outside Cards density nothing
+        // paints, so the map (and its owned Card/ActiveChild escapes) is
+        // never consulted at all.
         let finalize = |line: Line| -> Line {
-            let bg = line.bg;
-            let mut line = match bg.escape(row, &opts.theme, &rail) {
-                Some(esc) if cards => line.painted(width, &esc),
-                _ => line,
+            let mut line = if cards {
+                match line.bg.escape(row, &opts.theme, &rail) {
+                    Some(esc) => line.painted(width, &esc),
+                    None => line,
+                }
+            } else {
+                line
             };
             line.bg = LineBg::None;
             line

--- a/crates/plugin/src/render/tests.rs
+++ b/crates/plugin/src/render/tests.rs
@@ -3691,14 +3691,25 @@ fn line_bg_escape_is_the_one_home_for_the_surface_map() {
     // Each class resolves to exactly the surface the old inline logic used —
     // asserted against the existing helpers, not hard-coded RGB.
     assert_eq!(LineBg::None.escape(&active_row, &theme, &rail), None);
-    assert_eq!(LineBg::Rail.escape(&active_row, &theme, &rail), Some(rail.clone()));
     assert_eq!(
-        LineBg::Card.escape(&active_row, &theme, &rail),
-        Some(card_tint(&active_row, &theme)),
+        LineBg::Rail.escape(&active_row, &theme, &rail).as_deref(),
+        Some(rail.as_str()),
     );
+    // Rail resolves by borrowing the caller's precomputed escape — the
+    // per-separator-line allocation this map used to pay is gone.
+    assert!(matches!(
+        LineBg::Rail.escape(&active_row, &theme, &rail),
+        Some(std::borrow::Cow::Borrowed(_)),
+    ));
+    let card = card_tint(&active_row, &theme);
     assert_eq!(
-        LineBg::ActiveChild.escape(&active_row, &theme, &rail),
-        Some(tc_bg(theme.surface_agent)),
+        LineBg::Card.escape(&active_row, &theme, &rail).as_deref(),
+        Some(card.as_str()),
+    );
+    let agent = tc_bg(theme.surface_agent);
+    assert_eq!(
+        LineBg::ActiveChild.escape(&active_row, &theme, &rail).as_deref(),
+        Some(agent.as_str()),
     );
     // The drift the `cards_active_more_line_*` regression guards: on an active
     // row a child line (ActiveChild → surface_agent) must NOT resolve to the

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -104,6 +104,11 @@ const PRESENCE_READ_TICK_INTERVAL: u64 = 5;
 /// fire alone starved exactly the busiest sessions stale.
 const PRESENCE_HEARTBEAT_S: u64 = 60;
 
+// The liveness ladder's safety argument IS this ordering — writes beat the
+// dim threshold, and dimming long precedes the file-deleting reap.
+const _: () = assert!(PRESENCE_HEARTBEAT_S < crate::sessions::STALE_AFTER_SECS);
+const _: () = assert!(crate::sessions::STALE_AFTER_SECS < crate::sessions::DEAD_AFTER_SECS);
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Effect {
     RequestPermission,
@@ -159,7 +164,10 @@ pub(crate) enum Effect {
     SwitchSession { name: String, tab_position: Option<usize> },
     /// Delete every on-disk presence file whose `session_name` matches
     /// `name` — all of them, since a name can have multiple pid-keyed
-    /// corpses (`sessions.rs`'s dedup doc). Emitted by `mouse_right_click`
+    /// corpses (`sessions.rs`'s dedup doc) — except this session's own
+    /// live file, which `SessionFiles::remove_presences_matching` spares
+    /// by path identity, so even a dismiss of our own name (a dead corpse
+    /// of a restarted session) is safe. Emitted by `mouse_right_click`
     /// right after `Sessions::dismiss` has already dropped the name from
     /// THIS instance's in-memory roster (the instant-feedback half); this
     /// is the on-disk half, so every peer's next Fast read converges too.
@@ -569,9 +577,9 @@ impl PluginRuntime {
     /// what the target resolved to:
     ///
     /// - **A peer-session badge line** (`session: Some(name)`) — dismiss a
-    ///   STALE cross-session entry, the manual complement to the 6h
-    ///   open-time sweep (`session_files`'s `PRESENCE_MAX_AGE`), for a
-    ///   session the user already knows is dead. This branch is untouched
+    ///   STALE cross-session entry, the manual complement to the
+    ///   `sessions::DEAD_AFTER_SECS` auto-reap, for a stale-not-yet-dead
+    ///   entry the user already knows is dead. This branch is untouched
     ///   from before issue #5 and takes precedence: a session target never
     ///   also carries a `pane_id`, but checking it first keeps the cases
     ///   visibly exclusive rather than relying on that absence. Everything
@@ -743,23 +751,17 @@ impl PluginRuntime {
     /// already reaped from the badge, and each gets an
     /// `Effect::DismissPresence` here so the on-disk file is unlinked too —
     /// idempotent across the per-tab instances (every unlink after the
-    /// first finds nothing left matching). One exemption: our OWN name. A
-    /// dead corpse can carry this session's name (pid-keyed files — see
-    /// `Sessions::ordered`'s collision note), and the on-disk dismiss
-    /// deletes by name content with deliberately no own-file exclusion
-    /// (`SessionFiles::remove_presences_matching`) — dismissing our own
-    /// name would unlink our own LIVE presence file and blank this session
-    /// off every peer's badge until the next heartbeat. Such a corpse is
-    /// left to the open-time `PRESENCE_MAX_AGE` sweep instead (it never
-    /// renders anyway — `ordered()` drops own-name peers outright).
+    /// first finds nothing left matching). Unconditional, own name
+    /// included: a dead corpse can carry this session's name (pid-keyed
+    /// files — see `Sessions::ordered`'s collision note), and reaping it is
+    /// safe because the on-disk delete spares our own live file by *path*
+    /// identity (`SessionFiles::remove_presences_matching`'s own-file
+    /// exclusion), never by name.
     pub(crate) fn presences_changed(&mut self, raw: Vec<(String, u64)>) -> Outcome {
         let update = self.sessions.update_presences(raw);
         let change = RadarChange { render: update.changed, ..RadarChange::default() };
         let mut out = self.project(vec![], change, self.last_now_epoch_s);
         for name in update.dead {
-            if name == self.own_session_name {
-                continue;
-            }
             out.effects.push(Effect::DismissPresence { name });
         }
         out

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -24,11 +24,25 @@ fn runtime_with_config(config: config::Config) -> PluginRuntime {
 }
 
 impl PluginRuntime {
+    /// Test shorthand: deliver a timer fire "now" (a real wall-clock
+    /// capture) with the given elapsed. The sites that still pass an
+    /// explicit epoch to `timer` directly are exactly the ones where the
+    /// epoch value is load-bearing (virtual time, or a deliberately shifted
+    /// clock) — they're meant to stand out.
+    fn timer_now(&mut self, permission: PermissionProbe, elapsed: f64) -> Outcome {
+        self.timer(permission, elapsed, crate::clock::now_epoch_s())
+    }
+
     /// Test shorthand: deliver a live Fast fire (elapsed ~1s) — how every
     /// test that isn't about the stale-fire dedup drives the tick entry
-    /// point. Dedup tests pass explicit elapsed values to `timer` instead.
+    /// point. Dedup tests pass explicit elapsed values via `timer_now`.
     fn timer_fast(&mut self, permission: PermissionProbe) -> Outcome {
-        self.timer(permission, Cadence::Fast.seconds(), crate::clock::now_epoch_s())
+        self.timer_now(permission, Cadence::Fast.seconds())
+    }
+
+    /// Test shorthand: deliver a live Slow fire (elapsed ~60s).
+    fn timer_slow(&mut self, permission: PermissionProbe) -> Outcome {
+        self.timer_now(permission, Cadence::Slow.seconds())
     }
 }
 
@@ -1219,19 +1233,25 @@ fn dead_peer_read_auto_dismisses_and_repaints() {
 }
 
 #[test]
-fn dead_corpse_carrying_own_name_is_never_auto_dismissed() {
+fn dead_corpse_carrying_own_name_is_auto_dismissed_like_any_other() {
     // A pid-keyed corpse of THIS session (killed and recreated under the
-    // same name) reads back as a dead peer carrying our own name. The
-    // on-disk dismiss deletes by name content with no own-file exclusion
-    // (`remove_presences_matching`), so auto-dismissing it would unlink our
-    // own LIVE presence file too — the reap must skip our own name and
-    // leave that corpse to the open-time sweep.
+    // same name) reads back as a dead peer carrying our own name. The reap
+    // treats it like any other dead name — no own-name exemption — because
+    // the on-disk delete (`remove_presences_matching`) spares our own LIVE
+    // presence file by *path* identity, never by name: the dismiss unlinks
+    // the corpse's pid-keyed file and nothing else (the file-level half is
+    // pinned by session_files.rs's
+    // `remove_presences_matching_spares_the_own_file_but_reaps_same_name_corpses`).
     let mut rt = runtime_with_granted_permission(); // own session name "work"
     let out = rt.presences_changed(vec![dead(r#"{"session_name":"work","running":9,"attention":9}"#)]);
     assert!(
-        !out.effects.iter().any(|e| matches!(e, Effect::DismissPresence { .. })),
-        "a dead corpse of our own name must never be auto-dismissed, got {:?}",
+        out.effects.contains(&Effect::DismissPresence { name: "work".into() }),
+        "a dead corpse carrying our own name must be reaped like any other dead entry, got {:?}",
         out.effects
+    );
+    assert!(
+        !rt.sessions.badge().iter().any(|b| b.name == "work" && !b.is_current),
+        "the corpse must not linger as a peer entry in memory"
     );
 }
 
@@ -2075,7 +2095,7 @@ fn idle_with_fresh_history_arms_slow_and_repaints() {
     // The slow fire itself must render — it exists precisely to repaint
     // the ledger's ages. A genuine Slow fire (elapsed ~60s), because the
     // repaint clause keys on the fire that landed, not on `desired_cadence`.
-    let tick = rt.timer(PermissionProbe::default(), Cadence::Slow.seconds(), crate::clock::now_epoch_s());
+    let tick = rt.timer_slow(PermissionProbe::default());
     assert!(tick.render, "a slow fire renders to repaint ledger ages");
 }
 
@@ -2256,7 +2276,7 @@ fn live_fast_fire_processes_then_stale_slow_fire_is_swallowed() {
 
     // The live fast fire (elapsed ~1s) ticks and re-arms exactly once.
     let tick_before = rt.tick;
-    let live = rt.timer(PermissionProbe::default(), 1.0, crate::clock::now_epoch_s());
+    let live = rt.timer_now(PermissionProbe::default(), 1.0);
     assert_eq!(rt.tick, tick_before + 1, "the live fast fire ticks");
     let rearms = live
         .effects
@@ -2274,13 +2294,13 @@ fn live_fast_fire_processes_then_stale_slow_fire_is_swallowed() {
     // effects, the live arm untouched. Ticking it would re-arm a
     // second persistent chain.
     let tick_before = rt.tick;
-    let stale = rt.timer(PermissionProbe::default(), 60.0, crate::clock::now_epoch_s());
+    let stale = rt.timer_now(PermissionProbe::default(), 60.0);
     assert_eq!(stale, Outcome::none(), "a stale slow fire must be swallowed whole");
     assert_eq!(rt.tick, tick_before, "a swallowed fire must not advance the tick");
     assert_eq!(rt.timer_chain.armed(), Some(Cadence::Fast), "a swallowed fire must not disturb the live arm");
 
     // Steady state: exactly one chain remains and keeps ticking.
-    let next = rt.timer(PermissionProbe::default(), 1.0, crate::clock::now_epoch_s());
+    let next = rt.timer_now(PermissionProbe::default(), 1.0);
     assert_eq!(rt.tick, tick_before + 1, "the surviving chain keeps ticking");
     assert!(
         next.effects.contains(&Effect::SetTimeout(Cadence::Fast)),
@@ -2298,13 +2318,13 @@ fn stale_slow_fire_landing_first_is_swallowed() {
     let mut rt = slow_armed_then_fast_topup();
 
     let tick_before = rt.tick;
-    let stale = rt.timer(PermissionProbe::default(), 60.0, crate::clock::now_epoch_s());
+    let stale = rt.timer_now(PermissionProbe::default(), 60.0);
     assert_eq!(stale, Outcome::none(), "a stale slow fire must be swallowed whole");
     assert_eq!(rt.tick, tick_before, "a swallowed fire must not advance the tick");
     assert_eq!(rt.timer_chain.armed(), Some(Cadence::Fast), "a swallowed fire must not disturb the live arm");
 
     // The surviving fast fire ticks normally and re-arms exactly once.
-    let live = rt.timer(PermissionProbe::default(), 1.0, crate::clock::now_epoch_s());
+    let live = rt.timer_now(PermissionProbe::default(), 1.0);
     assert_eq!(rt.tick, tick_before + 1, "the live fire ticks");
     let rearms = live
         .effects
@@ -2340,7 +2360,7 @@ fn lone_slow_fire_processes_as_the_live_chain() {
     rt.tabs_changed(vec![]); // arms Slow: the only fire in flight
     assert_eq!(rt.timer_chain.armed(), Some(Cadence::Slow));
 
-    let tick = rt.timer(PermissionProbe::default(), 60.0, crate::clock::now_epoch_s());
+    let tick = rt.timer_now(PermissionProbe::default(), 60.0);
     assert!(tick.render, "the lone slow fire processes and repaints ledger ages");
     assert!(
         tick.effects.contains(&Effect::SetTimeout(Cadence::Slow)),
@@ -2419,7 +2439,7 @@ fn heartbeat_coincident_with_a_genuine_presence_edge_persists_exactly_once() {
     // slow-armed fire first (the "rare order" of
     // `stale_slow_fire_landing_first_is_swallowed`): swallowed whole, so it
     // doesn't advance the debounce tick count either.
-    let stale = rt.timer(PermissionProbe::default(), Cadence::Slow.seconds(), crate::clock::now_epoch_s());
+    let stale = rt.timer_slow(PermissionProbe::default());
     assert_eq!(stale, Outcome::none(), "setup: the pre-armed slow fire is stale and swallowed");
 
     // Ticks short of the debounce window: quiet, and don't disturb the fire
@@ -2437,7 +2457,7 @@ fn heartbeat_coincident_with_a_genuine_presence_edge_persists_exactly_once() {
     // reviewer's exact probe: a live fire whose overdue heartbeat seeds a
     // push AND whose own tick promotes pending -> Running, landing a genuine
     // content edge on the same pass.
-    let tick = rt.timer(PermissionProbe::default(), Cadence::Slow.seconds(), crate::clock::now_epoch_s());
+    let tick = rt.timer_slow(PermissionProbe::default());
     let persists = tick.effects.iter().filter(|e| matches!(e, Effect::PersistPresence)).count();
     assert_eq!(
         persists, 1,
@@ -2463,7 +2483,7 @@ fn read_presences_is_bound_to_fast_fires_only() {
 
     let scans: Vec<bool> = (0..(2 * PRESENCE_READ_TICK_INTERVAL))
         .map(|_| {
-            rt.timer(PermissionProbe::default(), Cadence::Fast.seconds(), crate::clock::now_epoch_s())
+            rt.timer_fast(PermissionProbe::default())
                 .effects
                 .contains(&Effect::ReadPresences)
         })
@@ -2483,7 +2503,7 @@ fn read_presences_is_bound_to_fast_fires_only() {
         config: config(),
         ..Default::default()
     };
-    let slow = rt.timer(PermissionProbe::default(), Cadence::Slow.seconds(), crate::clock::now_epoch_s());
+    let slow = rt.timer_slow(PermissionProbe::default());
     assert!(!slow.effects.contains(&Effect::ReadPresences), "a Slow fire must not scan peers, got {:?}", slow.effects);
 }
 

--- a/crates/plugin/src/session_files.rs
+++ b/crates/plugin/src/session_files.rs
@@ -38,16 +38,15 @@ const NOTIFY_CLAIM_TTL: Duration = Duration::from_secs(30);
 const NOTIFY_CLAIM_SWEEP_AGE: Duration = Duration::from_secs(300);
 const PERMISSION_GRANTED_MARKER: &str = "granted";
 const PERMISSION_DENIED_MARKER: &str = "denied";
-/// Horizon after which a presence file is deleted as debris at `open` time —
-/// the ONLY true forgetting a peer's roster entry is subject to (never-vanish
-/// roster, user decision: a remembered session must never silently vanish
-/// from the badge — `docs/design.md`). Peers dead well before their file
-/// turns 6h old still keep showing up in every other session's badge, dimmed
-/// as stale
-/// (`sessions::STALE_AFTER_SECS`) rather than dropped — this sweep only
-/// exists so a long string of genuinely dead sessions' files don't
-/// accumulate forever in the shared root. Generous: a detached-but-alive
-/// session whose timer idles must not be reaped.
+/// Horizon after which a presence file is deleted as debris at `open` time.
+/// NOT the primary forgetting: the roster ladder (`docs/design.md`) is
+/// fresh (≤90s, `sessions::STALE_AFTER_SECS`) → stale/dimmed (90–300s) →
+/// reaped past `sessions::DEAD_AFTER_SECS` (300s), when the runtime's
+/// auto-reap unlinks the file (`Effect::DismissPresence`). This sweep is
+/// the backstop for debris that reap can't touch — malformed/unparseable
+/// files, which never produce a name to dismiss by. Generous: a live
+/// session heartbeats its file every 60s, so anything this old is
+/// unambiguously abandoned.
 const PRESENCE_MAX_AGE: Duration = Duration::from_secs(6 * 60 * 60);
 /// Deliberately distinct from the pid-scoped `session_prefix` (`zj-radar.<pid>`) so
 /// `is_owned_session_file` / `is_current_session_file` and the snapshot sweep
@@ -193,20 +192,17 @@ impl SessionFiles {
     /// Raw JSON of every OTHER session's presence file (own pid excluded, tmp
     /// files excluded), paired with how long ago its mtime was last touched.
     /// Parsing/validation is the caller's job (`Presence::parse` skips
-    /// corrupt peers) — and so, now, is staleness: this method used to treat
-    /// an old mtime as "peer is gone" and skip it outright, but the
-    /// never-vanish-roster user decision (`docs/design.md`) is that a
-    /// remembered session must never silently vanish from the badge, so
-    /// every peer file found comes back
-    /// unconditionally. `age_secs` is measured off THIS session's own
+    /// corrupt peers) — and so is liveness grading: every peer file found
+    /// comes back unconditionally, and `sessions::Sessions::update_presences`
+    /// grades its age into the fresh (≤90s) → stale/dimmed (90–300s) →
+    /// reaped (>300s, `sessions::DEAD_AFTER_SECS`) ladder without doing its
+    /// own filesystem I/O. `age_secs` is measured off THIS session's own
     /// filesystem clock reading the file's mtime — not the peer's
     /// self-reported `updated_epoch_s` inside the JSON, which a corrupt or
-    /// merely-slow-to-update peer could get wrong — and lets
-    /// `sessions::Sessions::update_presences` mark an entry stale
-    /// (`sessions::STALE_AFTER_SECS`) without doing its own filesystem I/O.
-    /// Read-only regardless: nothing is ever deleted here (the open-time
-    /// sweep, `PRESENCE_MAX_AGE`, owns the only actual forgetting). Read on
-    /// timer ticks only — bounded by live session count, never per-pane.
+    /// merely-slow-to-update peer could get wrong. Read-only regardless:
+    /// nothing is ever deleted here (the reap's `Effect::DismissPresence`
+    /// and the open-time `PRESENCE_MAX_AGE` sweep own the forgetting). Read
+    /// on timer ticks only — bounded by live session count, never per-pane.
     pub(crate) fn read_peer_presences(&self) -> Vec<PeerPresenceFile> {
         self.read_peer_presences_at(SystemTime::now())
     }
@@ -231,28 +227,32 @@ impl SessionFiles {
     }
 
     /// Delete every presence file in the shared root whose raw JSON content
-    /// satisfies `matches` — the on-disk half of a manual dismiss
-    /// (`Effect::DismissPresence`), and the only forgetting besides the
-    /// open-time `PRESENCE_MAX_AGE` sweep. Same file recognizer as
-    /// `read_peer_presences` (prefix + `.json`, so tmp files and snapshots
-    /// never match), but deliberately no own-file exclusion: this is
-    /// content-driven, not identity-driven, and the runtime only ever calls
-    /// it for a name it has confirmed stale — the own entry is never stale
-    /// (`sessions::Sessions::dismiss`). Every match is deleted, not just the
-    /// freshest: a name can have multiple pid-keyed corpses on disk (see
-    /// `update_presences`'s dedup doc in `sessions.rs`). Parse-agnostic on
-    /// purpose — the predicate receives raw file content, and the caller
-    /// (lib.rs's effect handler) supplies a `Presence::parse`-based closure,
-    /// so name matching stays exactly as lenient as every other presence
-    /// read path without this module learning about `Presence` at all.
-    /// A no-op in disabled mode (no writable root).
+    /// satisfies `matches` — the on-disk half of a dismiss
+    /// (`Effect::DismissPresence`, manual or auto-reap). Same file
+    /// recognizer as `read_peer_presences` (prefix + `.json`, so tmp files
+    /// and snapshots never match) and the same own-file exclusion, applied
+    /// at the same pre-read seam: this session's own live file is spared by
+    /// *path* identity, so the delete primitive itself can never unlink it
+    /// — but its NAME is still matched like any other content, so a dead
+    /// pid-keyed corpse carrying our own name (a restarted session) is
+    /// reaped here like any other corpse. Every match is deleted, not just
+    /// the freshest: a name can have multiple pid-keyed corpses on disk
+    /// (see `update_presences`'s dedup doc in `sessions.rs`). One edge two
+    /// servers sharing a presence root can hit: a name-matched delete could
+    /// unlink a same-named LIVE session under another server — covered by
+    /// the non-destructive doctrine (`sessions::Sessions::dismiss`): its
+    /// next heartbeat republishes the file and it reappears fresh.
+    /// Parse-agnostic on purpose — the predicate receives raw file content,
+    /// and the caller (lib.rs's effect handler) supplies a
+    /// `Presence::parse`-based closure, so name matching stays exactly as
+    /// lenient as every other presence read path without this module
+    /// learning about `Presence` at all. A no-op in disabled mode (no
+    /// writable root).
     pub(crate) fn remove_presences_matching(&self, matches: impl Fn(&str) -> bool) {
         let Some(paths) = &self.paths else {
             return;
         };
-        // Pass-all name predicate: the delete is content-driven by design
-        // (see above), so every presence file must actually be read.
-        for_each_presence_file(&paths.root, |_| true, |entry, json| {
+        for_each_presence_file(&paths.root, |name| !paths.is_own_presence_file(name), |entry, json| {
             if matches(&json) {
                 let _ = std::fs::remove_file(entry.path());
             }
@@ -1039,13 +1039,12 @@ mod tests {
 
     #[test]
     fn read_peer_presences_never_drops_an_old_mtime_peer_and_reports_its_age() {
-        // Never-vanish roster, user decision: a remembered session must
-        // never silently vanish from the badge. This method used to skip a
-        // peer once its file's mtime drifted past a liveness TTL; now it must keep
-        // returning that peer unconditionally — dropping only ever happens
-        // at `open`'s much-longer `PRESENCE_MAX_AGE` sweep — and report an
-        // honest age so the caller (`sessions::Sessions`) can mark it stale
-        // instead.
+        // The read path grades nothing: this method used to skip a peer
+        // once its file's mtime drifted past a liveness TTL; now it must
+        // keep returning that peer unconditionally with an honest age, so
+        // the caller (`sessions::Sessions`) owns the whole fresh → stale →
+        // reaped ladder — dropping happens there (`DEAD_AFTER_SECS`) or at
+        // `open`'s much-longer `PRESENCE_MAX_AGE` debris sweep, never here.
         let dir = tempfile::tempdir().unwrap();
         let reader = SessionFiles::open_with_roots_at(
             SessionFileIds { plugin_id: 1, zellij_pid: 100 },
@@ -1083,7 +1082,7 @@ mod tests {
         let old = peers.iter().find(|p| p.json.contains("\"old\"")).expect("old-mtime peer still present, not dropped");
         assert!(fresh.age_secs < 5, "freshly-written peer's age should read ~0s, got {}", fresh.age_secs);
         assert!(old.age_secs >= old_age.as_secs(), "backdated peer's age must reflect its real mtime, got {}", old.age_secs);
-        assert!(old_path.exists(), "the read path must never delete anything — only the open-time sweep does");
+        assert!(old_path.exists(), "the read path must never delete anything — only the dismiss/reap and the open-time sweep do");
     }
 
     #[test]
@@ -1136,6 +1135,41 @@ mod tests {
         assert!(!dir.path().join("zj-radar.presence.200.json").exists());
         assert!(!dir.path().join("zj-radar.presence.300.json").exists());
         assert!(dir.path().join("zj-radar.presence.400.json").exists());
+    }
+
+    #[test]
+    fn remove_presences_matching_spares_the_own_file_but_reaps_same_name_corpses() {
+        // The own-file exclusion lives at the delete primitive itself, by
+        // *path* identity: a dismiss of this session's own NAME (a dead
+        // pid-keyed corpse of a restarted session) unlinks the corpse's
+        // file while the live file this instance keeps heartbeating is
+        // structurally unreachable — which is what lets the runtime's
+        // auto-reap treat its own name like any other dead name.
+        let dir = tempfile::tempdir().unwrap();
+        let me = SessionFiles::open_with_roots_at(
+            SessionFileIds { plugin_id: 1, zellij_pid: 100 },
+            [dir.path().to_path_buf()],
+            SystemTime::now(),
+            SNAPSHOT_MAX_AGE,
+        );
+        me.files.persist_presence(r#"{"session_name":"alpha","running":1,"attention":0}"#);
+        // A corpse of a previous server incarnation, same name, older pid.
+        std::fs::write(
+            dir.path().join("zj-radar.presence.99.json"),
+            r#"{"session_name":"alpha","running":0,"attention":0}"#,
+        )
+        .unwrap();
+
+        me.files.remove_presences_matching(|json| json.contains(r#""alpha""#));
+
+        assert!(
+            dir.path().join("zj-radar.presence.100.json").exists(),
+            "the own live file must be spared by path identity even when its name matches"
+        );
+        assert!(
+            !dir.path().join("zj-radar.presence.99.json").exists(),
+            "a same-name corpse under another pid must be reaped"
+        );
     }
 
     #[test]

--- a/crates/plugin/src/sessions.rs
+++ b/crates/plugin/src/sessions.rs
@@ -59,14 +59,27 @@ pub(crate) const STALE_AFTER_SECS: u64 = 90;
 /// returns, fresh.
 pub(crate) const DEAD_AFTER_SECS: u64 = 300;
 
-/// A peer's [`Presence`] plus the staleness derived from its presence
-/// file's mtime age at the last read (see the module doc). `stale` is a
-/// snapshot from that read, not re-evaluated against a live clock — like
-/// every other peer fact here, it's only ever as fresh as the last
-/// `update_presences` call.
+/// A peer's [`Presence`] plus its presence file's mtime age at the last
+/// read (see the module doc). `age_secs` is a snapshot from that read, not
+/// re-evaluated against a live clock — like every other peer fact here,
+/// it's only ever as fresh as the last `update_presences` call.
 struct Peer {
     presence: Presence,
-    stale: bool,
+    age_secs: u64,
+}
+
+impl Peer {
+    /// Past [`STALE_AFTER_SECS`]: dimmed on the badge, unreachable via
+    /// `cycle()`. The one place the threshold is applied.
+    fn stale(&self) -> bool {
+        self.age_secs > STALE_AFTER_SECS
+    }
+
+    /// Past [`DEAD_AFTER_SECS`]: reaped from the badge, name reported for
+    /// the on-disk unlink. The one place the threshold is applied.
+    fn dead(&self) -> bool {
+        self.age_secs > DEAD_AFTER_SECS
+    }
 }
 
 /// A row in the shared ordering: a [`Presence`] (own or peer) plus whether
@@ -89,7 +102,6 @@ struct OrderedEntry<'a> {
 /// `peers` this pass, reported so the runtime can unlink their files
 /// (`Effect::DismissPresence`). Sorted by name, so the downstream effect
 /// order is deterministic (the dedup map isn't).
-#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct PresenceUpdate {
     pub changed: bool,
     pub dead: Vec<String>,
@@ -172,13 +184,19 @@ impl Sessions {
         // carried alongside is whichever entry won this dedup — a corpse
         // losing to a fresh recreation of the same name also loses its
         // (typically old) age along with it.
-        let mut by_name: HashMap<String, (Presence, u64)> = HashMap::new();
+        let mut by_name: HashMap<String, Peer> = HashMap::new();
         for (json, age_secs) in raw {
             let Some(p) = Presence::parse(&json) else { continue };
-            if by_name.get(&p.session_name).is_some_and(|(kept, _)| kept.updated_epoch_s > p.updated_epoch_s) {
-                continue; // existing is strictly fresher: keep it
+            match by_name.entry(p.session_name.clone()) {
+                std::collections::hash_map::Entry::Occupied(kept)
+                    if kept.get().presence.updated_epoch_s > p.updated_epoch_s => {} // existing is strictly fresher: keep it
+                std::collections::hash_map::Entry::Occupied(mut kept) => {
+                    kept.insert(Peer { presence: p, age_secs });
+                }
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    slot.insert(Peer { presence: p, age_secs });
+                }
             }
-            by_name.insert(p.session_name.clone(), (p, age_secs));
         }
         // Grade each entry's age AFTER the dedup, never before: a dead
         // corpse must not report its name dead when a fresher file for the
@@ -186,12 +204,11 @@ impl Sessions {
         let mut dead: Vec<String> = Vec::new();
         self.peers = by_name
             .into_values()
-            .filter_map(|(presence, age_secs)| {
-                if age_secs > DEAD_AFTER_SECS {
-                    dead.push(presence.session_name);
-                    return None;
+            .filter(|p| {
+                if p.dead() {
+                    dead.push(p.presence.session_name.clone());
                 }
-                Some(Peer { presence, stale: age_secs > STALE_AFTER_SECS })
+                !p.dead()
             })
             .collect();
         dead.sort();
@@ -368,8 +385,8 @@ impl Sessions {
             if own_name == Some(peer.presence.session_name.as_str()) {
                 continue;
             }
-            let entry = OrderedEntry { presence: &peer.presence, is_current: false, stale: peer.stale };
-            if peer.stale {
+            let entry = OrderedEntry { presence: &peer.presence, is_current: false, stale: peer.stale() };
+            if peer.stale() {
                 stale.push(entry);
             } else if peer.presence.attention > 0 {
                 attention.push(entry);

--- a/crates/plugin/tests/e2e/main.rs
+++ b/crates/plugin/tests/e2e/main.rs
@@ -1074,9 +1074,9 @@ fn rail_paints_every_column_of_its_pane() {
 /// "Why not SessionUpdate", for the full root-cause dive (this test used to
 /// fail with a STOP-CONDITION panic pointing at exactly that). The fix drops
 /// `SessionUpdate` from the design entirely: liveness is now the presence
-/// files' own mtimes, turned into a per-entry fresh/stale state
-/// (`sessions::STALE_AFTER_SECS`) rather than a read-time drop (the
-/// never-vanish roster), and this session's own name comes from `ModeUpdate`
+/// files' own mtimes, graded per entry into fresh (≤90s,
+/// `sessions::STALE_AFTER_SECS`) → stale/dimmed (90–300s) → reaped past
+/// `sessions::DEAD_AFTER_SECS` (300s), and this session's own name comes from `ModeUpdate`
 /// instead — both push-style, neither needing any other plugin to be running.
 #[test]
 #[ignore = "e2e: requires zellij + built wasm; run via `just test-e2e`"]
@@ -1149,7 +1149,7 @@ fn session_next_switches_to_the_session_with_attention() {
          `Event::ModeUpdate` (so `project` withheld `Effect::PersistPresence`), or B's presence \
          file (written under the shared /cache root) never reached A (A's `Effect::ReadPresences` \
          is Fast-tick-gated — see the rail above for whether A even looks fast-armed). Under \
-         the never-vanish roster, a stale peer still renders (dimmed) rather than being dropped, so a bare \
+         the fresh→stale→reaped ladder, a merely-stale peer still renders (dimmed) for 300s before the reap, so a bare \
          name with the wrong (or missing) counts, not an absent line, is the sign of a genuine \
          presence-plumbing failure here. See the printed rail above.",
     );

--- a/docs/design.md
+++ b/docs/design.md
@@ -626,8 +626,8 @@ timer fires (`Effect::ReadPresences`; never on the Slow heartbeat — and
 within Fast only every 5th tick, except mid-cycle, since peers heartbeat at
 60s and dim at 90s). The read side rests on a write-side guarantee: a live
 session refreshes its presence file's mtime at least every 60s — the
-**liveness heartbeat**, `timer`'s level trigger (`PRESENCE_HEARTBEAT_S`)
-that re-emits `PersistPresence` from any live fire (Slow or Fast) once the
+**liveness heartbeat**, `project`'s level trigger (`PRESENCE_HEARTBEAT_S`)
+that re-emits `PersistPresence` on any pass through `project` once the
 last write is 60s old, bypassing the usual content-edge gate. Without it, a
 session sitting fully idle (no count change) would let its mtime age and
 read as gone while still alive; with it, file age is a reliable liveness
@@ -650,9 +650,11 @@ republishes and the entry returns fresh. Right-click dismiss remains the
 manual path for a stale-but-not-yet-dead entry the user already knows is
 gone. Separately, a `6h` sweep (`PRESENCE_MAX_AGE`) deletes abandoned
 presence files at plugin `load()` — the backstop for debris the reap can't
-touch (e.g. a dead corpse carrying the current session's own name, which is
-never auto-dismissed because the on-disk dismiss matches by name and would
-take the live file with it).
+touch: malformed/unparseable files, which never produce a name to dismiss
+by. (A dead corpse carrying the current session's own name is no longer in
+that bucket: the on-disk dismiss spares the live file by *path* identity —
+`remove_presences_matching`'s own-file exclusion — so the auto-reap handles
+own-name corpses like any other dead entry.)
 
 **Own session name.** Zellij's `Event::ModeUpdate` carries
 `ModeInfo.session_name`; the plugin already subscribes to `ModeUpdate` for

--- a/plugins/zj-radar-claude/scripts/notify.sh
+++ b/plugins/zj-radar-claude/scripts/notify.sh
@@ -99,16 +99,29 @@ contains_word() {
     [[ "$1" =~ $re ]]
 }
 
-# File-tool activity: "<verb> <basename>" from the path at jq path $2 in the
-# hook payload. Prints nothing when the STRIPPED basename is empty — a
+# Fork-free whole-string whitespace trim (mirrors Rust .trim()): sets
+# trim_result to $1 with leading + trailing [:space:] (newlines included)
+# stripped via parameter expansion — no subshell, no pipeline. Used on the
+# high-frequency sites only (the per-tool-call Bash branch and the pending
+# gate); the once-per-turn prompt/ack/done trims keep their pipelines.
+trim() { # $1 = string → trim_result
+    trim_result="${1#"${1%%[![:space:]]*}"}"
+    trim_result="${trim_result%"${trim_result##*[![:space:]]}"}"
+}
+
+# File-tool activity: sets tool_activity to "<verb> <basename>" from the path
+# at jq path $2 in the hook payload. Sets the global directly rather than
+# printing for a $(…) capture — this runs on the per-file-tool-hook hot path,
+# and the command substitution cost an extra subshell fork per hook. Leaves
+# tool_activity untouched when the STRIPPED basename is empty — a
 # trailing-slash path ("src/") has a non-empty path but an empty basename, and
 # Rust's basename() filters that to None, so a dangling "<verb> " with no name
-# must not broadcast. Always exits 0 (callers assign under `set -e`).
-file_activity() { # $1 = verb, $2 = jq path to the file path
+# must not broadcast. The `return 0` guards `set -e` when the guard is falsy.
+file_activity() { # $1 = verb, $2 = jq path to the file path → tool_activity
     local fp base
     fp="$(jq -r "$2 // empty" <<<"$input" 2>/dev/null || true)"
     base="${fp##*/}"
-    [[ -n "$base" ]] && printf '%s %s' "$1" "$base"
+    [[ -n "$base" ]] && tool_activity="$1 $base"
     return 0
 }
 
@@ -140,11 +153,11 @@ if [[ "$status" == "running" ]]; then
         tool_activity=""
         case "$tool_name" in
             Edit|Write|MultiEdit)
-                tool_activity="$(file_activity editing '.tool_input.file_path')" ;;
+                file_activity editing '.tool_input.file_path' ;;
             NotebookEdit)
-                tool_activity="$(file_activity editing '.tool_input.notebook_path')" ;;
+                file_activity editing '.tool_input.notebook_path' ;;
             Read)
-                tool_activity="$(file_activity reading '.tool_input.file_path')" ;;
+                file_activity reading '.tool_input.file_path' ;;
             Grep|Glob)
                 tool_activity="searching"
                 ;;
@@ -171,11 +184,12 @@ if [[ "$status" == "running" ]]; then
                 cmd="$(jq -r '.tool_input.command // empty' <<<"$input" 2>/dev/null || true)"
                 # POSIX lowercase (works on macOS' stock Bash 3.2; ${cmd,,} is Bash 4+).
                 cmd_lower="$(printf '%s' "$cmd" | tr '[:upper:]' '[:lower:]')"
-                # Leading whitespace (newlines included) stripped by parameter
-                # expansion — this is the per-tool-call hot path, so no forks.
+                # Whitespace (newlines included) stripped by trim() — this is
+                # the per-tool-call hot path, so no forks.
                 # Non-empty after the strip mirrors Rust .trim(): an
                 # all-whitespace command derives nothing.
-                rest="${cmd#"${cmd%%[![:space:]]*}"}"
+                trim "$cmd"
+                rest="$trim_result"
                 if [[ -n "$rest" ]]; then
                     if contains_word "$cmd_lower" "git push"; then
                         tool_activity="pushing"
@@ -216,8 +230,8 @@ fi
 # (parity with the Rust producer's msg.trim()) so a whitespace-padded generic
 # phrase is still dropped; the broadcast itself keeps the raw msg, as Rust does.
 if [[ "$status" == "pending" ]]; then
-    m_trim="$(printf '%s' "$msg" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-    case "$m_trim" in
+    trim "$msg"
+    case "$trim_result" in
         ""|"Claude needs attention"|"Claude Code needs your attention")
             exit 0
             ;;

--- a/plugins/zj-radar-claude/tests/parity.bats
+++ b/plugins/zj-radar-claude/tests/parity.bats
@@ -107,22 +107,24 @@ teardown() { teardown_fakes; }
   [ "$(jq -r '.msg' <<<"$BASH_PAYLOAD")" = "working" ]
 }
 
-@test "parity: git pull / git fetch both derive 'syncing'" {
-  local cmd json
-  for cmd in "git pull --rebase" "git fetch origin"; do
-    json="$(jq -nc --arg c "$cmd" '{hook_event_name:"PostToolUse",cwd:"/home/u/myrepo",tool_name:"Bash",tool_input:{command:$c}}')"
-    parity_case "$json" running
-    [ "$(jq -r '.msg' <<<"$BASH_PAYLOAD")" = "syncing" ] || { echo "[$cmd] did not derive syncing"; return 1; }
-  done
+@test "parity: git pull derives 'syncing'" {
+  parity_case '{"hook_event_name":"PostToolUse","cwd":"/home/u/myrepo","tool_name":"Bash","tool_input":{"command":"git pull --rebase"}}' running
+  [ "$(jq -r '.msg' <<<"$BASH_PAYLOAD")" = "syncing" ]
 }
 
-@test "parity: build / compile verbs both derive 'building'" {
-  local cmd json
-  for cmd in "cargo build --release" "gcc -c compile main.c"; do
-    json="$(jq -nc --arg c "$cmd" '{hook_event_name:"PostToolUse",cwd:"/home/u/myrepo",tool_name:"Bash",tool_input:{command:$c}}')"
-    parity_case "$json" running
-    [ "$(jq -r '.msg' <<<"$BASH_PAYLOAD")" = "building" ] || { echo "[$cmd] did not derive building"; return 1; }
-  done
+@test "parity: git fetch derives 'syncing'" {
+  parity_case '{"hook_event_name":"PostToolUse","cwd":"/home/u/myrepo","tool_name":"Bash","tool_input":{"command":"git fetch origin"}}' running
+  [ "$(jq -r '.msg' <<<"$BASH_PAYLOAD")" = "syncing" ]
+}
+
+@test "parity: build verb derives 'building'" {
+  parity_case '{"hook_event_name":"PostToolUse","cwd":"/home/u/myrepo","tool_name":"Bash","tool_input":{"command":"cargo build --release"}}' running
+  [ "$(jq -r '.msg' <<<"$BASH_PAYLOAD")" = "building" ]
+}
+
+@test "parity: compile verb derives 'building'" {
+  parity_case '{"hook_event_name":"PostToolUse","cwd":"/home/u/myrepo","tool_name":"Bash","tool_input":{"command":"gcc -c compile main.c"}}' running
+  [ "$(jq -r '.msg' <<<"$BASH_PAYLOAD")" = "building" ]
 }
 
 @test "parity: leading-newline Bash command still derives its first token" {
@@ -221,7 +223,7 @@ teardown() { teardown_fakes; }
 @test "parity: generic pending backstop drops the broadcast in both" {
   parity_noop '{"hook_event_name":"Notification","cwd":"/home/u/myrepo","message":"Claude needs attention"}' pending
   # Whitespace-padded generic phrase and whitespace-only msg must also drop —
-  # both producers compare a TRIMMED copy (msg.trim() / the sed trim).
+  # both producers compare a TRIMMED copy (msg.trim() / the trim() helper).
   parity_noop '{"hook_event_name":"Notification","cwd":"/home/u/myrepo","message":"  Claude needs attention  "}' pending
   parity_noop '{"hook_event_name":"Notification","cwd":"/home/u/myrepo","message":"   "}' pending
 }


### PR DESCRIPTION
## Summary

Four-angle self-review (reuse / simplification / efficiency / altitude) of #23's tail commits — the badge feature and the first-round fixes — applied as one commit. ~24 findings applied, 8 skipped with reasons.

**Structural (the interesting ones)**
- **Own-name corpse exemption deleted** — the altitude review showed it was compensating for a missing guard one layer down: `remove_presences_matching` now spares the own presence file by **path identity** (the same pre-read exclusion the 6h sweep already uses), so an own-name corpse reaps in 5 minutes like any other, the runtime workaround disappears, and the test that pinned the workaround-as-policy inverts.
- **Liveness ladder cross-pinned**: `heartbeat < stale < dead` is now a compile-time assert; the stale/dead thresholds read from one home (`Peer::stale()/dead()`).
- **Bare `-` skip generalized** into `first_non_option` — fixes the two siblings the call-site filter missed (a `-` operative verb; `python -`), pinned with new cases.

**Efficiency**
- `LineBg::escape` returns `Cow` — the per-card-separator Rail String alloc is gone, `card_tint` is never built outside Cards, and the row-less-surface `debug_assert` is restored.
- Presence dedup back to one hash lookup; notify.sh's `file_activity` sets the global instead of forking a capture subshell; fork-free `trim()` for the hot trim sites.

**Cohesion**
- tty probed once in the setup dispatcher, carried on the opts structs; `consented(&str)` replaces the BufRead generic; `claude_marketplace_name` reuses `basename` (fixes the trailing-slash `ZJ_RADAR_REPO` dangling-plugin-id edge); `ZellijPaths` carries the resolved layout name; ledger disk-load fallback returns to an origin-neutral token; `timer_now`/`timer_slow` absorb 11 noisy test clock args; parity.bats back to flat literal cases; heartbeat/never-vanish doc vestiges rewritten to the fresh→stale→reaped ladder.

**Skipped with reasons**: reverting the single-lookup re-promotion fold and the pre-read keep predicate (efficiency wins — per-tick / per-scan×N-instances paths), full clock hoist for the 7 other runtime entry points (doc scoped instead), remaining per-turn notify.sh pipeline trims, peer-space Seg trim (snapshot churn), NotifyTarget enum (standing skip).

## Test plan
`just ci` green (12 suites incl. 535 plugin lib tests, 127 core, 285 cli, bash suite), clippy `-D warnings` all targets, shellcheck clean. New pins: own-file-spared/same-name-reaped pair, `Cow::Borrowed` Rail arm, skip-and-continue `-` cases, trailing-slash marketplace fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)