### PR TITLE
Add OpenCode plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,8 @@ thin — it points at the real docs rather than duplicating them.
 
 zj-radar is a native [Zellij](https://zellij.dev) sidebar (Rust → `wasm32-wasip1`)
 plus a host-side `zj-radar` CLI and producer adapters for Claude Code (a bundled
-Claude plugin) and Codex (hooks installed by `zj-radar setup codex`) — both
+Claude plugin), Codex (hooks installed by `zj-radar setup codex`), and Opencode
+(a vendored JS bridge plugin installed by `zj-radar setup opencode`) — all
 first-class producers.
 
 ## Read first

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -267,11 +267,12 @@ renders — so the emitted ANSI and the click maps cannot drift.
 
 The real external seam between producers and the plugin: the versioned
 `zj_radar.status.v1` pipe payload (`{v, source, pane, status, repo, branch,
-msg, task, ack}`). Producers (the Claude plugin, the Codex CLI) are adapters that
-broadcast it; the plugin defends itself at parse time (sanitize, truncate, drop
-oversized/malformed). Ordering is latest-wins — the pipe delivers in order and no
-producer stamps a sequence, so there is nothing to reorder. Unknown fields are
-tolerated and ignored, so older producers still parse: a legacy `seq` and the
+msg, task, ack}`). Producers (the Claude plugin, the Codex CLI, the Opencode
+bridge plugin) are adapters that broadcast it; the plugin defends itself at
+parse time (sanitize, truncate, drop oversized/malformed). Ordering is
+latest-wins — the pipe delivers in order and no producer stamps a sequence,
+so there is nothing to reorder. Unknown fields are tolerated and ignored, so
+older producers still parse: a legacy `seq` and the
 former `on_focus` clear-on-focus hint (dropped when focus stopped driving state)
 both round-trip harmlessly. `task` (optional): sticky task label — empty/absent
 leaves the stored label unchanged, non-empty replaces it; the plugin clears it
@@ -383,19 +384,22 @@ runtime's `Outcome`, which names its `{render, effects}` return value.)
 
 How `zj-radar setup` learns the current state of the world. The **setup-analysis
 seam** is a pure analyze function per target —
-`analyze_zellij(&ZellijEnv) -> ZellijFacts` and `analyze_codex(&CodexEnv) ->
-CodexFacts` in `crates/cli/src/setup/analyze.rs` — each fed a thin
-`Env` of already-read values (file contents, fs stat booleans) by the IO shell.
-`Facts` (`ZellijFacts`, `CodexFacts`) is the single home for every derived fact —
-"is our alias present?" (managed vs unmanaged kept distinct), has-rail, granted,
-producer-wired, the Codex hooks-feature and notify states.
+`analyze_zellij(&ZellijEnv) -> ZellijFacts`, `analyze_codex(&CodexEnv) ->
+CodexFacts`, and `analyze_opencode(&OpencodeEnv) -> OpencodeFacts` in
+`crates/cli/src/setup/analyze.rs` — each fed a thin `Env` of already-read values
+(file contents, fs stat booleans) by the IO shell.
+`Facts` (`ZellijFacts`, `CodexFacts`, `OpencodeFacts`) is the single home for
+every derived fact — "is our alias present?" (managed vs unmanaged kept
+distinct), has-rail, granted, producer-wired, the Codex hooks-feature and notify
+states, the opencode plugin-ownership state.
 
 Both consumers project from `Facts`: `*_check_items(&Facts)` renders the
-`--check` doctor output; the install orchestrators (`setup_zellij`, `setup_codex`)
-read `Facts` for their gating decisions and pull raw config text from `Env` for
-the `edit_*` splice. The pure mutators (`edit_zellij`, `edit_codex`,
-`edit_codex_hooks` → `Outcome`) are NOT driven by `Facts` — they share only the
-low-level primitive detectors (`notify_is_ours`, `has_unmanaged_radar_alias`,
+`--check` doctor output; the install orchestrators (`setup_zellij`,
+`setup_codex`, `setup_opencode`) read `Facts` for their gating decisions and
+pull raw config text from `Env` for the `edit_*` splice. The pure mutators
+(`edit_zellij`, `edit_codex`, `edit_codex_hooks` → `Outcome`) are NOT driven by
+`Facts` — they share only the low-level primitive detectors (`notify_is_ours`,
+`has_unmanaged_radar_alias`, `opencode_plugin_is_ours`,
 `strip_managed_zellij_alias`, `codex_hook_handler_is_ours`), which live in
 `crates/cli/src/setup/detect.rs`, a neutral module that both `analyze` and `edit`
 depend on. The legacy-notify vs hooks choice is a flag the consumer projects on,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,9 @@
 # Contributing to zj-radar
 
 Thanks for your interest! zj-radar is a native [Zellij](https://zellij.dev)
-sidebar (Rust → `wasm32-wasip1`) plus a host-side CLI and a Claude Code producer
-plugin. This guide covers how to build, test, and propose changes.
+sidebar (Rust → `wasm32-wasip1`) plus a host-side CLI and producer adapters for
+Claude Code, Codex, and Opencode. This guide covers how to build, test, and
+propose changes.
 
 ## Project shape
 
@@ -11,9 +12,10 @@ zj-radar is a three-member Cargo workspace:
 | Path | What it is |
 |------|------------|
 | `crates/core/` | Pure shared library (`zj_radar_core`): the versioned wire schema and status/command classification (`command`, `kind`, `observation`, `payload`, `pipe`, `status`, `wire`). No `clap`, no `zellij-tile`. |
-| `crates/cli/` | The native `zj-radar` CLI (`notify`, `setup`, `run`). `build.rs` embeds the wasm via `include_bytes!`. |
+| `crates/cli/` | The native `zj-radar` CLI (`notify`, `setup`, `run`). `build.rs` embeds the wasm via `include_bytes!`; `setup opencode` embeds a vendored JS bridge via `include_str!`. |
 | `crates/plugin/` | The Zellij sidebar wasm plugin (`zj_radar_plugin`, Rust → `wasm32-wasip1`). A thin Zellij adapter (`lib.rs`/`main.rs`, wasm-only) over host-testable modules (runtime, stores, model, renderer). |
 | `plugins/zj-radar-claude/` | The Claude Code producer plugin (hooks + bundled `notify.sh`). |
+| `crates/cli/src/setup/opencode_plugin.js` | The Opencode producer bridge (vendored into opencode's plugins dir by `zj-radar setup opencode`). |
 | `docs/` | Living design docs. Start with [`CONTEXT.md`](CONTEXT.md) (domain glossary), [`docs/design.md`](docs/design.md), and [`docs/activity-model.md`](docs/activity-model.md) (how pane activity maps to the statuses the rail shows). |
 
 Two ideas are load-bearing — read [`CONTEXT.md`](CONTEXT.md) before changing the

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ wrapping your agents. It's a status rail for the session you already run.
 
 ## Highlights
 
-- See which Claude Code / Codex tabs are **working, done, errored, or waiting for you**.
+- See which Claude Code / Codex / Opencode tabs are **working, done, errored, or waiting for you**.
 - **Jump directly** to the tab that needs attention (bind `attention-next` — see [binding keys to commands](https://github.com/marktoda/zj-radar/blob/main/docs/configuration.md#binding-keys-to-commands)).
 - Keep your existing Zellij workflow — **no new terminal, no tmux wrapper, no agent orchestrator**.
 - **Push-driven** updates via `zellij pipe`; no pane polling, no per-output host queries.
-- Works with **Claude Code** today, **Codex** via the native CLI, and any
+- Works with **Claude Code**, **Codex**, and **Opencode** today, and any
   [custom producer](https://github.com/marktoda/zj-radar/blob/main/docs/producers.md#writing-your-own-producer) that can send JSON.
 - Running more than one Zellij session? A **cross-session badge** shows every
   other session's live status-origin pane counts, with click-to-switch and a
@@ -96,8 +96,9 @@ panes stay dark (the sidebar deliberately doesn't guess at agents it can't
 hear from). One command per agent:
 
 ```sh
-zj-radar setup claude   # installs the zj-radar-claude plugin via Claude Code's marketplace
-zj-radar setup codex    # wires Codex hooks — then run `/hooks` inside Codex to trust them
+zj-radar setup claude    # installs the zj-radar-claude plugin via Claude Code's marketplace
+zj-radar setup codex     # wires Codex hooks — then run `/hooks` inside Codex to trust them
+zj-radar setup opencode  # drops the JS bridge plugin into opencode's plugins dir — then restart opencode
 ```
 
 (Prefer Claude Code's own UI? `/plugin install zj-radar-claude@zj-radar` inside
@@ -220,12 +221,14 @@ The full option table, keybindings for runtime config, and `attention-next` /
 
 ## Producers
 
-A producer broadcasts agent status to the sidebar. zj-radar ships three and
+A producer broadcasts agent status to the sidebar. zj-radar ships four and
 documents the wire format so you can write your own:
 
 - **Claude Code** — a Claude plugin that auto-registers status hooks (no
   `settings.json` editing).
 - **Codex / native CLI** — `zj-radar notify` + `zj-radar setup codex`.
+- **Opencode** — a vendored JS bridge plugin dropped into opencode's
+  auto-loaded plugins dir (`zj-radar setup opencode`).
 - **Custom** — `zj-radar notify generic --status/--msg/--task/--source` from
   any script (no JSON needed), or broadcast a `zj_radar.status.v1` JSON
   payload from anything.
@@ -238,7 +241,7 @@ schema, and a copy-paste smoke test.
 | Doc | What's in it |
 |-----|--------------|
 | [`docs/install.md`](https://github.com/marktoda/zj-radar/blob/main/docs/install.md) | Full sidebar install: CLI + manual setup, layout templates, permissions, remote-URL caveat, Nix / home-manager. |
-| [`docs/producers.md`](https://github.com/marktoda/zj-radar/blob/main/docs/producers.md) | Claude Code, Codex, and writing your own producer (payload schema + smoke test). |
+| [`docs/producers.md`](https://github.com/marktoda/zj-radar/blob/main/docs/producers.md) | Claude Code, Codex, Opencode, and writing your own producer (payload schema + smoke test). |
 | [`docs/configuration.md`](https://github.com/marktoda/zj-radar/blob/main/docs/configuration.md) | Density/naming/header/glyphs, runtime config, and keybindings. |
 | [`docs/activity-model.md`](https://github.com/marktoda/zj-radar/blob/main/docs/activity-model.md) | Attention/activity semantics: jobs vs services vs interactive programs, and how each renders. |
 | [`docs/rail-reference.md`](https://github.com/marktoda/zj-radar/blob/main/docs/rail-reference.md) | The executable render spec — `include_str!`'d by the plugin's reference tests. |
@@ -256,8 +259,10 @@ schema, and a copy-paste smoke test.
   interactive, each with its own presentation (spinner + run tag, steady `▸`,
   muted label); see [`docs/activity-model.md`](https://github.com/marktoda/zj-radar/blob/main/docs/activity-model.md).
 - ✅ **Claude Code producer** — ships as a Claude plugin (`plugins/zj-radar-claude`).
-- ✅ **`zj-radar` CLI** — native, jq-free `notify` (Claude + Codex) and
-  conflict-aware `setup`; see [`docs/producers.md`](https://github.com/marktoda/zj-radar/blob/main/docs/producers.md#codex-and-the-native-cli).
+- ✅ **Codex producer** — native CLI `notify` + `setup codex` (hooks.json).
+- ✅ **Opencode producer** — vendored JS bridge plugin + `setup opencode`.
+- ✅ **`zj-radar` CLI** — native, jq-free `notify` (Claude + Codex + Opencode)
+  and conflict-aware `setup`; see [`docs/producers.md`](https://github.com/marktoda/zj-radar/blob/main/docs/producers.md).
 - ✅ **Prebuilt releases** — a tagged release ships static Linux + macOS CLI
   binaries, a one-line `curl | sh` installer, and the sidebar wasm;
   `zj-radar setup zellij --download` fetches the matching wasm. See

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -46,7 +46,9 @@ before the tag**. The order below matters; each step gates the next.
 
    Core's API is allowed to break between 0.x releases (it's internal); the
    exact pin is what protects previously published CLIs. Never loosen it to a
-   caret/minor range.
+   caret/minor range. Note that core gains a non-exhaustive `Kind` variant on
+   any new producer (e.g. `Opencode`): downstream exhaustive matches on `Kind`
+   break, but core is internal so the only consumer is this workspace.
 
    Publishing before the tag opens a window where crates.io serves the new
    version but its GitHub release assets don't exist yet — and that window is

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -46,9 +46,9 @@ before the tag**. The order below matters; each step gates the next.
 
    Core's API is allowed to break between 0.x releases (it's internal); the
    exact pin is what protects previously published CLIs. Never loosen it to a
-   caret/minor range. Note that core gains a non-exhaustive `Kind` variant on
-   any new producer (e.g. `Opencode`): downstream exhaustive matches on `Kind`
-   break, but core is internal so the only consumer is this workspace.
+   caret/minor range. Note that core gains a new `Kind` variant on any new
+   producer (e.g. `Opencode`): downstream exhaustive matches on `Kind` break,
+   but core is internal so the only consumer is this workspace.
 
    Publishing before the tag opens a window where crates.io serves the new
    version but its GitHub release assets don't exist yet — and that window is

--- a/crates/cli/src/agents.rs
+++ b/crates/cli/src/agents.rs
@@ -176,6 +176,15 @@ pub fn baseline_msg(status: Status, msg: &str) -> String {
     }
 }
 
+/// A non-empty string field of a JSON payload, or `None`. Shared by the codex
+/// and opencode adapters (both read `cwd`-style fields off a `serde_json::Value`).
+pub(crate) fn string_field(v: &serde_json::Value, field: &str) -> Option<String> {
+    v.get(field)
+        .and_then(|x| x.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
 pub(crate) fn basename(path: &str) -> Option<&str> {
     if path.is_empty() {
         return None;

--- a/crates/cli/src/agents.rs
+++ b/crates/cli/src/agents.rs
@@ -11,6 +11,7 @@
 
 mod claude;
 mod codex;
+mod opencode;
 
 use crate::payload::MAX_WIRE_FIELD_CHARS;
 use crate::status::Status;
@@ -49,13 +50,14 @@ pub struct AgentUpdate {
 pub enum Agent {
     Claude,
     Codex,
+    Opencode,
 }
 
 impl Agent {
     /// Every push-reporter agent, in declaration order. Lets the coherence
     /// guards iterate the variants without re-typing the list (mirrors
     /// `Kind::ALL`).
-    pub const ALL: &'static [Agent] = &[Agent::Claude, Agent::Codex];
+    pub const ALL: &'static [Agent] = &[Agent::Claude, Agent::Codex, Agent::Opencode];
 
     /// Parse the `notify <agent>` CLI argument. Inverse of [`Agent::source`].
     pub fn from_cli(s: &str) -> Option<Agent> {
@@ -68,6 +70,7 @@ impl Agent {
         match self {
             Agent::Claude => "claude",
             Agent::Codex => "codex",
+            Agent::Opencode => "opencode",
         }
     }
 
@@ -76,6 +79,7 @@ impl Agent {
         match self {
             Agent::Claude => claude::derive(intake),
             Agent::Codex => codex::derive(intake),
+            Agent::Opencode => opencode::derive(intake),
         }
     }
 }
@@ -226,6 +230,7 @@ mod tests {
             let expected = match agent {
                 Agent::Claude => Kind::Claude,
                 Agent::Codex => Kind::Codex,
+                Agent::Opencode => Kind::Opencode,
             };
             assert_eq!(
                 Kind::from_source(agent.source()),
@@ -273,10 +278,10 @@ mod tests {
     fn all_lists_every_variant() {
         for &a in Agent::ALL {
             match a {
-                Agent::Claude | Agent::Codex => {}
+                Agent::Claude | Agent::Codex | Agent::Opencode => {}
             }
         }
-        assert_eq!(Agent::ALL.len(), 2, "a variant is missing from Agent::ALL");
+        assert_eq!(Agent::ALL.len(), 3, "a variant is missing from Agent::ALL");
     }
 
     /// The clap doc-comment on the `agent` arg (lib.rs) cannot be dynamic. This

--- a/crates/cli/src/agents/codex.rs
+++ b/crates/cli/src/agents/codex.rs
@@ -1,6 +1,6 @@
 //! Codex hook/notify JSON → Radar status update.
 
-use super::{tool_activity, AgentUpdate, Intake};
+use super::{string_field, tool_activity, AgentUpdate, Intake};
 use crate::status::Status;
 use serde_json::Value;
 
@@ -90,13 +90,6 @@ fn permission_message(v: &Value) -> String {
 fn last_assistant_message(v: &Value) -> Option<String> {
     v.get("last_assistant_message")
         .and_then(|x| x.as_str())
-        .map(str::to_string)
-}
-
-fn string_field(v: &Value, field: &str) -> Option<String> {
-    v.get(field)
-        .and_then(|x| x.as_str())
-        .filter(|s| !s.is_empty())
         .map(str::to_string)
 }
 

--- a/crates/cli/src/agents/opencode.rs
+++ b/crates/cli/src/agents/opencode.rs
@@ -11,7 +11,7 @@
 //! no-op. `session.error` maps to `Status::Error` — a real failure signal
 //! Claude's hook model deliberately lacks (see the claude.rs header comment).
 
-use super::{tool_activity, AgentUpdate, Intake};
+use super::{string_field, tool_activity, AgentUpdate, Intake};
 use crate::status::Status;
 use serde_json::Value;
 
@@ -111,8 +111,9 @@ pub fn derive(intake: &Intake) -> Option<AgentUpdate> {
 /// vocabulary. opencode built-ins (`read`, `bash`, …) and common spelling
 /// variants are covered; an unknown name passes through unchanged (it falls
 /// to the `_` arm of `tool_activity`, yielding `None` → the `working`
-/// baseline). `mcp__*` names pass through verbatim so the shared
-/// basename-extraction arm handles them.
+/// baseline). opencode keys MCP tools `<server>_<tool>` (no `mcp__` prefix),
+/// so they are indistinguishable from unknown names here and read as the
+/// baseline too.
 fn normalize_tool_name(raw: &str) -> &str {
     match raw {
         "read" => "Read",
@@ -126,7 +127,6 @@ fn normalize_tool_name(raw: &str) -> &str {
         "task" | "subtask" => "Task",
         "todowrite" | "todo" => "TodoWrite",
         "applypatch" | "apply_patch" => "apply_patch",
-        n if n.starts_with("mcp__") => n,
         _ => raw,
     }
 }
@@ -149,13 +149,6 @@ fn normalize_tool_args(input: &Value) -> Value {
         out.insert(k.to_string(), v.clone());
     }
     Value::Object(out)
-}
-
-fn string_field(v: &Value, field: &str) -> Option<String> {
-    v.get(field)
-        .and_then(|x| x.as_str())
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)
 }
 
 #[cfg(test)]

--- a/crates/cli/src/agents/opencode.rs
+++ b/crates/cli/src/agents/opencode.rs
@@ -19,7 +19,7 @@ use serde_json::Value;
 /// bridge always passes `--status`, so this is the robustness/test path).
 fn status_from_event(event: &str) -> Option<Status> {
     match event {
-        "chat.message" | "tool.execute" => Some(Status::Running),
+        "chat.message" | "tool.execute" | "permission.replied" => Some(Status::Running),
         "permission.ask" => Some(Status::Pending),
         "session.idle" => Some(Status::Done),
         "session.error" => Some(Status::Error),
@@ -244,6 +244,17 @@ mod tests {
         assert_eq!(u.status, Status::Pending);
         assert_eq!(u.msg, "Approve network access?");
         assert_eq!(u.cwd.as_deref(), Some("/repo"));
+    }
+
+    #[test]
+    fn permission_replied_resumes_running() {
+        // The user answered the prompt: the row leaves ◆ immediately instead of
+        // waiting for the next tool/idle event (a denied permission throws
+        // inside the tool, so `tool.execute.after` may never come).
+        let u = derive(&intake(r#"{"event":"permission.replied","cwd":"/repo"}"#, None)).unwrap();
+        assert_eq!(u.status, Status::Running);
+        assert_eq!(u.msg, "working");
+        assert_eq!(u.task, None);
     }
 
     #[test]

--- a/crates/cli/src/agents/opencode.rs
+++ b/crates/cli/src/agents/opencode.rs
@@ -1,0 +1,345 @@
+//! Opencode plugin bridge → Radar status update.
+//!
+//! The opencode producer is a thin JS bridge (see
+//! `setup/opencode_plugin.js`) that serializes each hook/bus-event payload and
+//! spawns `zj-radar notify opencode --status <s>` with JSON on stdin. The
+//! bridge picks the status class (it knows the event); this adapter owns the
+//! refinements keyed off the payload's `event` field: the pending backstop,
+//! the running baseline, tool-activity substitution (opencode tool names/args
+//! normalized into the shared `tool_activity` vocabulary), the sticky task
+//! capture, and the trailing-question Done→Pending remap. Returns `None` for a
+//! no-op. `session.error` maps to `Status::Error` — a real failure signal
+//! Claude's hook model deliberately lacks (see the claude.rs header comment).
+
+use super::{tool_activity, AgentUpdate, Intake};
+use crate::status::Status;
+use serde_json::Value;
+
+/// Map an opencode event name to a status, used when `--status` is absent (the
+/// bridge always passes `--status`, so this is the robustness/test path).
+fn status_from_event(event: &str) -> Option<Status> {
+    match event {
+        "chat.message" | "tool.execute" => Some(Status::Running),
+        "permission.ask" => Some(Status::Pending),
+        "session.idle" => Some(Status::Done),
+        "session.error" => Some(Status::Error),
+        "session.lifecycle" => Some(Status::Idle),
+        _ => None,
+    }
+}
+
+/// Decide opencode's status + msg + cwd. `status_arg` (the bridge always
+/// passes it) wins; else derive from the `event` field. Applies the pending
+/// backstop, the running baseline, tool-activity substitution for tool events,
+/// the task capture for chat.message, and the trailing-question remap for a
+/// Done that ends by asking. Returns `None` for a no-op.
+pub fn derive(intake: &Intake) -> Option<AgentUpdate> {
+    let v: Value = serde_json::from_str(intake.raw).unwrap_or(Value::Null);
+    let event = v.get("event").and_then(|x| x.as_str()).unwrap_or("");
+    // `message` carries the event's text (a permission title, the tracked last
+    // assistant text on idle, an error message). The user's submitted prompt
+    // (`prompt`) is task-capture-only below — it must NOT become the running
+    // msg, or the row would show the prompt instead of the "working" baseline.
+    let msg = v.get("message").and_then(|x| x.as_str()).unwrap_or("");
+    let cwd = string_field(&v, "cwd");
+
+    let status = match intake.status_arg {
+        Some(s) => Status::from_wire(s),
+        None => status_from_event(event)?,
+    };
+
+    // A turn that ends by asking the user something is blocked on input, not
+    // finished — opencode's `session.idle` carries no terminal-outcome flag,
+    // so a prose question just surfaces as idle. Remap that Done to Pending
+    // with the trailing question as the message (same rule as the Claude and
+    // Codex adapters' Stop).
+    if status == Status::Done {
+        if let Some(question) = super::trailing_question(msg) {
+            return Some(AgentUpdate {
+                status: Status::Pending,
+                msg: question.to_string(),
+                cwd,
+                task: None,
+            });
+        }
+    }
+
+    // Pending backstop: a permission whose title is blank is not a real
+    // "needs you" — drop it rather than paint a generic pending row.
+    if status == Status::Pending && msg.trim().is_empty() {
+        return None;
+    }
+
+    let mut out_msg = super::baseline_msg(status, msg);
+
+    // An error event with no message still reads as an error via its color/mark,
+    // but a neutral label is friendlier than a blank red row.
+    if status == Status::Error && out_msg.trim().is_empty() {
+        out_msg = "errored".to_string();
+    }
+
+    // For tool events, show the live action instead of the baseline. opencode
+    // tool names are lowercase and args use camelCase keys; normalize both
+    // into the shared `tool_activity` vocabulary before delegating.
+    if status == Status::Running && event == "tool.execute" {
+        let raw_tool = v.get("tool").and_then(|x| x.as_str()).unwrap_or("");
+        let raw_input = v.get("tool_input").unwrap_or(&Value::Null);
+        let tool = normalize_tool_name(raw_tool);
+        let tool_input = normalize_tool_args(raw_input);
+        if let Some(activity) = tool_activity(tool, &tool_input) {
+            out_msg = activity;
+        }
+    }
+
+    // The sticky task label rides on chat.message (the user-prompt-submit
+    // event); every other event sends task=None (keep the stored label).
+    let task = if status == Status::Running && event == "chat.message" {
+        v.get("prompt").and_then(|x| x.as_str()).and_then(super::task_from_prompt)
+    } else {
+        None
+    };
+
+    Some(AgentUpdate {
+        status,
+        msg: out_msg,
+        cwd,
+        task,
+    })
+}
+
+/// Map opencode's lowercase tool names to the shared `tool_activity`
+/// vocabulary. opencode built-ins (`read`, `bash`, …) and common spelling
+/// variants are covered; an unknown name passes through unchanged (it falls
+/// to the `_` arm of `tool_activity`, yielding `None` → the `working`
+/// baseline). `mcp__*` names pass through verbatim so the shared
+/// basename-extraction arm handles them.
+fn normalize_tool_name(raw: &str) -> &str {
+    match raw {
+        "read" => "Read",
+        "write" | "create" | "save" => "Write",
+        "edit" | "str_replace" | "update" => "Edit",
+        "bash" | "execute" => "Bash",
+        "grep" => "Grep",
+        "glob" | "list" => "Glob",
+        "webfetch" | "fetch" => "WebFetch",
+        "websearch" | "search" => "WebSearch",
+        "task" | "subtask" => "Task",
+        "todowrite" | "todo" => "TodoWrite",
+        "applypatch" | "apply_patch" => "apply_patch",
+        n if n.starts_with("mcp__") => n,
+        _ => raw,
+    }
+}
+
+/// Rename opencode's camelCase arg keys into the snake_case keys
+/// `tool_activity` reads (`filePath` → `file_path`,
+/// `notebookPath` → `notebook_path`). Other keys pass through unchanged. A
+/// non-object input is returned as-is.
+fn normalize_tool_args(input: &Value) -> Value {
+    let Some(obj) = input.as_object() else {
+        return input.clone();
+    };
+    let mut out = serde_json::Map::with_capacity(obj.len());
+    for (k, v) in obj {
+        let k = match k.as_str() {
+            "filePath" => "file_path",
+            "notebookPath" => "notebook_path",
+            other => other,
+        };
+        out.insert(k.to_string(), v.clone());
+    }
+    Value::Object(out)
+}
+
+fn string_field(v: &Value, field: &str) -> Option<String> {
+    v.get(field)
+        .and_then(|x| x.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn intake<'a>(raw: &'a str, status_arg: Option<&'a str>) -> Intake<'a> {
+        Intake { raw, status_arg }
+    }
+
+    #[test]
+    fn explicit_status_passes_through() {
+        let u = derive(&intake(r#"{"event":"chat.message","prompt":"hi"}"#, Some("running"))).unwrap();
+        assert_eq!(u.status, Status::Running);
+    }
+
+    #[test]
+    fn chat_message_is_running_and_captures_the_task() {
+        let u = derive(&intake(
+            r#"{"event":"chat.message","prompt":"fix the flaky e2e retries\ndetails…","cwd":"/repo"}"#,
+            Some("running"),
+        ))
+        .unwrap();
+        assert_eq!(u.status, Status::Running);
+        assert_eq!(u.msg, "working");
+        assert_eq!(u.task.as_deref(), Some("fix the flaky e2e retries"));
+        assert_eq!(u.cwd.as_deref(), Some("/repo"));
+    }
+
+    #[test]
+    fn non_prompt_events_never_carry_a_task() {
+        let u = derive(&intake(
+            r#"{"event":"tool.execute","tool":"read","tool_input":{"filePath":"/p/x.rs"}}"#,
+            Some("running"),
+        ))
+        .unwrap();
+        assert_eq!(u.task, None);
+    }
+
+    #[test]
+    fn tool_hooks_normalize_names_and_args_into_shared_vocab() {
+        // opencode `read` + `filePath` → shared `Read` + `file_path`.
+        let u = derive(&intake(
+            r#"{"event":"tool.execute","tool":"read","tool_input":{"filePath":"/p/auth.rs"}}"#,
+            Some("running"),
+        ))
+        .unwrap();
+        assert_eq!(u.status, Status::Running);
+        assert_eq!(u.msg, "reading auth.rs");
+
+        // `bash` + `command` → `Bash` activity.
+        let u = derive(&intake(
+            r#"{"event":"tool.execute","tool":"bash","tool_input":{"command":"git push origin main"}}"#,
+            Some("running"),
+        ))
+        .unwrap();
+        assert_eq!(u.msg, "pushing");
+
+        // `edit` + `filePath`.
+        let u = derive(&intake(
+            r#"{"event":"tool.execute","tool":"edit","tool_input":{"filePath":"/p/mod.rs"}}"#,
+            Some("running"),
+        ))
+        .unwrap();
+        assert_eq!(u.msg, "editing mod.rs");
+    }
+
+    #[test]
+    fn unknown_tool_falls_back_to_working() {
+        let u = derive(&intake(
+            r#"{"event":"tool.execute","tool":"frobnicate","tool_input":{}}"#,
+            Some("running"),
+        ))
+        .unwrap();
+        assert_eq!(u.status, Status::Running);
+        assert_eq!(u.msg, "working");
+    }
+
+    #[test]
+    fn permission_ask_is_pending_with_title() {
+        let u = derive(&intake(
+            r#"{"event":"permission.ask","message":"Approve network access?","cwd":"/repo"}"#,
+            Some("pending"),
+        ))
+        .unwrap();
+        assert_eq!(u.status, Status::Pending);
+        assert_eq!(u.msg, "Approve network access?");
+        assert_eq!(u.cwd.as_deref(), Some("/repo"));
+    }
+
+    #[test]
+    fn permission_ask_with_blank_title_is_dropped() {
+        // The pending backstop: a permission with no title is not a real
+        // "needs you" — drop it rather than paint a generic pending row.
+        assert!(derive(&intake(r#"{"event":"permission.ask","message":""}"#, Some("pending"))).is_none());
+        assert!(derive(&intake(r#"{"event":"permission.ask","message":"   "}"#, Some("pending"))).is_none());
+    }
+
+    #[test]
+    fn session_idle_with_statement_stays_done() {
+        let u = derive(&intake(
+            r#"{"event":"session.idle","message":"All tests pass.","cwd":"/repo"}"#,
+            Some("done"),
+        ))
+        .unwrap();
+        assert_eq!(u.status, Status::Done);
+        assert_eq!(u.msg, "All tests pass.");
+        assert_eq!(u.cwd.as_deref(), Some("/repo"));
+    }
+
+    #[test]
+    fn session_idle_ending_in_a_question_remaps_done_to_pending() {
+        // A turn that ends mid-question is blocked on the user; only the
+        // trailing line rides as the msg.
+        let u = derive(&intake(
+            r#"{"event":"session.idle","message":"Refactored the auth module.\n\nShould I also update the tests?"}"#,
+            Some("done"),
+        ))
+        .unwrap();
+        assert_eq!(u.status, Status::Pending);
+        assert_eq!(u.msg, "Should I also update the tests?");
+        assert_eq!(u.task, None, "no prompt here — keep the stored label");
+    }
+
+    #[test]
+    fn session_error_maps_to_error_status() {
+        // opencode surfaces a real error event (Claude's hook model has none);
+        // carry its message, falling back to a neutral label when blank.
+        let u = derive(&intake(
+            r#"{"event":"session.error","message":"provider auth failed","cwd":"/repo"}"#,
+            Some("error"),
+        ))
+        .unwrap();
+        assert_eq!(u.status, Status::Error);
+        assert_eq!(u.msg, "provider auth failed");
+        assert_eq!(u.cwd.as_deref(), Some("/repo"));
+    }
+
+    #[test]
+    fn session_error_with_blank_message_gets_neutral_label() {
+        let u = derive(&intake(r#"{"event":"session.error","message":""}"#, Some("error"))).unwrap();
+        assert_eq!(u.status, Status::Error);
+        assert_eq!(u.msg, "errored");
+    }
+
+    #[test]
+    fn session_lifecycle_resets_to_idle_with_blank_msg() {
+        // session.created/deleted → idle: any stale message is dropped so the
+        // rail never shows an idle row with leftover text.
+        let u = derive(&intake(
+            r#"{"event":"session.lifecycle","message":"stale","cwd":"/repo"}"#,
+            Some("idle"),
+        ))
+        .unwrap();
+        assert_eq!(u.status, Status::Idle);
+        assert_eq!(u.msg, "");
+        assert_eq!(u.cwd.as_deref(), Some("/repo"));
+    }
+
+    #[test]
+    fn running_with_empty_msg_falls_back_to_working() {
+        let u = derive(&intake(r#"{"event":"chat.message"}"#, Some("running"))).unwrap();
+        assert_eq!(u.status, Status::Running);
+        assert_eq!(u.msg, "working");
+    }
+
+    #[test]
+    fn derives_status_from_event_when_no_explicit_status() {
+        // Robustness path: the bridge always passes --status, but deriving
+        // from `event` keeps the adapter directly testable without it.
+        assert_eq!(
+            derive(&intake(r#"{"event":"chat.message"}"#, None)).unwrap().status,
+            Status::Running
+        );
+        assert_eq!(
+            derive(&intake(r#"{"event":"session.error","message":"boom"}"#, None)).unwrap().status,
+            Status::Error
+        );
+        assert!(derive(&intake(r#"{"event":"unknown"}"#, None)).is_none());
+    }
+
+    #[test]
+    fn cwd_absent_is_none() {
+        let u = derive(&intake(r#"{"event":"session.idle","message":"done"}"#, Some("done"))).unwrap();
+        assert_eq!(u.cwd, None);
+    }
+}

--- a/crates/cli/src/agents/opencode.rs
+++ b/crates/cli/src/agents/opencode.rs
@@ -19,8 +19,8 @@ use serde_json::Value;
 /// bridge always passes `--status`, so this is the robustness/test path).
 fn status_from_event(event: &str) -> Option<Status> {
     match event {
-        "chat.message" | "tool.execute" | "permission.replied" => Some(Status::Running),
-        "permission.ask" => Some(Status::Pending),
+        "chat.message" | "tool.execute" | "needs_you.replied" => Some(Status::Running),
+        "permission.ask" | "question.ask" => Some(Status::Pending),
         "session.idle" => Some(Status::Done),
         "session.error" => Some(Status::Error),
         "session.lifecycle" => Some(Status::Idle),
@@ -107,26 +107,22 @@ pub fn derive(intake: &Intake) -> Option<AgentUpdate> {
     })
 }
 
-/// Map opencode's lowercase tool names to the shared `tool_activity`
-/// vocabulary. opencode built-ins (`read`, `bash`, …) and common spelling
-/// variants are covered; an unknown name passes through unchanged (it falls
-/// to the `_` arm of `tool_activity`, yielding `None` → the `working`
-/// baseline). opencode keys MCP tools `<server>_<tool>` (no `mcp__` prefix),
-/// so they are indistinguishable from unknown names here and read as the
-/// baseline too.
+/// Map opencode's built-in tool ids (`packages/opencode/src/tool/registry.ts`,
+/// all lowercase) to the shared `tool_activity` vocabulary. Anything else —
+/// including MCP tools, which opencode keys `<server>_<tool>` — passes through
+/// and falls to `tool_activity`'s `_` arm: `None` → the `working` baseline.
 fn normalize_tool_name(raw: &str) -> &str {
     match raw {
         "read" => "Read",
-        "write" | "create" | "save" => "Write",
-        "edit" | "str_replace" | "update" => "Edit",
-        "bash" | "execute" => "Bash",
+        "write" => "Write",
+        "edit" => "Edit",
+        "bash" => "Bash",
         "grep" => "Grep",
-        "glob" | "list" => "Glob",
-        "webfetch" | "fetch" => "WebFetch",
-        "websearch" | "search" => "WebSearch",
-        "task" | "subtask" => "Task",
-        "todowrite" | "todo" => "TodoWrite",
-        "applypatch" | "apply_patch" => "apply_patch",
+        "glob" => "Glob",
+        "webfetch" => "WebFetch",
+        "websearch" => "WebSearch",
+        "task" => "Task",
+        "todowrite" => "TodoWrite",
         _ => raw,
     }
 }
@@ -240,14 +236,16 @@ mod tests {
     }
 
     #[test]
-    fn permission_replied_resumes_running() {
-        // The user answered the prompt: the row leaves ◆ immediately instead of
-        // waiting for the next tool/idle event (a denied permission throws
-        // inside the tool, so `tool.execute.after` may never come).
-        let u = derive(&intake(r#"{"event":"permission.replied","cwd":"/repo"}"#, None)).unwrap();
+    fn question_ask_is_pending_and_any_needs_you_reply_resumes_running() {
+        // opencode's built-in `question` tool blocks the TUI like a permission
+        // prompt; the bridge sends it as `question.ask`, and every reply edge
+        // (permission.replied / question.replied / question.rejected) arrives
+        // as one `needs_you.replied` running.
+        let u = derive(&intake(r#"{"event":"question.ask","message":"Which auth strategy?"}"#, None)).unwrap();
+        assert_eq!(u.status, Status::Pending);
+        assert_eq!(u.msg, "Which auth strategy?");
+        let u = derive(&intake(r#"{"event":"needs_you.replied"}"#, None)).unwrap();
         assert_eq!(u.status, Status::Running);
-        assert_eq!(u.msg, "working");
-        assert_eq!(u.task, None);
     }
 
     #[test]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -79,7 +79,7 @@ enum Command {
         /// `generic` (any script — pass explicit `--status`/`--msg`/`--task`
         /// flags, no hook payload needed).
         agent: String,
-        /// Hook payload as a trailing argument (codex). Claude passes it on stdin instead.
+        /// Hook payload as a trailing argument (codex). Claude and opencode pass it on stdin instead.
         input: Option<String>,
         /// Explicit status (claude hooks pass this; required for `generic`):
         /// running | pending | done | error | idle.

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -5,9 +5,10 @@
 //!   agent's hook payload and broadcasts a `zj_radar.status.v1` update. Each
 //!   agent is a peer adapter behind the [`agents::Agent::derive`] seam, so
 //!   `notify` stays agent-agnostic.
-//! - `setup [codex|zellij]` ([`setup`]) — idempotent wiring: manage Codex
-//!   notify/`hooks.json`, install the wasm plugin, and inject the rail into a
-//!   Zellij layout ([`layout`]).
+//! - `setup [codex|opencode|zellij]` ([`setup`]) — idempotent wiring: manage
+//!   Codex notify/`hooks.json`, drop the opencode JS bridge plugin into its
+//!   auto-loaded plugins dir, install the wasm plugin, and inject the rail
+//!   into a Zellij layout ([`layout`]).
 //! - `run` ([`run`]) — turnkey launch of a Zellij session that owns its own
 //!   config with the rail preinstalled.
 
@@ -74,9 +75,9 @@ struct Cli {
 enum Command {
     /// Broadcast one agent's status to the sidebar (called from an agent hook).
     Notify {
-        /// Which agent is reporting: `claude`, `codex`, or `generic` (any
-        /// script — pass explicit `--status`/`--msg`/`--task` flags, no hook
-        /// payload needed).
+        /// Which agent is reporting: `claude`, `codex`, `opencode`, or
+        /// `generic` (any script — pass explicit `--status`/`--msg`/`--task`
+        /// flags, no hook payload needed).
         agent: String,
         /// Hook payload as a trailing argument (codex). Claude passes it on stdin instead.
         input: Option<String>,
@@ -109,7 +110,7 @@ enum Command {
     },
     /// Idempotently wire installed agents and Zellij to use zj-radar.
     Setup {
-        /// Targets to set up (default: detected agents only). Supported: claude, codex, zellij.
+        /// Targets to set up (default: detected agents only). Supported: claude, codex, opencode, zellij.
         targets: Vec<String>,
         /// Wasm artifact to install when setting up Zellij.
         #[arg(long, value_name = "PATH")]

--- a/crates/cli/src/notify.rs
+++ b/crates/cli/src/notify.rs
@@ -291,7 +291,7 @@ fn broadcast(pane_id: u32, update: AgentUpdate, source: &str, dry_run: bool) {
 /// `RUNNING_PIPE_TIMEOUT_SECS`, while the once-per-turn edges keep the full
 /// `DEFAULT_PIPE_TIMEOUT_SECS` — dropping an edge loses real state. Keying
 /// the default here (instead of per-entry env prefixes in hooks.json) gives
-/// every producer — claude, codex, generic — the policy from one seam.
+/// every producer — claude, codex, opencode, generic — the policy from one seam.
 /// Clamped to an hour: `Instant::now() + Duration::from_secs(u64::MAX)`
 /// overflows and panics, and this module promises the calling hook never
 /// sees a panic.

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -5,7 +5,7 @@
 //! pure-editor / thin-IO split that `setup.rs` uses.
 
 use super::fsutil::atomic_write;
-use super::setup::{CODEX_HOOK_MARKER, OPENCODE_PLUGIN_MARKER};
+use super::setup::CODEX_HOOK_MARKER;
 use std::path::{Path, PathBuf};
 
 /// Shown on first run (create OR attach) when the wasm isn't granted. The grant
@@ -214,7 +214,7 @@ pub(crate) fn claude_producer_wired(installed_plugins_json: Option<&str>) -> boo
 /// plugin text the caller already gathered (the shared `opencode_plugin_text`
 /// reader behind `run`'s advisory, `setup zellij`'s epilogue, and `--check`).
 pub(crate) fn opencode_producer_wired(opencode_plugin: Option<&str>) -> bool {
-    opencode_plugin.is_some_and(|p| p.contains(OPENCODE_PLUGIN_MARKER))
+    opencode_plugin.is_some_and(crate::setup::detect::opencode_plugin_is_ours)
 }
 
 /// Join argv into a copy-pasteable shell command. Every printed command hint
@@ -834,6 +834,7 @@ pub fn run(opts: RunOptions) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::setup::OPENCODE_PLUGIN_MARKER;
     use tempfile::tempdir;
 
     #[test]

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -5,7 +5,7 @@
 //! pure-editor / thin-IO split that `setup.rs` uses.
 
 use super::fsutil::atomic_write;
-use super::setup::CODEX_HOOK_MARKER;
+use super::setup::{CODEX_HOOK_MARKER, OPENCODE_PLUGIN_MARKER};
 use std::path::{Path, PathBuf};
 
 /// Shown on first run (create OR attach) when the wasm isn't granted. The grant
@@ -17,10 +17,11 @@ use std::path::{Path, PathBuf};
 /// branching into a second, dead-end message.
 const GRANT_HINT: &str = "First run: a permission prompt opens — press y to enable agent status \
     (if it doesn't appear, press Ctrl-y in the session).";
-/// Two producers, two wiring routes — name both, because `zj-radar setup` can
-/// only wire Codex; the Claude producer installs from inside Claude Code.
+/// Three producers, three wiring routes — name all, because `zj-radar setup`
+/// wires each agent symmetrically (claude drives Claude Code's plugin
+/// marketplace; opencode drops a vendored JS bridge into its plugins dir).
 pub(crate) const PRODUCER_HINT: &str = "Agent status off — no producer wired. Run `zj-radar setup claude` \
-    (Claude Code) or `zj-radar setup codex` (Codex).";
+    (Claude Code), `zj-radar setup codex` (Codex), or `zj-radar setup opencode` (Opencode).";
 
 // ── Pure helpers ─────────────────────────────────────────────────────────────
 
@@ -182,9 +183,14 @@ pub(crate) fn wasm_is_granted(permissions_kdl: &str, wasm_abs_path: &str) -> boo
 }
 
 /// Producer-detection advisory: `Some(hint)` when NO producer is wired (Codex
-/// hooks lack our marker AND the Claude producer plugin is absent), else `None`.
-pub(crate) fn producer_hint(codex_hooks: Option<&str>, claude_present: bool) -> Option<String> {
-    if codex_producer_wired(codex_hooks) || claude_present {
+/// hooks lack our marker AND the Claude producer plugin is absent AND the
+/// opencode bridge plugin is absent), else `None`.
+pub(crate) fn producer_hint(
+    codex_hooks: Option<&str>,
+    claude_present: bool,
+    opencode_present: bool,
+) -> Option<String> {
+    if codex_producer_wired(codex_hooks) || claude_present || opencode_present {
         None
     } else {
         Some(PRODUCER_HINT.to_string())
@@ -201,6 +207,14 @@ pub(crate) fn codex_producer_wired(codex_hooks: Option<&str>) -> bool {
 /// plugin ([`crate::setup::CLAUDE_PLUGIN`]). `None`/empty input returns `false`.
 pub(crate) fn claude_producer_wired(installed_plugins_json: Option<&str>) -> bool {
     installed_plugins_json.is_some_and(|s| s.contains(crate::setup::CLAUDE_PLUGIN))
+}
+
+/// True iff the opencode bridge plugin file carries our marker — the opencode
+/// producer's detection route, twin of [`codex_producer_wired`]. Reads the
+/// plugin text the caller already gathered (the shared `opencode_plugin_text`
+/// reader behind `run`'s advisory, `setup zellij`'s epilogue, and `--check`).
+pub(crate) fn opencode_producer_wired(opencode_plugin: Option<&str>) -> bool {
+    opencode_plugin.is_some_and(|p| p.contains(OPENCODE_PLUGIN_MARKER))
 }
 
 /// Join argv into a copy-pasteable shell command. Every printed command hint
@@ -411,6 +425,7 @@ struct RunFacts {
     permissions_kdl: Option<String>,
     codex_hooks: Option<String>,
     installed_plugins: Option<String>,
+    opencode_plugin: Option<String>,
 }
 
 /// What to launch and what to advise — the pure result of `plan_run`.
@@ -477,7 +492,8 @@ fn plan_run(facts: &RunFacts) -> RunPlan {
         advisories.push(GRANT_HINT.to_string());
     }
     let claude = claude_producer_wired(facts.installed_plugins.as_deref());
-    if let Some(hint) = producer_hint(facts.codex_hooks.as_deref(), claude) {
+    let opencode = opencode_producer_wired(facts.opencode_plugin.as_deref());
+    if let Some(hint) = producer_hint(facts.codex_hooks.as_deref(), claude, opencode) {
         advisories.push(hint);
     }
     RunPlan {
@@ -676,6 +692,7 @@ pub fn run(opts: RunOptions) {
         permissions_kdl: zellij_permissions_text(),
         codex_hooks: crate::setup::codex_hooks_text(),
         installed_plugins: crate::setup::claude_installed_plugins_text(),
+        opencode_plugin: crate::setup::opencode_plugin_text(),
     };
     let plan = plan_run(&facts);
 
@@ -1137,27 +1154,39 @@ mod tests {
     }
 
     #[test]
+    fn opencode_producer_detection() {
+        let ours = format!("// {OPENCODE_PLUGIN_MARKER}\nexport const …");
+        assert!(opencode_producer_wired(Some(&ours)));
+        assert!(!opencode_producer_wired(Some("// some other plugin\n")));
+        assert!(!opencode_producer_wired(None));
+    }
+
+    #[test]
     fn producer_hint_only_when_none_wired() {
         let wired = format!("{CODEX_HOOK_MARKER} zj-radar notify codex");
-        assert!(producer_hint(Some(&wired), false).is_none());
-        assert!(producer_hint(None, true).is_none());
-        // The hint must name BOTH wiring routes — `setup <agent>` covers each
-        // agent symmetrically (claude drives Claude Code's plugin marketplace).
-        let hint = producer_hint(None, false).unwrap();
+        assert!(producer_hint(Some(&wired), false, false).is_none());
+        assert!(producer_hint(None, true, false).is_none());
+        assert!(producer_hint(None, false, true).is_none());
+        // The hint must name EVERY wiring route — `setup <agent>` covers each
+        // agent symmetrically (claude drives Claude Code's plugin marketplace;
+        // opencode drops a vendored JS bridge into its plugins dir).
+        let hint = producer_hint(None, false, false).unwrap();
         assert!(hint.contains("zj-radar setup codex"), "must name the Codex route: {hint}");
         assert!(hint.contains("zj-radar setup claude"), "must name the Claude route: {hint}");
+        assert!(hint.contains("zj-radar setup opencode"), "must name the Opencode route: {hint}");
     }
 
     #[test]
     fn producer_detection_covers_every_instrumented_agent() {
-        // Producer detection knows exactly two wiring routes: the Codex hooks
-        // marker (`codex_producer_wired`) and the Claude plugin manifest
-        // (`claude_producer_wired`). This is the ONE wiring point the agent
-        // guard lattice doesn't reach: a third instrumented agent would wire
+        // Producer detection knows exactly three wiring routes: the Codex hooks
+        // marker (`codex_producer_wired`), the Claude plugin manifest
+        // (`claude_producer_wired`), and the opencode bridge plugin marker
+        // (`opencode_producer_wired`). This is the ONE wiring point the agent
+        // guard lattice doesn't reach: a new instrumented agent would wire
         // fine but `run` would still say "no producer wired". If this list is
         // out of date, teach detection the new agent's route (here, PRODUCER_HINT,
         // and the doctor's producer item in setup/check.rs), then extend it.
-        let covered = ["claude", "codex"];
+        let covered = ["claude", "codex", "opencode"];
         let sources: Vec<&str> = crate::agents::Agent::ALL.iter().map(|a| a.source()).collect();
         assert_eq!(
             sources, covered,
@@ -1240,9 +1269,14 @@ mod tests {
     }
 
     // ── plan_run decision matrix ──
-    // `granted`/`codex`/`claude` toggle whether each input signals "already set up".
-    // Defaults: session "proj", does not exist (create path), not running, not nested.
+    // `granted`/`codex`/`claude`/`opencode` toggle whether each input signals
+    // "already set up". Defaults: session "proj", does not exist (create path),
+    // not running, not nested.
     fn facts(granted: bool, codex: bool, claude: bool) -> RunFacts {
+        facts4(granted, codex, claude, false)
+    }
+
+    fn facts4(granted: bool, codex: bool, claude: bool, opencode: bool) -> RunFacts {
         let wasm = "/data/zj-radar/zellij/plugins/zj_radar.wasm";
         RunFacts {
             session: "proj".to_string(),
@@ -1261,6 +1295,7 @@ mod tests {
             }),
             codex_hooks: codex.then(|| format!("{CODEX_HOOK_MARKER} zj-radar notify codex")),
             installed_plugins: claude.then(|| "zj-radar-claude".to_string()),
+            opencode_plugin: opencode.then(|| format!("// {OPENCODE_PLUGIN_MARKER}\n")),
         }
     }
 

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -1357,6 +1357,20 @@ mod tests {
     }
 
     #[test]
+    fn plan_run_is_quiet_when_only_opencode_is_wired() {
+        // The opencode bridge is a producer in its own right: granted + only the
+        // opencode plugin present must yield no "no producer wired" advisory.
+        // This is the one call site exercising `RunFacts.opencode_plugin` →
+        // `opencode_producer_wired` → `producer_hint` end-to-end.
+        let p = plan_run(&facts4(true, false, false, true));
+        assert!(p.advisories.is_empty(), "{:?}", p.advisories);
+
+        let p = plan_run(&facts4(true, false, false, false));
+        assert_eq!(p.advisories.len(), 1, "{:?}", p.advisories);
+        assert!(p.advisories[0].contains("zj-radar setup opencode"), "{}", p.advisories[0]);
+    }
+
+    #[test]
     fn plan_run_advises_grant_when_ungranted() {
         let p = plan_run(&facts(false, true, false)); // producer wired, not granted
         assert_eq!(p.advisories.len(), 1);

--- a/crates/cli/src/setup/analyze.rs
+++ b/crates/cli/src/setup/analyze.rs
@@ -430,7 +430,7 @@ mod tests {
             permissions_text: None,
             codex_hooks_text: None,
             installed_plugins_text: Some(r#"{"plugins":["zj-radar-claude"]}"#.to_string()),
-            opencode_plugin_text:   None,
+            opencode_plugin_text: None,
             wasm_present: false,
             config_managed: false,
             wasm_path: "/x.wasm".to_string(),

--- a/crates/cli/src/setup/analyze.rs
+++ b/crates/cli/src/setup/analyze.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use crate::setup::detect::{codex_hook_handler_is_ours, has_unmanaged_radar_alias, is_unmanaged_radar_alias_line, notify_is_ours, strip_managed_zellij_alias};
+use crate::setup::detect::{codex_hook_handler_is_ours, has_unmanaged_radar_alias, is_unmanaged_radar_alias_line, notify_is_ours, opencode_plugin_is_ours, strip_managed_zellij_alias};
 
 use std::path::{Path, PathBuf};
 use toml_edit::{DocumentMut, Item};
@@ -13,6 +13,9 @@ pub(crate) struct ZellijEnv {
     pub permissions_text:      Option<String>,
     pub codex_hooks_text:      Option<String>,
     pub installed_plugins_text: Option<String>,
+    /// The opencode bridge plugin's text (`~/.config/opencode/plugins/zj-radar.js`),
+    /// read for producer detection — `None` when the file is absent.
+    pub opencode_plugin_text:  Option<String>,
     pub wasm_present:          bool,
     pub config_managed:        bool,
     pub wasm_path:             String,
@@ -48,6 +51,7 @@ pub(crate) fn read_zellij_env(config_dir: &Path, layout_name: Option<&str>) -> (
         permissions_text:       crate::run::zellij_permissions_text(),
         codex_hooks_text:       codex_hooks_text(),
         installed_plugins_text: claude_installed_plugins_text(),
+        opencode_plugin_text:   opencode_plugin_text(),
         wasm_present:           wasm_dest.is_file(),
         config_managed:         path_is_managed(&config_path),
         wasm_path:              wasm_dest.to_string_lossy().into_owned(),
@@ -69,6 +73,7 @@ pub(crate) struct ZellijFacts {
     pub granted:                 Option<bool>,
     pub codex_producer:          bool,
     pub claude_producer:         bool,
+    pub opencode_producer:       bool,
     pub config_managed:          bool,
     pub zellij_version:          Option<String>,
 }
@@ -77,7 +82,7 @@ impl ZellijFacts {
     /// Any producer at all — what install gating and the doctor's pass/fail
     /// care about; the per-producer bools let the doctor SAY which one.
     pub(crate) fn producer_wired(&self) -> bool {
-        self.codex_producer || self.claude_producer
+        self.codex_producer || self.claude_producer || self.opencode_producer
     }
 }
 
@@ -171,6 +176,7 @@ pub(crate) fn analyze_zellij(env: &ZellijEnv) -> ZellijFacts {
         .map(|t| crate::run::wasm_is_granted(t, &env.wasm_path));
     let claude_producer = crate::run::claude_producer_wired(env.installed_plugins_text.as_deref());
     let codex_producer = crate::run::codex_producer_wired(env.codex_hooks_text.as_deref());
+    let opencode_producer = crate::run::opencode_producer_wired(env.opencode_plugin_text.as_deref());
     ZellijFacts {
         managed_alias_present,
         unmanaged_alias_present,
@@ -180,6 +186,7 @@ pub(crate) fn analyze_zellij(env: &ZellijEnv) -> ZellijFacts {
         granted,
         codex_producer,
         claude_producer,
+        opencode_producer,
         config_managed: env.config_managed,
         zellij_version: env.zellij_version.clone(),
     }
@@ -278,6 +285,35 @@ fn codex_hooks_disabled_in_config(existing: &str) -> Result<bool, String> {
         == Some(false))
 }
 
+/// Raw, already-read environment for opencode setup. The only IO layer.
+pub(crate) struct OpencodeEnv {
+    pub opencode_on_path:   bool,
+    pub zj_radar_on_path:   bool,
+    pub plugin_text:        Option<String>,
+}
+
+/// Every derived fact about opencode setup state. `plugin_is_ours` is the
+/// single home for "is the installed plugin ours?" — read by the install/
+/// uninstall gating, the doctor, and `run`'s detection (via
+/// `opencode_plugin_is_ours` in `detect.rs`).
+pub(crate) struct OpencodeFacts {
+    pub opencode_on_path: bool,
+    pub zj_radar_on_path: bool,
+    /// `None` = plugin file absent; `Some(true)` = ours (marker present);
+    /// `Some(false)` = foreign (file present, marker absent).
+    pub plugin_is_ours:   Option<bool>,
+}
+
+/// Pure: derive every opencode setup fact from already-read inputs. No I/O.
+pub(crate) fn analyze_opencode(env: &OpencodeEnv) -> OpencodeFacts {
+    let plugin_is_ours = env.plugin_text.as_deref().map(opencode_plugin_is_ours);
+    OpencodeFacts {
+        opencode_on_path: env.opencode_on_path,
+        zj_radar_on_path: env.zj_radar_on_path,
+        plugin_is_ours,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -292,6 +328,7 @@ mod tests {
             permissions_text: None,
             codex_hooks_text: None,
             installed_plugins_text: None,
+            opencode_plugin_text: None,
             wasm_present: false,
             config_managed: false,
             wasm_path: "/x.wasm".to_string(),
@@ -324,6 +361,7 @@ mod tests {
             permissions_text: None,
             codex_hooks_text: None,
             installed_plugins_text: None,
+            opencode_plugin_text: None,
             wasm_present: false,
             config_managed: false,
             wasm_path: "/x.wasm".to_string(),
@@ -352,6 +390,7 @@ mod tests {
             permissions_text: Some(perms),
             codex_hooks_text: None,
             installed_plugins_text: None,
+            opencode_plugin_text: None,
             wasm_present: true,
             config_managed: false,
             wasm_path: wasm_path.to_string(),
@@ -371,6 +410,7 @@ mod tests {
             permissions_text: None,
             codex_hooks_text: None,
             installed_plugins_text: None,
+            opencode_plugin_text: None,
             wasm_present: false,
             config_managed: false,
             wasm_path: "/x.wasm".to_string(),
@@ -390,6 +430,7 @@ mod tests {
             permissions_text: None,
             codex_hooks_text: None,
             installed_plugins_text: Some(r#"{"plugins":["zj-radar-claude"]}"#.to_string()),
+            opencode_plugin_text:   None,
             wasm_present: false,
             config_managed: false,
             wasm_path: "/x.wasm".to_string(),
@@ -407,6 +448,7 @@ mod tests {
             permissions_text: None,
             codex_hooks_text: Some(format!("{{\"command\": \"{CODEX_HOOK_MARKER} zj-radar notify codex\"}}")),
             installed_plugins_text: None,
+            opencode_plugin_text: None,
             wasm_present: false,
             config_managed: false,
             wasm_path: "/x.wasm".to_string(),

--- a/crates/cli/src/setup/check.rs
+++ b/crates/cli/src/setup/check.rs
@@ -137,13 +137,17 @@ pub(crate) fn zellij_check_items(f: &ZellijFacts, layout_name: &str) -> Vec<Chec
     });
 
     // 5. producer — diagnosis, not a guess: say WHICH producer the doctor saw.
-    items.push(match (f.codex_producer, f.claude_producer) {
-        (true, true) => CheckItem::ok("producer", "Codex hooks and Claude plugin wired"),
-        (true, false) => CheckItem::ok("producer", "Codex hooks wired"),
-        (false, true) => CheckItem::ok("producer", "Claude plugin wired"),
-        (false, false) => CheckItem::missing(
+    items.push(match (f.codex_producer, f.claude_producer, f.opencode_producer) {
+        (true, true, true) => CheckItem::ok("producer", "Codex, Claude, and Opencode producers wired"),
+        (true, true, false) => CheckItem::ok("producer", "Codex hooks and Claude plugin wired"),
+        (true, false, true) => CheckItem::ok("producer", "Codex hooks and Opencode plugin wired"),
+        (false, true, true) => CheckItem::ok("producer", "Claude and Opencode plugins wired"),
+        (true, false, false) => CheckItem::ok("producer", "Codex hooks wired"),
+        (false, true, false) => CheckItem::ok("producer", "Claude plugin wired"),
+        (false, false, true) => CheckItem::ok("producer", "Opencode plugin wired"),
+        (false, false, false) => CheckItem::missing(
             "producer",
-            "no producer detected — run `zj-radar setup claude` or `zj-radar setup codex`",
+            "no producer detected — run `zj-radar setup claude`, `zj-radar setup codex`, or `zj-radar setup opencode`",
         ),
     });
 
@@ -204,6 +208,46 @@ pub(crate) fn claude_check_items(on_path: bool, wired: bool) -> Vec<CheckItem> {
             CheckItem::ok("plugin", format!("{CLAUDE_PLUGIN} plugin installed"))
         } else {
             CheckItem::missing("plugin", format!("{CLAUDE_PLUGIN} not installed — run `zj-radar setup claude`"))
+        },
+    ]
+}
+
+/// Returns true when any item is `Missing` — see [`check_codex`]. The opencode
+/// producer is a vendored JS bridge plugin in opencode's auto-loaded plugins
+/// dir; the doctor has two facts: the binary and our marker in the plugin file.
+pub(crate) fn check_opencode() -> bool {
+    let env = OpencodeEnv {
+        opencode_on_path:   which("opencode"),
+        zj_radar_on_path:   which("zj-radar"),
+        plugin_text:        opencode_plugin_text(),
+    };
+    let items = opencode_check_items(&analyze_opencode(&env));
+    println!("opencode:");
+    print_check_items(&items)
+}
+
+pub(crate) fn opencode_check_items(f: &OpencodeFacts) -> Vec<CheckItem> {
+    vec![
+        if f.opencode_on_path {
+            CheckItem::ok("opencode binary", "found on PATH")
+        } else {
+            CheckItem::missing("opencode binary", "not found on PATH")
+        },
+        if f.zj_radar_on_path {
+            CheckItem::ok("zj-radar binary", "found on PATH")
+        } else {
+            CheckItem::missing("zj-radar binary", "not found on PATH")
+        },
+        match f.plugin_is_ours {
+            None => CheckItem::missing(
+                "plugin",
+                "zj-radar bridge plugin not installed — run `zj-radar setup opencode`",
+            ),
+            Some(true) => CheckItem::ok("plugin", "zj-radar bridge plugin installed"),
+            Some(false) => CheckItem::warn(
+                "plugin",
+                "plugin file present but not ours (no marker) — re-run `zj-radar setup opencode --force` to replace it",
+            ),
         },
     ]
 }
@@ -462,6 +506,7 @@ mod tests {
             granted:                 Some(true),
             codex_producer:          true,
             claude_producer:         false,
+            opencode_producer:       false,
             config_managed:          false,
             zellij_version:          Some("zellij 0.44.3".to_string()),
         }

--- a/crates/cli/src/setup/check.rs
+++ b/crates/cli/src/setup/check.rs
@@ -239,9 +239,12 @@ pub(crate) fn opencode_check_items(f: &OpencodeFacts) -> Vec<CheckItem> {
             CheckItem::missing("zj-radar binary", "not found on PATH")
         },
         match f.plugin_is_ours {
+            // `opencode` is in `AGENT_NAMES`, so an uninstrumented pane is
+            // suppressed from command-tracking: without the bridge its row is
+            // dark, not merely un-enriched — say so, it's the reason to act.
             None => CheckItem::missing(
                 "plugin",
-                "zj-radar bridge plugin not installed — run `zj-radar setup opencode`",
+                "zj-radar bridge plugin not installed — opencode panes stay dark until it is; run `zj-radar setup opencode` and restart opencode",
             ),
             Some(true) => CheckItem::ok("plugin", "zj-radar bridge plugin installed"),
             Some(false) => CheckItem::warn(
@@ -728,6 +731,44 @@ mod tests {
         );
     }
 
+    fn opencode_facts(on_path: bool, plugin_text: Option<&str>) -> OpencodeFacts {
+        analyze_opencode(&OpencodeEnv {
+            opencode_on_path:   on_path,
+            zj_radar_on_path:   true,
+            plugin_text:        plugin_text.map(str::to_string),
+        })
+    }
+
+    #[test]
+    fn opencode_check_reports_ready_when_bridge_is_ours() {
+        let items = opencode_check_items(&opencode_facts(true, Some(OPENCODE_PLUGIN_JS)));
+        assert!(items.contains(&CheckItem::ok("opencode binary", "found on PATH")));
+        assert!(items.contains(&CheckItem::ok("zj-radar binary", "found on PATH")));
+        assert!(items.contains(&CheckItem::ok("plugin", "zj-radar bridge plugin installed")));
+        assert!(items.iter().all(|i| i.level == CheckLevel::Ok), "{items:?}");
+    }
+
+    #[test]
+    fn opencode_check_flags_missing_bridge_as_dark_pane() {
+        // `opencode` is in AGENT_NAMES, so an uninstrumented pane is suppressed
+        // from command-tracking: the doctor must say the row goes dark, not
+        // merely "not installed" — that consequence is the whole reason to act.
+        let items = opencode_check_items(&opencode_facts(true, None));
+        let plugin = items.iter().find(|i| i.name == "plugin").expect("plugin item");
+        assert_eq!(plugin.level, CheckLevel::Missing);
+        assert!(plugin.detail.contains("dark"), "must name the dark-row consequence: {}", plugin.detail);
+        assert!(plugin.detail.contains("`zj-radar setup opencode`"), "{}", plugin.detail);
+    }
+
+    #[test]
+    fn opencode_check_warns_on_foreign_plugin_file() {
+        let items = opencode_check_items(&opencode_facts(true, Some("// not ours\n")));
+        let plugin = items.iter().find(|i| i.name == "plugin").expect("plugin item");
+        assert_eq!(plugin.level, CheckLevel::Warn);
+        assert!(plugin.detail.contains("--force"), "{}", plugin.detail);
+        assert!(!items.iter().any(|i| i.level == CheckLevel::Missing), "a foreign file is a warn, not a fail");
+    }
+
     /// Every backtick-quoted `zj-radar …` invocation the doctor prints as a
     /// remedy must parse as a real CLI invocation — a hint that clap rejects
     /// sends the user into a usage error instead of a fix.
@@ -760,6 +801,16 @@ mod tests {
                 }),
                 false,
             ),
+            opencode_check_items(&analyze_opencode(&OpencodeEnv {
+                opencode_on_path:   false,
+                zj_radar_on_path:   false,
+                plugin_text:        None,
+            })),
+            opencode_check_items(&analyze_opencode(&OpencodeEnv {
+                opencode_on_path:   true,
+                zj_radar_on_path:   true,
+                plugin_text:        Some("// someone else's plugin\n".to_string()),
+            })),
         ] {
             details.extend(items.into_iter().map(|i| i.detail));
         }

--- a/crates/cli/src/setup/detect.rs
+++ b/crates/cli/src/setup/detect.rs
@@ -27,6 +27,15 @@ pub(crate) fn codex_hook_handler_is_ours(handler: &Value) -> bool {
             .is_some_and(|command| command.contains(CODEX_HOOK_MARKER))
 }
 
+/// True iff the opencode plugin file's text carries our ownership marker. The
+/// single reader behind `analyze_opencode`, the install/uninstall gating, the
+/// doctor, and `run`'s `opencode_producer_wired` (the `CODEX_HOOK_MARKER`
+/// precedent: one shared source of truth so detection can't drift). A foreign
+/// plugin file (no marker) is never mistaken for ours.
+pub(crate) fn opencode_plugin_is_ours(plugin_text: &str) -> bool {
+    plugin_text.contains(OPENCODE_PLUGIN_MARKER)
+}
+
 /// The layout name a `config.kdl` selects via `default_layout "name"`, or
 /// `None` when unset. Line-scan like the other config detectors: the node at
 /// line start (not commented out), its first argument quoted or bare. This is

--- a/crates/cli/src/setup/mod.rs
+++ b/crates/cli/src/setup/mod.rs
@@ -10,7 +10,7 @@ mod analyze;
 mod check;
 mod claude;
 mod codex;
-mod detect;
+pub(crate) mod detect;
 mod download;
 mod edit;
 mod opencode;

--- a/crates/cli/src/setup/mod.rs
+++ b/crates/cli/src/setup/mod.rs
@@ -1,8 +1,10 @@
-//! `zj-radar setup [claude|codex|zellij]` — idempotent, conflict-aware local
-//! wiring. Claude is wired through Claude Code's own plugin marketplace (we
-//! drive the `claude plugin` CLI, never its files); Codex gets hooks.json
-//! entries; Zellij setup installs the wasm at a stable path and manages the
-//! `radar` alias in `config.kdl`.
+//! `zj-radar setup [claude|codex|opencode|zellij]` — idempotent,
+//! conflict-aware local wiring. Claude is wired through Claude Code's own
+//! plugin marketplace (we drive the `claude plugin` CLI, never its files);
+//! Codex gets hooks.json entries; Opencode gets a vendored JS bridge plugin
+//! dropped into its auto-loaded global plugins dir (no `opencode.json` edit);
+//! Zellij setup installs the wasm at a stable path and manages the `radar`
+//! alias in `config.kdl`.
 
 mod analyze;
 mod check;
@@ -11,6 +13,7 @@ mod codex;
 mod detect;
 mod download;
 mod edit;
+mod opencode;
 mod preseed;
 mod zellij;
 pub(crate) use analyze::*;
@@ -19,6 +22,7 @@ pub(crate) use claude::*;
 pub(crate) use codex::*;
 pub(crate) use download::*;
 pub(crate) use edit::*;
+pub(crate) use opencode::*;
 pub(crate) use zellij::*;
 
 use std::path::{Path, PathBuf};
@@ -69,6 +73,22 @@ pub(crate) const ZELLIJ_ALIAS_END: &str = "// zj-radar: managed plugin alias end
 // trailing punctuation — callers supply their own.
 pub(crate) const CODEX_HOOK_TRUST_ADVICE: &str =
     "run `/hooks` in Codex to review and trust the zj-radar command hook";
+
+/// The idempotency/ownership marker stamped into the vendored opencode bridge
+/// plugin's header. One shared source of truth (the CODEX_HOOK_MARKER
+/// precedent) behind `setup opencode`'s install/uninstall gating, the doctor,
+/// and `run`'s producer detection, so the three can't drift on what counts as
+/// "ours". The JS plugin carries it as a leading comment: `// ZJ_RADAR_OPENCODE_PLUGIN=v1`.
+pub(crate) const OPENCODE_PLUGIN_MARKER: &str = "ZJ_RADAR_OPENCODE_PLUGIN=v1";
+/// The filename opencode auto-loads from its global plugins dir — the single
+/// install/uninstall target (no `opencode.json` edit, clean uninstall = delete
+/// one file). Inside the cargo package via `include_str!` so `cargo publish`
+/// works (a repo-root path would break crates.io installs).
+pub(crate) const OPENCODE_PLUGIN_FILE_NAME: &str = "zj-radar.js";
+/// The vendored bridge plugin, embedded so `setup opencode` writes a known-good
+/// copy and `cargo publish` packages it. A `flake.nix` filter entry covers this
+/// non-Rust `include_str!` input for the hermetic build.
+pub(crate) const OPENCODE_PLUGIN_JS: &str = include_str!("opencode_plugin.js");
 
 pub struct SetupOptions<'a> {
     pub targets: &'a [String],
@@ -127,6 +147,13 @@ pub(crate) struct CodexSetupOpts {
     is_tty:        bool,
 }
 
+pub(crate) struct OpencodeSetupOpts {
+    pub force:   bool,
+    pub dry_run: bool,
+    pub yes:     bool,
+    pub is_tty:  bool,
+}
+
 /// The single operation a `setup` invocation performs. Resolving this once makes
 /// the precedence (grant > check > uninstall > install) explicit instead of
 /// implicit in the order of `if` blocks.
@@ -177,6 +204,10 @@ pub fn run(options: SetupOptions<'_>) {
 
     let bare = options.targets.is_empty() && options.wasm.is_none() && !options.download;
     let want_codex = bare || options.targets.iter().any(|a| a == "codex");
+    // Bare `setup` = detected agents only: claude and opencode join codex
+    // there, and each `setup_*` itself skips gracefully when the binary is
+    // absent.
+    let want_opencode = bare || options.targets.iter().any(|a| a == "opencode");
     // Bare `setup` = detected agents only: claude joins codex there, and
     // `setup_claude` itself skips gracefully when the binary is absent.
     let want_claude = bare || options.targets.iter().any(|a| a == "claude");
@@ -186,9 +217,9 @@ pub fn run(options: SetupOptions<'_>) {
     for a in options
         .targets
         .iter()
-        .filter(|a| !matches!(a.as_str(), "claude" | "codex" | "zellij"))
+        .filter(|a| !matches!(a.as_str(), "claude" | "codex" | "opencode" | "zellij"))
     {
-        crate::exit::fail_report("zj-radar", format!("setup does not support '{a}' (supported: claude, codex, zellij). Skipping."));
+        crate::exit::fail_report("zj-radar", format!("setup does not support '{a}' (supported: claude, codex, opencode, zellij). Skipping."));
     }
     // Cross-target flag hygiene: `--wasm`/`--download` *imply* the zellij
     // target (they're zellij artifacts, see `want_zellij`), but `--inject`/
@@ -225,6 +256,11 @@ pub fn run(options: SetupOptions<'_>) {
         // doesn't have.
         if options.targets.iter().any(|a| a == "claude") || (both && which("claude")) {
             missing |= check_claude();
+        }
+        // opencode's doctor is binary-gated the same way: a machine without
+        // opencode shouldn't be failed by an agent it doesn't have.
+        if options.targets.iter().any(|a| a == "opencode") || (both && which("opencode")) {
+            missing |= check_opencode();
         }
         if missing {
             // The items above are the diagnostic; this sets the exit code so
@@ -281,6 +317,17 @@ pub fn run(options: SetupOptions<'_>) {
     }
     if want_claude {
         setup_claude(uninstall, options.dry_run, options.yes, is_tty);
+    }
+    if want_opencode {
+        setup_opencode(
+            uninstall,
+            OpencodeSetupOpts {
+                force:   options.force,
+                dry_run: options.dry_run,
+                yes:     options.yes,
+                is_tty,
+            },
+        );
     }
 }
 

--- a/crates/cli/src/setup/opencode.rs
+++ b/crates/cli/src/setup/opencode.rs
@@ -1,4 +1,5 @@
 use super::*;
+use super::detect::opencode_plugin_is_ours;
 
 use std::ffi::OsString;
 use std::path::PathBuf;
@@ -44,6 +45,85 @@ fn opencode_installed(opencode_on_path: bool) -> bool {
     opencode_on_path || opencode_plugin_path().is_some_and(|p| p.exists())
 }
 
+/// What `setup opencode` found at the plugin path. Three-state on purpose:
+/// `Absent` must never collapse into `Text("")` — the foreign-file refusal
+/// gate and the `--uninstall` report both key on the difference — and a file
+/// that is present but unreadable (non-UTF8, permissions) is not ours to
+/// overwrite either.
+pub(crate) enum Existing {
+    Absent,
+    Text(String),
+    Unreadable(std::io::Error),
+}
+
+fn read_existing(path: &std::path::Path) -> Existing {
+    match std::fs::read_to_string(path) {
+        Ok(text) => Existing::Text(text),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Existing::Absent,
+        Err(e) => Existing::Unreadable(e),
+    }
+}
+
+impl Existing {
+    /// The plugin text for `OpencodeEnv`, honoring its `None` = absent contract
+    /// (an unreadable file has no text to classify, so it is `None` too).
+    fn text(&self) -> Option<&str> {
+        match self {
+            Existing::Text(t) => Some(t),
+            Existing::Absent | Existing::Unreadable(_) => None,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum InstallPlan {
+    /// Ours and byte-identical to the embedded bridge.
+    UpToDate,
+    /// A file we can't claim (no marker, or unreadable) and no `--force`.
+    RefuseForeign,
+    /// Absent, empty, stale-ours, or `--force` over a foreign file.
+    Write,
+}
+
+/// Pure: the install decision. The embedded JS is the single source of truth,
+/// so "already up to date" is a byte-identical compare; a foreign file (no
+/// marker) is refused unless `force`, mirroring the codex notify-slot rule.
+pub(crate) fn plan_install(existing: &Existing, force: bool) -> InstallPlan {
+    match existing {
+        Existing::Absent => InstallPlan::Write,
+        Existing::Unreadable(_) if force => InstallPlan::Write,
+        Existing::Unreadable(_) => InstallPlan::RefuseForeign,
+        Existing::Text(text) => {
+            let ours = opencode_plugin_is_ours(text);
+            if ours && text == OPENCODE_PLUGIN_JS {
+                InstallPlan::UpToDate
+            } else if !text.is_empty() && !ours && !force {
+                InstallPlan::RefuseForeign
+            } else {
+                InstallPlan::Write
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum UninstallPlan {
+    /// Nothing at the path — nothing to do, and not an error.
+    Absent,
+    /// A file is there but carries no marker (or can't be read): leave it.
+    NotOurs,
+    Remove,
+}
+
+/// Pure: the uninstall decision — only a marker-bearing file is ours to delete.
+pub(crate) fn plan_uninstall(existing: &Existing) -> UninstallPlan {
+    match existing {
+        Existing::Absent => UninstallPlan::Absent,
+        Existing::Text(text) if opencode_plugin_is_ours(text) => UninstallPlan::Remove,
+        Existing::Text(_) | Existing::Unreadable(_) => UninstallPlan::NotOurs,
+    }
+}
+
 pub(crate) fn setup_opencode(uninstall: bool, opts: OpencodeSetupOpts) {
     if opencode_config_dir().is_none() {
         crate::exit::fail_report(
@@ -62,18 +142,25 @@ pub(crate) fn setup_opencode(uninstall: bool, opts: OpencodeSetupOpts) {
         println!("opencode: skipped (binary/config not found)");
         return;
     }
-    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    let existing = read_existing(&path);
     let env = OpencodeEnv {
         opencode_on_path,
         zj_radar_on_path: which("zj-radar"),
-        plugin_text: Some(existing.clone()),
+        plugin_text: existing.text().map(str::to_string),
     };
     let facts = analyze_opencode(&env);
 
     if uninstall {
-        if facts.plugin_is_ours != Some(true) {
-            println!("opencode: plugin not ours (marker absent) — leaving {}", path.display());
-            return;
+        match plan_uninstall(&existing) {
+            UninstallPlan::Absent => {
+                println!("opencode: plugin not installed ({})", path.display());
+                return;
+            }
+            UninstallPlan::NotOurs => {
+                println!("opencode: plugin not ours (marker absent) — leaving {}", path.display());
+                return;
+            }
+            UninstallPlan::Remove => {}
         }
         if opts.dry_run {
             println!("--- would remove {} (dry-run) ---", path.display());
@@ -86,25 +173,28 @@ pub(crate) fn setup_opencode(uninstall: bool, opts: OpencodeSetupOpts) {
         return;
     }
 
-    // Install: the embedded JS is the single source of truth, so "already up to
-    // date" is a byte-identical compare; a foreign file (no marker) is refused
-    // unless --force, mirroring the codex notify-slot conflict rule.
-    let plugin_is_ours = facts.plugin_is_ours.unwrap_or(false);
-    if plugin_is_ours && existing == OPENCODE_PLUGIN_JS {
-        println!("opencode: plugin already up to date ({})", path.display());
-        print_opencode_guidance(&facts);
-        return;
-    }
-    if !existing.is_empty() && !plugin_is_ours && !opts.force {
-        crate::exit::fail_report(
-            "opencode",
-            format!(
-                "{} already exists and is not ours (no marker). Refusing to overwrite it.\n\
-                 Re-run with --force to replace it.",
-                path.display()
-            ),
-        );
-        return;
+    match plan_install(&existing, opts.force) {
+        InstallPlan::UpToDate => {
+            println!("opencode: plugin already up to date ({})", path.display());
+            print_opencode_guidance(&facts);
+            return;
+        }
+        InstallPlan::RefuseForeign => {
+            let why = match &existing {
+                Existing::Unreadable(e) => format!("could not be read ({e})"),
+                _ => "is not ours (no marker)".to_string(),
+            };
+            crate::exit::fail_report(
+                "opencode",
+                format!(
+                    "{} already exists and {why}. Refusing to overwrite it.\n\
+                     Re-run with --force to replace it.",
+                    path.display()
+                ),
+            );
+            return;
+        }
+        InstallPlan::Write => {}
     }
     if opts.dry_run {
         println!("--- {} (dry-run) ---\n{OPENCODE_PLUGIN_JS}", path.display());
@@ -138,7 +228,7 @@ fn print_opencode_guidance(facts: &OpencodeFacts) {
 #[cfg(test)]
 mod tests {
     use super::super::{OPENCODE_PLUGIN_JS, OPENCODE_PLUGIN_MARKER};
-    use super::opencode_config_dir_from;
+    use super::{opencode_config_dir_from, plan_install, plan_uninstall, Existing, InstallPlan, UninstallPlan};
     use std::ffi::OsString;
     use std::path::PathBuf;
 
@@ -173,6 +263,48 @@ mod tests {
             opencode_config_dir_from(Some(OsString::new()), Some(os("/home/u"))),
             Some(PathBuf::from("/home/u/.config/opencode")),
         );
+    }
+
+    fn unreadable() -> Existing {
+        Existing::Unreadable(std::io::Error::new(std::io::ErrorKind::InvalidData, "stream did not contain valid UTF-8"))
+    }
+
+    #[test]
+    fn plan_install_writes_when_absent_or_empty() {
+        assert_eq!(plan_install(&Existing::Absent, false), InstallPlan::Write);
+        // An empty file is nobody's plugin — write over it without --force.
+        assert_eq!(plan_install(&Existing::Text(String::new()), false), InstallPlan::Write);
+    }
+
+    #[test]
+    fn plan_install_is_up_to_date_only_when_byte_identical() {
+        assert_eq!(plan_install(&Existing::Text(OPENCODE_PLUGIN_JS.to_string()), false), InstallPlan::UpToDate);
+        // Ours (marker present) but stale → rewrite, no --force needed.
+        let stale = format!("// {OPENCODE_PLUGIN_MARKER}\n// older bridge\n");
+        assert_eq!(plan_install(&Existing::Text(stale), false), InstallPlan::Write);
+    }
+
+    #[test]
+    fn plan_install_refuses_foreign_plugin_without_force() {
+        let foreign = Existing::Text("export const Other = async () => ({});\n".to_string());
+        assert_eq!(plan_install(&foreign, false), InstallPlan::RefuseForeign);
+        assert_eq!(plan_install(&foreign, true), InstallPlan::Write);
+    }
+
+    #[test]
+    fn plan_install_treats_unreadable_file_as_foreign() {
+        // A present-but-unreadable file (non-UTF8, permissions) must NOT read as
+        // absent — that would skip the refusal gate and overwrite it silently.
+        assert_eq!(plan_install(&unreadable(), false), InstallPlan::RefuseForeign);
+        assert_eq!(plan_install(&unreadable(), true), InstallPlan::Write);
+    }
+
+    #[test]
+    fn plan_uninstall_distinguishes_absent_from_foreign() {
+        assert_eq!(plan_uninstall(&Existing::Absent), UninstallPlan::Absent);
+        assert_eq!(plan_uninstall(&Existing::Text("// not ours\n".to_string())), UninstallPlan::NotOurs);
+        assert_eq!(plan_uninstall(&unreadable()), UninstallPlan::NotOurs);
+        assert_eq!(plan_uninstall(&Existing::Text(OPENCODE_PLUGIN_JS.to_string())), UninstallPlan::Remove);
     }
 
     /// Weld: the embedded plugin carries the marker and the spawn contract the

--- a/crates/cli/src/setup/opencode.rs
+++ b/crates/cli/src/setup/opencode.rs
@@ -42,7 +42,18 @@ fn opencode_config_dir_from(xdg: Option<OsString>, home: Option<OsString>) -> Op
 }
 
 fn opencode_installed(opencode_on_path: bool) -> bool {
-    opencode_on_path || opencode_plugin_path().is_some_and(|p| p.exists())
+    opencode_installed_from(
+        opencode_on_path,
+        opencode_config_dir().is_some_and(|d| d.is_dir()),
+        opencode_plugin_path().is_some_and(|p| p.exists()),
+    )
+}
+
+/// Pure: is opencode present on this machine? The binary on PATH, or a
+/// populated `~/.config/opencode/` (opencode.json, auth — a Nix/bun-run user
+/// may have no `opencode` on PATH), or our plugin already dropped there.
+fn opencode_installed_from(on_path: bool, config_dir_exists: bool, plugin_exists: bool) -> bool {
+    on_path || config_dir_exists || plugin_exists
 }
 
 /// What `setup opencode` found at the plugin path. Three-state on purpose:
@@ -132,10 +143,9 @@ pub(crate) fn setup_opencode(uninstall: bool, opts: OpencodeSetupOpts) {
         );
         return;
     }
-    // The plugins dir may not exist yet on a fresh opencode install; create it
-    // (and parents) on install so `backup_then_write` can place the file. This
-    // is the one mkdir in the setup tree — opencode auto-loads the dir but
-    // doesn't guarantee it exists.
+    // The plugins dir may not exist yet on a fresh opencode install; the
+    // atomic write below creates it (and parents) — after consent, so a
+    // declined install leaves nothing behind.
     let Some(path) = opencode_plugin_path() else { return };
     let opencode_on_path = which("opencode");
     if !uninstall && !opencode_installed(opencode_on_path) {
@@ -164,6 +174,12 @@ pub(crate) fn setup_opencode(uninstall: bool, opts: OpencodeSetupOpts) {
         }
         if opts.dry_run {
             println!("--- would remove {} (dry-run) ---", path.display());
+            return;
+        }
+        // Same consent step as every other setup write/remove: a non-tty run
+        // without -y skips rather than deleting unasked.
+        if !confirm(&format!("Remove {}?", path.display()), opts.yes, opts.is_tty) {
+            println!("opencode: skipped (declined)");
             return;
         }
         if let Err(e) = std::fs::remove_file(&path) {
@@ -201,11 +217,6 @@ pub(crate) fn setup_opencode(uninstall: bool, opts: OpencodeSetupOpts) {
         print_opencode_guidance(&facts);
         return;
     }
-    // Ensure the plugins dir exists before the backup+write (opencode auto-loads
-    // it, but a fresh install may not have created it).
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
     let prompt = format!("Write {}?", path.display());
     if !confirm_and_write("opencode", &path, OPENCODE_PLUGIN_JS, opts.yes, opts.is_tty, &prompt, || Ok(())) {
         return;
@@ -228,7 +239,7 @@ fn print_opencode_guidance(facts: &OpencodeFacts) {
 #[cfg(test)]
 mod tests {
     use super::super::{OPENCODE_PLUGIN_JS, OPENCODE_PLUGIN_MARKER};
-    use super::{opencode_config_dir_from, plan_install, plan_uninstall, Existing, InstallPlan, UninstallPlan};
+    use super::{opencode_config_dir_from, opencode_installed_from, plan_install, plan_uninstall, Existing, InstallPlan, UninstallPlan};
     use std::ffi::OsString;
     use std::path::PathBuf;
 
@@ -263,6 +274,16 @@ mod tests {
             opencode_config_dir_from(Some(OsString::new()), Some(os("/home/u"))),
             Some(PathBuf::from("/home/u/.config/opencode")),
         );
+    }
+
+    #[test]
+    fn opencode_counts_as_installed_via_binary_config_dir_or_plugin() {
+        assert!(opencode_installed_from(true, false, false));
+        // A populated ~/.config/opencode with no binary on PATH (Nix/bun-run
+        // users) must not make an explicit `setup opencode` silently skip.
+        assert!(opencode_installed_from(false, true, false));
+        assert!(opencode_installed_from(false, false, true));
+        assert!(!opencode_installed_from(false, false, false));
     }
 
     fn unreadable() -> Existing {

--- a/crates/cli/src/setup/opencode.rs
+++ b/crates/cli/src/setup/opencode.rs
@@ -1,0 +1,201 @@
+use super::*;
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+pub(crate) fn opencode_plugin_path() -> Option<PathBuf> {
+    opencode_plugins_dir().map(|d| d.join(OPENCODE_PLUGIN_FILE_NAME))
+}
+
+/// Read the vendored plugin file for producer *detection* (`run`'s advisory,
+/// `setup zellij`'s epilogue hint, `--check`). Routed through
+/// [`opencode_plugin_path`] so `$XDG_CONFIG_HOME` is honored on the read side
+/// exactly as `setup opencode` honors it on the write side — a hand-rolled
+/// `~/.config/opencode` probe here would tell an `XDG_CONFIG_HOME` user their
+/// correctly-installed plugin is missing.
+pub(crate) fn opencode_plugin_text() -> Option<String> {
+    opencode_plugin_path().and_then(|p| std::fs::read_to_string(p).ok())
+}
+
+fn opencode_plugins_dir() -> Option<PathBuf> {
+    opencode_config_dir().map(|d| d.join("plugins"))
+}
+
+fn opencode_config_dir() -> Option<PathBuf> {
+    opencode_config_dir_from(std::env::var_os("XDG_CONFIG_HOME"), std::env::var_os("HOME"))
+}
+
+/// Resolve opencode's user config home: `$XDG_CONFIG_HOME/opencode` wins, else
+/// `$HOME/.config/opencode`. `None` when neither resolves to a usable path.
+///
+/// Deliberately NOT `dirs::config_dir()` — that yields `~/Library/Application
+/// Support` on macOS, but opencode's docs and load order put the user config
+/// at `~/.config/opencode` cross-platform (the macOS `Application Support`
+/// path is reserved for admin-managed settings, a different precedence tier).
+/// Pure (env passed in) so the precedence is unit-tested without touching env.
+fn opencode_config_dir_from(xdg: Option<OsString>, home: Option<OsString>) -> Option<PathBuf> {
+    if let Some(x) = xdg.filter(|x| !x.is_empty()) {
+        return Some(PathBuf::from(x).join("opencode"));
+    }
+    home.filter(|h| !h.is_empty()).map(|h| PathBuf::from(h).join(".config").join("opencode"))
+}
+
+fn opencode_installed(opencode_on_path: bool) -> bool {
+    opencode_on_path || opencode_plugin_path().is_some_and(|p| p.exists())
+}
+
+pub(crate) fn setup_opencode(uninstall: bool, opts: OpencodeSetupOpts) {
+    if opencode_config_dir().is_none() {
+        crate::exit::fail_report(
+            "opencode",
+            "skipped — set $HOME or $XDG_CONFIG_HOME so the opencode config dir can be resolved",
+        );
+        return;
+    }
+    // The plugins dir may not exist yet on a fresh opencode install; create it
+    // (and parents) on install so `backup_then_write` can place the file. This
+    // is the one mkdir in the setup tree — opencode auto-loads the dir but
+    // doesn't guarantee it exists.
+    let Some(path) = opencode_plugin_path() else { return };
+    let opencode_on_path = which("opencode");
+    if !uninstall && !opencode_installed(opencode_on_path) {
+        println!("opencode: skipped (binary/config not found)");
+        return;
+    }
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    let env = OpencodeEnv {
+        opencode_on_path,
+        zj_radar_on_path: which("zj-radar"),
+        plugin_text: Some(existing.clone()),
+    };
+    let facts = analyze_opencode(&env);
+
+    if uninstall {
+        if facts.plugin_is_ours != Some(true) {
+            println!("opencode: plugin not ours (marker absent) — leaving {}", path.display());
+            return;
+        }
+        if opts.dry_run {
+            println!("--- would remove {} (dry-run) ---", path.display());
+            return;
+        }
+        if let Err(e) = std::fs::remove_file(&path) {
+            crate::exit::fail_report("opencode", format!("remove failed — {e}"));
+        }
+        println!("opencode: plugin removed ({})", path.display());
+        return;
+    }
+
+    // Install: the embedded JS is the single source of truth, so "already up to
+    // date" is a byte-identical compare; a foreign file (no marker) is refused
+    // unless --force, mirroring the codex notify-slot conflict rule.
+    let plugin_is_ours = facts.plugin_is_ours.unwrap_or(false);
+    if plugin_is_ours && existing == OPENCODE_PLUGIN_JS {
+        println!("opencode: plugin already up to date ({})", path.display());
+        print_opencode_guidance(&facts);
+        return;
+    }
+    if !existing.is_empty() && !plugin_is_ours && !opts.force {
+        crate::exit::fail_report(
+            "opencode",
+            format!(
+                "{} already exists and is not ours (no marker). Refusing to overwrite it.\n\
+                 Re-run with --force to replace it.",
+                path.display()
+            ),
+        );
+        return;
+    }
+    if opts.dry_run {
+        println!("--- {} (dry-run) ---\n{OPENCODE_PLUGIN_JS}", path.display());
+        print_opencode_guidance(&facts);
+        return;
+    }
+    // Ensure the plugins dir exists before the backup+write (opencode auto-loads
+    // it, but a fresh install may not have created it).
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let prompt = format!("Write {}?", path.display());
+    if !confirm_and_write("opencode", &path, OPENCODE_PLUGIN_JS, opts.yes, opts.is_tty, &prompt, || Ok(())) {
+        return;
+    }
+    println!("opencode: plugin installed ({})", path.display());
+    print_opencode_guidance(&facts);
+}
+
+fn print_opencode_guidance(facts: &OpencodeFacts) {
+    if !facts.zj_radar_on_path {
+        eprintln!(
+            "opencode: warning — `zj-radar` not found on PATH; the bridge spawns it per event, \
+             so status won't broadcast until it's installed"
+        );
+    }
+    // Plugins load once at opencode startup, so a write mid-session needs a restart.
+    println!("opencode: restart opencode (or reload plugins) for the bridge to take effect.");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{OPENCODE_PLUGIN_JS, OPENCODE_PLUGIN_MARKER};
+    use super::opencode_config_dir_from;
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+
+    fn os(s: &str) -> OsString {
+        OsString::from(s)
+    }
+
+    #[test]
+    fn opencode_config_dir_prefers_xdg_over_home() {
+        assert_eq!(
+            opencode_config_dir_from(Some(os("/x/xdg")), Some(os("/home/u"))),
+            Some(PathBuf::from("/x/xdg/opencode")),
+        );
+    }
+
+    #[test]
+    fn opencode_config_dir_falls_back_to_home_dot_config() {
+        assert_eq!(
+            opencode_config_dir_from(None, Some(os("/home/u"))),
+            Some(PathBuf::from("/home/u/.config/opencode")),
+        );
+    }
+
+    #[test]
+    fn opencode_config_dir_is_none_when_neither_resolves() {
+        assert_eq!(opencode_config_dir_from(None, None), None);
+        // Empty strings are treated as unset, not as the root path.
+        assert_eq!(opencode_config_dir_from(Some(OsString::new()), Some(OsString::new())), None);
+        assert_eq!(opencode_config_dir_from(None, Some(OsString::new())), None);
+        // An empty XDG still lets a real HOME win.
+        assert_eq!(
+            opencode_config_dir_from(Some(OsString::new()), Some(os("/home/u"))),
+            Some(PathBuf::from("/home/u/.config/opencode")),
+        );
+    }
+
+    /// Weld: the embedded plugin carries the marker and the spawn contract the
+    /// install path, the doctor, and `run`'s detection all key off. A stale
+    /// `include_str!` target (renamed file, dropped marker, a `spawnSync` that
+    /// would freeze the TUI) is caught here rather than at runtime.
+    #[test]
+    fn embedded_plugin_carries_marker_and_contract() {
+        assert!(
+            OPENCODE_PLUGIN_JS.contains(OPENCODE_PLUGIN_MARKER),
+            "the vendored plugin must carry the {OPENCODE_PLUGIN_MARKER} marker in its header"
+        );
+        assert!(
+            OPENCODE_PLUGIN_JS.contains("notify opencode"),
+            "the bridge must spawn `zj-radar notify opencode`"
+        );
+        assert!(
+            !OPENCODE_PLUGIN_JS.contains("spawnSync"),
+            "the bridge must never use spawnSync — it runs in opencode's process and would freeze the TUI"
+        );
+        assert!(
+            OPENCODE_PLUGIN_JS.contains("ZELLIJ"),
+            "the bridge must gate on $ZELLIJ (skip spawn when not under Zellij)"
+        );
+    }
+}

--- a/crates/cli/src/setup/opencode.rs
+++ b/crates/cli/src/setup/opencode.rs
@@ -192,7 +192,7 @@ pub(crate) fn setup_opencode(uninstall: bool, opts: OpencodeSetupOpts) {
     match plan_install(&existing, opts.force) {
         InstallPlan::UpToDate => {
             println!("opencode: plugin already up to date ({})", path.display());
-            print_opencode_guidance(&facts);
+            print_opencode_guidance(&facts, false);
             return;
         }
         InstallPlan::RefuseForeign => {
@@ -214,7 +214,7 @@ pub(crate) fn setup_opencode(uninstall: bool, opts: OpencodeSetupOpts) {
     }
     if opts.dry_run {
         println!("--- {} (dry-run) ---\n{OPENCODE_PLUGIN_JS}", path.display());
-        print_opencode_guidance(&facts);
+        print_opencode_guidance(&facts, true);
         return;
     }
     let prompt = format!("Write {}?", path.display());
@@ -222,18 +222,21 @@ pub(crate) fn setup_opencode(uninstall: bool, opts: OpencodeSetupOpts) {
         return;
     }
     println!("opencode: plugin installed ({})", path.display());
-    print_opencode_guidance(&facts);
+    print_opencode_guidance(&facts, true);
 }
 
-fn print_opencode_guidance(facts: &OpencodeFacts) {
+fn print_opencode_guidance(facts: &OpencodeFacts, wrote: bool) {
     if !facts.zj_radar_on_path {
         eprintln!(
             "opencode: warning — `zj-radar` not found on PATH; the bridge spawns it per event, \
              so status won't broadcast until it's installed"
         );
     }
-    // Plugins load once at opencode startup, so a write mid-session needs a restart.
-    println!("opencode: restart opencode (or reload plugins) for the bridge to take effect.");
+    // Plugins load once at opencode startup, so a write mid-session needs a
+    // restart — but an already-current file needs nothing.
+    if wrote {
+        println!("opencode: restart opencode (or reload plugins) for the bridge to take effect.");
+    }
 }
 
 #[cfg(test)]

--- a/crates/cli/src/setup/opencode_plugin.js
+++ b/crates/cli/src/setup/opencode_plugin.js
@@ -12,14 +12,19 @@
 // status edges (pending/done/error/idle) and the task-carrying `chat.message`
 // go out strictly FIFO, while tool-activity `running` refreshes coalesce to
 // the latest unsent one (latest-wins is the project's ordering rule, so a
-// stale running is free to drop and can never head-of-line block an edge). Each child has a hard ~10s kill timer as an outer backstop;
-// a rejected child never breaks the queue.
+// stale running is free to drop and can never head-of-line block an edge).
+// Each child has a hard ~10s kill timer as an outer backstop; a rejected child
+// never breaks the queue.
 // ASYNC SPAWN ONLY — never a synchronous spawn: the plugin runs in opencode's
 // process, so a wedged rail must not freeze the TUI event loop.
 //
 // The bridge picks the status class (it knows the event); the Rust adapter
 // (crates/cli/src/agents/opencode.rs) owns the refinements keyed off the
 // payload's `event` field.
+//
+// Event shapes are opencode ≥ 1.18 (`packages/schema/src/v1/*.ts`): every bus
+// event carries a top-level `sessionID`; `session.*` also carry `info`
+// (Session.Info, whose own key is `id`), `message.part.updated` carries `part`.
 
 // Resolved once at plugin init. `directory` is the session cwd (forwarded as
 // `cwd` on every spawn so the rail resolves repo/branch without a host probe).
@@ -28,32 +33,34 @@ let CWD = "";
 // Subagent (task-tool) sessions. opencode forks them with `parentID`, and
 // their prompts/tools/idle fire the same hooks and bus events as the user's
 // session — so a subagent finishing would paint Done (and clobber the task
-// label) mid-turn. Children always announce themselves via `session.created`
-// (info.parentID) before anything else, so the bridge learns the set from
-// the stream and drops their events; every *other* session is the user's.
+// label) mid-turn. Children announce themselves via `session.created`
+// (info.parentID) before anything else, so the bridge learns the set from the
+// stream and drops their events; every *other* session is the user's.
 // Deliberately NOT a "pin the root" latch: switching to an existing session
 // (picker, `-c`, `--session`, attach) fires no `session.created`, and a latch
 // would freeze the rail on the old session forever.
 const childSessions = new Set();
 
-// The current user message ID: opencode publishes `message.part.updated` for
-// the user's own prompt parts too (Part carries no role), so parts of this
-// message must never land in `lastAssistantText`.
-let lastUserMessageID = null;
+// messageID → role for the current turn. Part carries no role, and opencode
+// publishes `message.part.updated` for the user's own prompt parts too (and
+// for compaction's synthetic user message, which never passes `chat.message`)
+// — so only parts of a known-assistant message may become `lastAssistantText`.
+const messageRoles = new Map();
 
-// messageID -> role, learned from `message.updated` (which does carry role);
-// cleared at each turn boundary so it stays bounded.
-let messageRoles = new Map();
-
-// The last assistant text part seen via `message.part.updated`, tracked so a
-// `session.idle` (which carries no message text) can emit the turn's final
-// assistant text for the adapter's trailing-question Done→Pending remap.
+// The last assistant text part seen, so a `session.idle` (which carries no
+// message text) can emit the turn's final assistant text for the adapter's
+// trailing-question Done→Pending remap.
 let lastAssistantText = "";
 
-// Queue with latest-wins coalescing for `running` events: running refreshes are
-// droppable so a backlog under slow/wedged sends never blocks pending/done edges.
+// opencode's `halt()` publishes `session.error` and then sets the session idle
+// in the same tick, so a real error is always followed by `session.idle`.
+// Latched, that idle must not paint Done over the error; the latch clears on
+// the next non-error send (the user's next prompt, a tool, a permission).
+let errorLatched = false;
+
+// Queue: edges FIFO, one droppable slot for the latest tool-activity running.
 let pendingRunning = null;
-let queue = [];
+const queue = [];
 let processing = false;
 
 function enqueue(status, payload) {
@@ -70,18 +77,16 @@ function enqueue(status, payload) {
     }
     queue.push({ status, payload });
   }
+  errorLatched = status === "error";
   processQueue();
 }
 
 async function processQueue() {
   if (processing) return;
   processing = true;
-
   while (queue.length > 0 || pendingRunning !== null) {
-    let item;
-    if (queue.length > 0) {
-      item = queue.shift();
-    } else {
+    let item = queue.shift();
+    if (item === undefined) {
       item = { status: "running", payload: pendingRunning };
       pendingRunning = null;
     }
@@ -89,7 +94,6 @@ async function processQueue() {
       await notify(item.status, item.payload);
     } catch {}
   }
-
   processing = false;
 }
 
@@ -130,7 +134,7 @@ function notify(status, payload) {
     .catch(() => clearTimeout(timer));
 }
 
-// Extract the user's prompt text from a chat.message `output.parts` array
+// The user's prompt text from a chat.message `output.parts` array
 // (UserMessage itself carries no text — the prompt is in its TextParts).
 function promptText(parts) {
   if (!Array.isArray(parts)) return "";
@@ -141,7 +145,7 @@ function promptText(parts) {
     .trim();
 }
 
-// Extract a human message from opencode's error union ({ name, data: { message? } }).
+// A human message from opencode's error union ({ name, data: { message? } }).
 function errorMessage(error) {
   if (!error) return "";
   if (error.data && typeof error.data.message === "string" && error.data.message) {
@@ -150,158 +154,129 @@ function errorMessage(error) {
   return typeof error.name === "string" ? error.name : "";
 }
 
-// Extract a permission description from `permission.asked` properties
-// ({ id, sessionID, permission, patterns, metadata, always, tool? } — no title).
-function permMessage(props) {
-  if (!props) return "Permission requested";
+// `permission.asked` is the flattened Request — no title; derive one from
+// `permission` (e.g. "bash") + `patterns` (e.g. "cargo test").
+function permissionMessage(props) {
   const name = typeof props.permission === "string" && props.permission ? props.permission : "permission";
-  const patterns = Array.isArray(props.patterns) && props.patterns.length > 0
-    ? props.patterns.join(", ")
-    : "";
+  const patterns = Array.isArray(props.patterns) ? props.patterns.join(", ") : "";
   return patterns ? `${name}: ${patterns}` : name;
 }
 
-// Whether a payload declares itself a child/subagent session (Session.Info
-// carries `parentID`), or names a session already learned as a child.
-function isChildSession(props) {
-  if (!props) return false;
-  if (props.parentID || props.parent_id || (props.info && (props.info.parentID || props.info.parent_id))) {
-    return true;
-  }
-  const sid = eventSession(props);
-  return sid !== null && childSessions.has(sid);
+// `question.asked` is the flattened Request: `questions[].question`.
+function questionMessage(props) {
+  const first = Array.isArray(props.questions) ? props.questions[0] : null;
+  return first && typeof first.question === "string" ? first.question : "question";
 }
 
-// The sessionID an event belongs to. Current opencode stamps a top-level
-// `sessionID` on every event; older shapes carried only `{ info }` (whose
-// session key is `id`) or `{ part }` (which carries its own `sessionID`).
+// The sessionID a bus event belongs to (top-level on every current event;
+// `info.id` / `part.sessionID` cover the older wrapped shapes).
 function eventSession(props) {
-  if (!props) return null;
-  return (
-    props.sessionID ||
-    props.session_id ||
-    (props.info && (props.info.sessionID || props.info.session_id || props.info.id)) ||
-    (props.part && props.part.sessionID) ||
-    null
-  );
+  return props.sessionID || (props.info && props.info.id) || (props.part && props.part.sessionID) || null;
+}
+
+function isChild(sessionID) {
+  return typeof sessionID === "string" && childSessions.has(sessionID);
+}
+
+function endTurn() {
+  lastAssistantText = "";
+  messageRoles.clear();
 }
 
 export const ZjRadarPlugin = async ({ directory }) => {
   CWD = typeof directory === "string" ? directory : "";
   return {
     // User submitted a prompt → running, with the prompt text for task capture.
+    // Fires before the message is stored, so the role is known before any of
+    // its parts arrive via `message.part.updated`.
     "chat.message": async (input, output) => {
-      if (!output || isChildSession(input) || isChildSession(output)) return;
+      if (!output || isChild(input && input.sessionID)) return;
       lastAssistantText = "";
-      const msgID = output.id || output.messageID || (output.message && output.message.id);
-      if (msgID) {
-        lastUserMessageID = msgID;
-        messageRoles.set(msgID, "user");
-      }
-      const prompt = promptText(output && (output.parts || (output.message && output.message.parts)));
-      enqueue("running", { event: "chat.message", prompt });
+      if (output.message && output.message.id) messageRoles.set(output.message.id, "user");
+      enqueue("running", { event: "chat.message", prompt: promptText(output.parts) });
     },
 
     // Tool about to run / just ran → running, with the live tool activity.
+    // `after` is load-bearing: a permission is asked inside the tool, between
+    // `before` and `after`, so `after` is what brings a ◆ back to running.
     "tool.execute.before": async (input, output) => {
-      if (isChildSession(input) || isChildSession(output)) return;
-      enqueue("running", {
-        event: "tool.execute",
-        tool: input && input.tool,
-        tool_input: output && output.args,
-      });
+      if (isChild(input && input.sessionID)) return;
+      enqueue("running", { event: "tool.execute", tool: input.tool, tool_input: output && output.args });
     },
     "tool.execute.after": async (input) => {
-      if (isChildSession(input)) return;
-      enqueue("running", {
-        event: "tool.execute",
-        tool: input && input.tool,
-        tool_input: input && input.args,
-      });
+      if (isChild(input && input.sessionID)) return;
+      enqueue("running", { event: "tool.execute", tool: input.tool, tool_input: input.args });
     },
 
-    // Legacy (< 1.14) permission hook → pending. Current opencode no longer
-    // triggers it (the signal is the `permission.asked` bus event below);
-    // kept so older installs still get the needs-you moment.
-    "permission.ask": async (input) => {
-      enqueue("pending", {
-        event: "permission.ask",
-        message: input && input.title,
-      });
-    },
-
-    // The catch-all event stream: session lifecycle + assistant-text tracking.
+    // The bus: needs-you prompts, session lifecycle, assistant-text tracking.
     event: async ({ event }) => {
       const type = event && event.type;
       const props = (event && event.properties) || {};
-      const eventSessionID = eventSession(props);
-
-      // Permission prompts block the user's TUI whichever session raised them
-      // (a subagent's `bash` asks through the parent's UI), so they are the one
-      // class of event that must NOT be filtered by session.
-      if (type === "permission.asked") {
-        enqueue("pending", { event: "permission.ask", message: permMessage(props) });
-        return;
-      }
-      if (type === "permission.replied") {
-        // The user answered → back to running now, rather than on the next
-        // tool/idle event (a denied permission throws inside the tool, so
-        // `tool.execute.after` may never come).
-        enqueue("running", { event: "permission.replied" });
-        return;
-      }
-
-      // Learn (and forget) subagent sessions from their lifecycle events.
-      if ((type === "session.created" || type === "session.updated") && eventSessionID) {
-        if (props.parentID || (props.info && props.info.parentID)) childSessions.add(eventSessionID);
-      }
-      if (type === "session.deleted" && eventSessionID && childSessions.has(eventSessionID)) {
-        childSessions.delete(eventSessionID);
-        return;
-      }
-      if (isChildSession(props)) return;
+      const sessionID = eventSession(props);
 
       switch (type) {
-        // Track message role updates so we can accurately ignore user parts.
-        case "message.updated": {
-          const msg = props.message || props.info || props;
-          const id = msg && (msg.id || msg.messageID);
-          const role = msg && msg.role;
-          if (id && role) {
-            messageRoles.set(id, role);
+        // Needs-you prompts block the user's TUI whichever session raised them
+        // (a subagent's `bash` asks through the parent's UI), so they are never
+        // filtered by session. The user answering brings the row back to
+        // running now — a denied permission throws inside the tool, so
+        // `tool.execute.after` may never come.
+        case "permission.asked":
+          enqueue("pending", { event: "permission.ask", message: permissionMessage(props) });
+          return;
+        case "question.asked":
+          enqueue("pending", { event: "question.ask", message: questionMessage(props) });
+          return;
+        case "permission.replied":
+        case "question.replied":
+        case "question.rejected":
+          enqueue("running", { event: "needs_you.replied" });
+          return;
+
+        // Learn subagent sessions from their lifecycle; forget them on delete.
+        case "session.created":
+        case "session.updated":
+          if (props.info && props.info.parentID && sessionID) {
+            childSessions.add(sessionID);
+            return;
           }
           break;
-        }
+        case "session.deleted":
+          if (childSessions.delete(sessionID)) return;
+          break;
+      }
+      if (isChild(sessionID)) return;
+
+      switch (type) {
+        case "message.updated":
+          if (props.info && props.info.id && props.info.role) messageRoles.set(props.info.id, props.info.role);
+          break;
         // Track the latest assistant text part so session.idle can emit it.
         case "message.part.updated": {
           const part = props.part;
-          const msgID = (part && part.messageID) || props.messageID || (props.message && props.message.id);
-          const role = (part && part.role) || props.role || (props.message && props.message.role) || (msgID && messageRoles.get(msgID));
-          if (role === "user" || (msgID && lastUserMessageID && msgID === lastUserMessageID)) {
-            break;
-          }
-          if (part && part.type === "text" && typeof part.text === "string") {
-            lastAssistantText = part.text;
-          }
+          if (!part || part.type !== "text" || typeof part.text !== "string") break;
+          if (messageRoles.get(part.messageID) === "assistant") lastAssistantText = part.text;
           break;
         }
         // Turn complete → done, with the tracked final assistant text (the
-        // adapter remaps to pending if it ends in a question).
+        // adapter remaps to pending if it ends in a question). Skipped while
+        // an error is latched: that idle is the tail of the error, not a Done.
         case "session.idle":
-          enqueue("done", { event: "session.idle", message: lastAssistantText });
-          lastAssistantText = "";
-          messageRoles.clear();
+          if (!errorLatched) enqueue("done", { event: "session.idle", message: lastAssistantText });
+          endTurn();
           break;
-        // A real failure signal Claude's hook model lacks → error.
+        // A real failure → error (a signal Claude's hook model lacks). An Esc
+        // interrupt also arrives here as `MessageAbortedError`; that is the
+        // user's own action, so it falls through to the idle → Done path.
         case "session.error":
+          if (props.error && props.error.name === "MessageAbortedError") break;
           enqueue("error", { event: "session.error", message: errorMessage(props.error) });
-          lastAssistantText = "";
+          endTurn();
           break;
         // Session lifecycle → idle (row recedes; /clear, new/deleted session).
         case "session.created":
         case "session.deleted":
           enqueue("idle", { event: "session.lifecycle" });
-          lastAssistantText = "";
+          endTurn();
           break;
       }
     },

--- a/crates/cli/src/setup/opencode_plugin.js
+++ b/crates/cli/src/setup/opencode_plugin.js
@@ -22,18 +22,57 @@
 // `cwd` on every spawn so the rail resolves repo/branch without a host probe).
 let CWD = "";
 
+// Track root sessionID to ignore child (subagent) sessions created by tasks.
+let rootSessionID = null;
+
+// Track the user message ID to ignore user prompt parts in message.part.updated.
+let lastUserMessageID = null;
+
+// Map of messageID -> role to track message roles across events.
+let messageRoles = new Map();
+
 // The last assistant text part seen via `message.part.updated`, tracked so a
 // `session.idle` (which carries no message text) can emit the turn's final
 // assistant text for the adapter's trailing-question Done→Pending remap.
 let lastAssistantText = "";
 
-// FIFO spawn queue: each notify resolves before the next spawns, preserving
-// in-order / latest-wins. A rejected child is swallowed so the queue never jams.
-let chain = Promise.resolve();
+// Queue with latest-wins coalescing for `running` events: running refreshes are
+// droppable so a backlog under slow/wedged sends never blocks pending/done edges.
+let pendingRunning = null;
+let queue = [];
+let processing = false;
 
 function enqueue(status, payload) {
-  chain = chain.then(() => notify(status, payload)).catch(() => {});
-  return chain;
+  if (status === "running") {
+    pendingRunning = payload;
+  } else {
+    if (pendingRunning !== null) {
+      queue.push({ status: "running", payload: pendingRunning });
+      pendingRunning = null;
+    }
+    queue.push({ status, payload });
+  }
+  processQueue();
+}
+
+async function processQueue() {
+  if (processing) return;
+  processing = true;
+
+  while (queue.length > 0 || pendingRunning !== null) {
+    let item;
+    if (queue.length > 0) {
+      item = queue.shift();
+    } else {
+      item = { status: "running", payload: pendingRunning };
+      pendingRunning = null;
+    }
+    try {
+      await notify(item.status, item.payload);
+    } catch {}
+  }
+
+  processing = false;
 }
 
 // Bounded async spawn: write the JSON payload to the child's stdin, then close
@@ -93,17 +132,51 @@ function errorMessage(error) {
   return typeof error.name === "string" ? error.name : "";
 }
 
+// Extract a permission description from permission.asked properties.
+function permMessage(props) {
+  if (!props) return "Permission requested";
+  const name = props.permission || props.tool || "permission";
+  const patterns = Array.isArray(props.patterns) && props.patterns.length > 0
+    ? props.patterns.join(", ")
+    : "";
+  return patterns ? `${name}: ${patterns}` : name;
+}
+
+// Helper to check if event or payload belongs to a child/subagent session.
+function isChildSession(props) {
+  if (!props) return false;
+  if (props.parentID || props.parent_id || (props.info && (props.info.parentID || props.info.parent_id))) {
+    return true;
+  }
+  return false;
+}
+
 export const ZjRadarPlugin = async ({ directory }) => {
   CWD = typeof directory === "string" ? directory : "";
   return {
     // User submitted a prompt → running, with the prompt text for task capture.
     "chat.message": async (_input, output) => {
-      const prompt = promptText(output && output.parts);
+      if (!output || isChildSession(output)) return;
+      const outputSessionID = output.sessionID || output.session_id || (_input && (_input.sessionID || _input.session_id));
+      if (outputSessionID && !rootSessionID) {
+        rootSessionID = outputSessionID;
+      } else if (rootSessionID && outputSessionID && outputSessionID !== rootSessionID) {
+        return;
+      }
+      lastAssistantText = "";
+      const msgID = output.id || output.messageID || (output.message && output.message.id);
+      if (msgID) {
+        lastUserMessageID = msgID;
+        messageRoles.set(msgID, "user");
+      }
+      const prompt = promptText(output && (output.parts || (output.message && output.message.parts)));
       enqueue("running", { event: "chat.message", prompt });
     },
 
     // Tool about to run / just ran → running, with the live tool activity.
     "tool.execute.before": async (input, output) => {
+      if (isChildSession(input) || isChildSession(output)) return;
+      if (rootSessionID && input && input.sessionID && input.sessionID !== rootSessionID) return;
       enqueue("running", {
         event: "tool.execute",
         tool: input && input.tool,
@@ -111,6 +184,8 @@ export const ZjRadarPlugin = async ({ directory }) => {
       });
     },
     "tool.execute.after": async (input) => {
+      if (isChildSession(input)) return;
+      if (rootSessionID && input && input.sessionID && input.sessionID !== rootSessionID) return;
       enqueue("running", {
         event: "tool.execute",
         tool: input && input.tool,
@@ -130,15 +205,46 @@ export const ZjRadarPlugin = async ({ directory }) => {
     event: async ({ event }) => {
       const type = event && event.type;
       const props = (event && event.properties) || {};
+      if (isChildSession(props)) return;
+
+      const eventSessionID = props.sessionID || props.session_id || (props.info && (props.info.sessionID || props.info.session_id));
+      if (type === "session.created") {
+        if (!props.parentID && !props.info?.parentID) {
+          rootSessionID = eventSessionID || null;
+        }
+      }
+      if (rootSessionID && eventSessionID && eventSessionID !== rootSessionID && type !== "session.created" && type !== "session.deleted") {
+        return;
+      }
+
       switch (type) {
+        // Track message role updates so we can accurately ignore user parts.
+        case "message.updated": {
+          const msg = props.message || props.info || props;
+          const id = msg && (msg.id || msg.messageID);
+          const role = msg && msg.role;
+          if (id && role) {
+            messageRoles.set(id, role);
+          }
+          break;
+        }
         // Track the latest assistant text part so session.idle can emit it.
         case "message.part.updated": {
           const part = props.part;
+          const msgID = (part && part.messageID) || props.messageID || (props.message && props.message.id);
+          const role = (part && part.role) || props.role || (props.message && props.message.role) || (msgID && messageRoles.get(msgID));
+          if (role === "user" || (msgID && lastUserMessageID && msgID === lastUserMessageID)) {
+            break;
+          }
           if (part && part.type === "text" && typeof part.text === "string") {
             lastAssistantText = part.text;
           }
           break;
         }
+        // opencode permission bus event (opencode >= 1.14).
+        case "permission.asked":
+          enqueue("pending", { event: "permission.ask", message: permMessage(props) });
+          break;
         // Turn complete → done, with the tracked final assistant text (the
         // adapter remaps to pending if it ends in a question).
         case "session.idle":
@@ -153,6 +259,9 @@ export const ZjRadarPlugin = async ({ directory }) => {
         // Session lifecycle → idle (row recedes; /clear, new/deleted session).
         case "session.created":
         case "session.deleted":
+          if (type === "session.deleted" && eventSessionID && eventSessionID === rootSessionID) {
+            rootSessionID = null;
+          }
           enqueue("idle", { event: "session.lifecycle" });
           lastAssistantText = "";
           break;
@@ -160,3 +269,5 @@ export const ZjRadarPlugin = async ({ directory }) => {
     },
   };
 };
+
+export default ZjRadarPlugin;

--- a/crates/cli/src/setup/opencode_plugin.js
+++ b/crates/cli/src/setup/opencode_plugin.js
@@ -1,0 +1,162 @@
+// ZJ_RADAR_OPENCODE_PLUGIN=v1
+//
+// zj-radar bridge plugin for opencode. vendored by `zj-radar setup opencode`
+// into opencode's auto-loaded global plugins dir (~/.config/opencode/plugins/),
+// so no `opencode.json` edit is needed and a clean uninstall is one file delete.
+//
+// Spawn discipline (load-bearing, see CONTEXT.md → Status contract / Bounded
+// sends): this bridge spawns `zj-radar notify opencode --status <s>` per event
+// with the payload JSON on stdin. The `zellij pipe` send is bounded by the CLI
+// path (self_limiting_pipe_argv's watchdog survives this bridge's own death),
+// so the bridge adds no second pipe client. Spawns are strictly FIFO (never
+// concurrent) to preserve in-order / latest-wins; each child has a hard ~10s
+// kill timer as an outer backstop; a rejected child never breaks the queue.
+// ASYNC SPAWN ONLY — never a synchronous spawn: the plugin runs in opencode's
+// process, so a wedged rail must not freeze the TUI event loop.
+//
+// The bridge picks the status class (it knows the event); the Rust adapter
+// (crates/cli/src/agents/opencode.rs) owns the refinements keyed off the
+// payload's `event` field.
+
+// Resolved once at plugin init. `directory` is the session cwd (forwarded as
+// `cwd` on every spawn so the rail resolves repo/branch without a host probe).
+let CWD = "";
+
+// The last assistant text part seen via `message.part.updated`, tracked so a
+// `session.idle` (which carries no message text) can emit the turn's final
+// assistant text for the adapter's trailing-question Done→Pending remap.
+let lastAssistantText = "";
+
+// FIFO spawn queue: each notify resolves before the next spawns, preserving
+// in-order / latest-wins. A rejected child is swallowed so the queue never jams.
+let chain = Promise.resolve();
+
+function enqueue(status, payload) {
+  chain = chain.then(() => notify(status, payload)).catch(() => {});
+  return chain;
+}
+
+// Bounded async spawn: write the JSON payload to the child's stdin, then close
+// it; a hard kill timer reaps a wedged child so the queue keeps moving. Returns
+// a promise that resolves when the child exits (cleanly or killed).
+function notify(status, payload) {
+  // Gate: skip entirely when not running under Zellij (the CLI no-ops anyway,
+  // but spawning it pointlessly burns a process per event).
+  if (!process.env.ZELLIJ) return Promise.resolve();
+  // Gate: skip spawn when zj-radar isn't on PATH (Bun.which returns undefined).
+  // Wiring only happens via `zj-radar setup opencode`, which implies the binary
+  // — but a partial install or a moved binary must not throw inside the TUI.
+  if (!Bun.which("zj-radar")) return Promise.resolve();
+
+  const data = JSON.stringify({ ...payload, cwd: CWD });
+  let child;
+  try {
+    child = Bun.spawn(["zj-radar", "notify", "opencode", "--status", status], {
+      stdin: "pipe",
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+  } catch {
+    return Promise.resolve(); // spawn failed — never throw in the TUI
+  }
+  try {
+    child.stdin.write(data);
+    child.stdin.end();
+  } catch {
+    // A broken stdin pipe is the child's problem; the kill timer reaps it.
+  }
+  const timer = setTimeout(() => {
+    try { child.kill(); } catch {}
+  }, 10_000);
+  return child.exited
+    .then(() => clearTimeout(timer))
+    .catch(() => clearTimeout(timer));
+}
+
+// Extract the user's prompt text from a chat.message `output.parts` array
+// (UserMessage itself carries no text — the prompt is in its TextParts).
+function promptText(parts) {
+  if (!Array.isArray(parts)) return "";
+  return parts
+    .filter((p) => p && p.type === "text" && typeof p.text === "string")
+    .map((p) => p.text)
+    .join("\n")
+    .trim();
+}
+
+// Extract a human message from opencode's error union ({ name, data: { message? } }).
+function errorMessage(error) {
+  if (!error) return "";
+  if (error.data && typeof error.data.message === "string" && error.data.message) {
+    return error.data.message;
+  }
+  return typeof error.name === "string" ? error.name : "";
+}
+
+export const ZjRadarPlugin = async ({ directory }) => {
+  CWD = typeof directory === "string" ? directory : "";
+  return {
+    // User submitted a prompt → running, with the prompt text for task capture.
+    "chat.message": async (_input, output) => {
+      const prompt = promptText(output && output.parts);
+      enqueue("running", { event: "chat.message", prompt });
+    },
+
+    // Tool about to run / just ran → running, with the live tool activity.
+    "tool.execute.before": async (input, output) => {
+      enqueue("running", {
+        event: "tool.execute",
+        tool: input && input.tool,
+        tool_input: output && output.args,
+      });
+    },
+    "tool.execute.after": async (input) => {
+      enqueue("running", {
+        event: "tool.execute",
+        tool: input && input.tool,
+        tool_input: input && input.args,
+      });
+    },
+
+    // opencode is asking for permission → pending, with the permission title.
+    "permission.ask": async (input) => {
+      enqueue("pending", {
+        event: "permission.ask",
+        message: input && input.title,
+      });
+    },
+
+    // The catch-all event stream: session lifecycle + assistant-text tracking.
+    event: async ({ event }) => {
+      const type = event && event.type;
+      const props = (event && event.properties) || {};
+      switch (type) {
+        // Track the latest assistant text part so session.idle can emit it.
+        case "message.part.updated": {
+          const part = props.part;
+          if (part && part.type === "text" && typeof part.text === "string") {
+            lastAssistantText = part.text;
+          }
+          break;
+        }
+        // Turn complete → done, with the tracked final assistant text (the
+        // adapter remaps to pending if it ends in a question).
+        case "session.idle":
+          enqueue("done", { event: "session.idle", message: lastAssistantText });
+          lastAssistantText = "";
+          break;
+        // A real failure signal Claude's hook model lacks → error.
+        case "session.error":
+          enqueue("error", { event: "session.error", message: errorMessage(props.error) });
+          lastAssistantText = "";
+          break;
+        // Session lifecycle → idle (row recedes; /clear, new/deleted session).
+        case "session.created":
+        case "session.deleted":
+          enqueue("idle", { event: "session.lifecycle" });
+          lastAssistantText = "";
+          break;
+      }
+    },
+  };
+};

--- a/crates/cli/src/setup/opencode_plugin.js
+++ b/crates/cli/src/setup/opencode_plugin.js
@@ -9,10 +9,10 @@
 // with the payload JSON on stdin. The `zellij pipe` send is bounded by the CLI
 // path (self_limiting_pipe_argv's watchdog survives this bridge's own death),
 // so the bridge adds no second pipe client. Spawns are never concurrent:
-// status edges (pending/done/error/idle) go out strictly FIFO, while `running`
-// refreshes coalesce to the latest unsent one (latest-wins is the project's
-// ordering rule, so a stale running is free to drop and can never head-of-line
-// block an edge). Each child has a hard ~10s kill timer as an outer backstop;
+// status edges (pending/done/error/idle) and the task-carrying `chat.message`
+// go out strictly FIFO, while tool-activity `running` refreshes coalesce to
+// the latest unsent one (latest-wins is the project's ordering rule, so a
+// stale running is free to drop and can never head-of-line block an edge). Each child has a hard ~10s kill timer as an outer backstop;
 // a rejected child never breaks the queue.
 // ASYNC SPAWN ONLY — never a synchronous spawn: the plugin runs in opencode's
 // process, so a wedged rail must not freeze the TUI event loop.
@@ -25,11 +25,16 @@
 // `cwd` on every spawn so the rail resolves repo/branch without a host probe).
 let CWD = "";
 
-// The root (user-facing) sessionID. opencode's task tool forks subagent
-// sessions with `parentID`, and their prompts/tools/idle fire the same hooks
-// and bus events — pinning the root lets the bridge ignore them, so a subagent
-// finishing never paints Done (or clobbers the task label) mid-turn.
-let rootSessionID = null;
+// Subagent (task-tool) sessions. opencode forks them with `parentID`, and
+// their prompts/tools/idle fire the same hooks and bus events as the user's
+// session — so a subagent finishing would paint Done (and clobber the task
+// label) mid-turn. Children always announce themselves via `session.created`
+// (info.parentID) before anything else, so the bridge learns the set from
+// the stream and drops their events; every *other* session is the user's.
+// Deliberately NOT a "pin the root" latch: switching to an existing session
+// (picker, `-c`, `--session`, attach) fires no `session.created`, and a latch
+// would freeze the rail on the old session forever.
+const childSessions = new Set();
 
 // The current user message ID: opencode publishes `message.part.updated` for
 // the user's own prompt parts too (Part carries no role), so parts of this
@@ -52,7 +57,11 @@ let queue = [];
 let processing = false;
 
 function enqueue(status, payload) {
-  if (status === "running") {
+  // Only tool-activity refreshes are droppable. The `chat.message` running
+  // carries the prompt that becomes the sticky task label — coalescing it
+  // away under a backlog would lose the label for the whole turn.
+  const droppable = status === "running" && payload.event !== "chat.message";
+  if (droppable) {
     pendingRunning = payload;
   } else {
     if (pendingRunning !== null) {
@@ -152,13 +161,15 @@ function permMessage(props) {
   return patterns ? `${name}: ${patterns}` : name;
 }
 
-// Helper to check if event or payload belongs to a child/subagent session.
+// Whether a payload declares itself a child/subagent session (Session.Info
+// carries `parentID`), or names a session already learned as a child.
 function isChildSession(props) {
   if (!props) return false;
   if (props.parentID || props.parent_id || (props.info && (props.info.parentID || props.info.parent_id))) {
     return true;
   }
-  return false;
+  const sid = eventSession(props);
+  return sid !== null && childSessions.has(sid);
 }
 
 // The sessionID an event belongs to. Current opencode stamps a top-level
@@ -179,14 +190,8 @@ export const ZjRadarPlugin = async ({ directory }) => {
   CWD = typeof directory === "string" ? directory : "";
   return {
     // User submitted a prompt → running, with the prompt text for task capture.
-    "chat.message": async (_input, output) => {
-      if (!output || isChildSession(output)) return;
-      const outputSessionID = output.sessionID || output.session_id || (_input && (_input.sessionID || _input.session_id));
-      if (outputSessionID && !rootSessionID) {
-        rootSessionID = outputSessionID;
-      } else if (rootSessionID && outputSessionID && outputSessionID !== rootSessionID) {
-        return;
-      }
+    "chat.message": async (input, output) => {
+      if (!output || isChildSession(input) || isChildSession(output)) return;
       lastAssistantText = "";
       const msgID = output.id || output.messageID || (output.message && output.message.id);
       if (msgID) {
@@ -200,7 +205,6 @@ export const ZjRadarPlugin = async ({ directory }) => {
     // Tool about to run / just ran → running, with the live tool activity.
     "tool.execute.before": async (input, output) => {
       if (isChildSession(input) || isChildSession(output)) return;
-      if (rootSessionID && input && input.sessionID && input.sessionID !== rootSessionID) return;
       enqueue("running", {
         event: "tool.execute",
         tool: input && input.tool,
@@ -209,7 +213,6 @@ export const ZjRadarPlugin = async ({ directory }) => {
     },
     "tool.execute.after": async (input) => {
       if (isChildSession(input)) return;
-      if (rootSessionID && input && input.sessionID && input.sessionID !== rootSessionID) return;
       enqueue("running", {
         event: "tool.execute",
         tool: input && input.tool,
@@ -231,17 +234,32 @@ export const ZjRadarPlugin = async ({ directory }) => {
     event: async ({ event }) => {
       const type = event && event.type;
       const props = (event && event.properties) || {};
-      if (isChildSession(props)) return;
-
       const eventSessionID = eventSession(props);
-      if (type === "session.created") {
-        if (!props.parentID && !props.info?.parentID) {
-          rootSessionID = eventSessionID || null;
-        }
-      }
-      if (rootSessionID && eventSessionID && eventSessionID !== rootSessionID && type !== "session.created" && type !== "session.deleted") {
+
+      // Permission prompts block the user's TUI whichever session raised them
+      // (a subagent's `bash` asks through the parent's UI), so they are the one
+      // class of event that must NOT be filtered by session.
+      if (type === "permission.asked") {
+        enqueue("pending", { event: "permission.ask", message: permMessage(props) });
         return;
       }
+      if (type === "permission.replied") {
+        // The user answered → back to running now, rather than on the next
+        // tool/idle event (a denied permission throws inside the tool, so
+        // `tool.execute.after` may never come).
+        enqueue("running", { event: "permission.replied" });
+        return;
+      }
+
+      // Learn (and forget) subagent sessions from their lifecycle events.
+      if ((type === "session.created" || type === "session.updated") && eventSessionID) {
+        if (props.parentID || (props.info && props.info.parentID)) childSessions.add(eventSessionID);
+      }
+      if (type === "session.deleted" && eventSessionID && childSessions.has(eventSessionID)) {
+        childSessions.delete(eventSessionID);
+        return;
+      }
+      if (isChildSession(props)) return;
 
       switch (type) {
         // Track message role updates so we can accurately ignore user parts.
@@ -267,16 +285,6 @@ export const ZjRadarPlugin = async ({ directory }) => {
           }
           break;
         }
-        // opencode permission bus event (opencode >= 1.14).
-        case "permission.asked":
-          enqueue("pending", { event: "permission.ask", message: permMessage(props) });
-          break;
-        // The user answered → back to running now, rather than on the next
-        // tool/idle event (a denied permission throws inside the tool, so
-        // `tool.execute.after` may never come).
-        case "permission.replied":
-          enqueue("running", { event: "permission.replied" });
-          break;
         // Turn complete → done, with the tracked final assistant text (the
         // adapter remaps to pending if it ends in a question).
         case "session.idle":
@@ -292,9 +300,6 @@ export const ZjRadarPlugin = async ({ directory }) => {
         // Session lifecycle → idle (row recedes; /clear, new/deleted session).
         case "session.created":
         case "session.deleted":
-          if (type === "session.deleted" && eventSessionID && eventSessionID === rootSessionID) {
-            rootSessionID = null;
-          }
           enqueue("idle", { event: "session.lifecycle" });
           lastAssistantText = "";
           break;

--- a/crates/cli/src/setup/opencode_plugin.js
+++ b/crates/cli/src/setup/opencode_plugin.js
@@ -8,9 +8,12 @@
 // sends): this bridge spawns `zj-radar notify opencode --status <s>` per event
 // with the payload JSON on stdin. The `zellij pipe` send is bounded by the CLI
 // path (self_limiting_pipe_argv's watchdog survives this bridge's own death),
-// so the bridge adds no second pipe client. Spawns are strictly FIFO (never
-// concurrent) to preserve in-order / latest-wins; each child has a hard ~10s
-// kill timer as an outer backstop; a rejected child never breaks the queue.
+// so the bridge adds no second pipe client. Spawns are never concurrent:
+// status edges (pending/done/error/idle) go out strictly FIFO, while `running`
+// refreshes coalesce to the latest unsent one (latest-wins is the project's
+// ordering rule, so a stale running is free to drop and can never head-of-line
+// block an edge). Each child has a hard ~10s kill timer as an outer backstop;
+// a rejected child never breaks the queue.
 // ASYNC SPAWN ONLY — never a synchronous spawn: the plugin runs in opencode's
 // process, so a wedged rail must not freeze the TUI event loop.
 //
@@ -22,13 +25,19 @@
 // `cwd` on every spawn so the rail resolves repo/branch without a host probe).
 let CWD = "";
 
-// Track root sessionID to ignore child (subagent) sessions created by tasks.
+// The root (user-facing) sessionID. opencode's task tool forks subagent
+// sessions with `parentID`, and their prompts/tools/idle fire the same hooks
+// and bus events — pinning the root lets the bridge ignore them, so a subagent
+// finishing never paints Done (or clobbers the task label) mid-turn.
 let rootSessionID = null;
 
-// Track the user message ID to ignore user prompt parts in message.part.updated.
+// The current user message ID: opencode publishes `message.part.updated` for
+// the user's own prompt parts too (Part carries no role), so parts of this
+// message must never land in `lastAssistantText`.
 let lastUserMessageID = null;
 
-// Map of messageID -> role to track message roles across events.
+// messageID -> role, learned from `message.updated` (which does carry role);
+// cleared at each turn boundary so it stays bounded.
 let messageRoles = new Map();
 
 // The last assistant text part seen via `message.part.updated`, tracked so a
@@ -132,10 +141,11 @@ function errorMessage(error) {
   return typeof error.name === "string" ? error.name : "";
 }
 
-// Extract a permission description from permission.asked properties.
+// Extract a permission description from `permission.asked` properties
+// ({ id, sessionID, permission, patterns, metadata, always, tool? } — no title).
 function permMessage(props) {
   if (!props) return "Permission requested";
-  const name = props.permission || props.tool || "permission";
+  const name = typeof props.permission === "string" && props.permission ? props.permission : "permission";
   const patterns = Array.isArray(props.patterns) && props.patterns.length > 0
     ? props.patterns.join(", ")
     : "";
@@ -149,6 +159,20 @@ function isChildSession(props) {
     return true;
   }
   return false;
+}
+
+// The sessionID an event belongs to. Current opencode stamps a top-level
+// `sessionID` on every event; older shapes carried only `{ info }` (whose
+// session key is `id`) or `{ part }` (which carries its own `sessionID`).
+function eventSession(props) {
+  if (!props) return null;
+  return (
+    props.sessionID ||
+    props.session_id ||
+    (props.info && (props.info.sessionID || props.info.session_id || props.info.id)) ||
+    (props.part && props.part.sessionID) ||
+    null
+  );
 }
 
 export const ZjRadarPlugin = async ({ directory }) => {
@@ -193,7 +217,9 @@ export const ZjRadarPlugin = async ({ directory }) => {
       });
     },
 
-    // opencode is asking for permission → pending, with the permission title.
+    // Legacy (< 1.14) permission hook → pending. Current opencode no longer
+    // triggers it (the signal is the `permission.asked` bus event below);
+    // kept so older installs still get the needs-you moment.
     "permission.ask": async (input) => {
       enqueue("pending", {
         event: "permission.ask",
@@ -207,7 +233,7 @@ export const ZjRadarPlugin = async ({ directory }) => {
       const props = (event && event.properties) || {};
       if (isChildSession(props)) return;
 
-      const eventSessionID = props.sessionID || props.session_id || (props.info && (props.info.sessionID || props.info.session_id));
+      const eventSessionID = eventSession(props);
       if (type === "session.created") {
         if (!props.parentID && !props.info?.parentID) {
           rootSessionID = eventSessionID || null;
@@ -245,11 +271,18 @@ export const ZjRadarPlugin = async ({ directory }) => {
         case "permission.asked":
           enqueue("pending", { event: "permission.ask", message: permMessage(props) });
           break;
+        // The user answered → back to running now, rather than on the next
+        // tool/idle event (a denied permission throws inside the tool, so
+        // `tool.execute.after` may never come).
+        case "permission.replied":
+          enqueue("running", { event: "permission.replied" });
+          break;
         // Turn complete → done, with the tracked final assistant text (the
         // adapter remaps to pending if it ends in a question).
         case "session.idle":
           enqueue("done", { event: "session.idle", message: lastAssistantText });
           lastAssistantText = "";
+          messageRoles.clear();
           break;
         // A real failure signal Claude's hook model lacks → error.
         case "session.error":

--- a/crates/cli/src/setup/zellij.rs
+++ b/crates/cli/src/setup/zellij.rs
@@ -530,7 +530,8 @@ fn print_grant_hint_if_needed(facts: &ZellijFacts) {
 
 /// Emit a producer hint at the tail of `setup zellij` when no producer is wired,
 /// per `facts.producer_wired` (derived from Codex hooks + the Claude plugin
-/// manifest, same as `run`'s detection — see `analyze_zellij`).
+/// manifest + the opencode bridge plugin, same as `run`'s detection — see
+/// `analyze_zellij`).
 fn print_producer_hint_if_needed(facts: &ZellijFacts) {
     if !facts.producer_wired() {
         println!("zellij: {}", crate::run::PRODUCER_HINT);

--- a/crates/cli/src/setup/zellij.rs
+++ b/crates/cli/src/setup/zellij.rs
@@ -535,6 +535,16 @@ fn print_grant_hint_if_needed(facts: &ZellijFacts) {
 fn print_producer_hint_if_needed(facts: &ZellijFacts) {
     if !facts.producer_wired() {
         println!("zellij: {}", crate::run::PRODUCER_HINT);
+    } else {
+        if which("opencode") && !facts.opencode_producer {
+            println!("zellij: note: opencode found on PATH but bridge plugin not installed — run `zj-radar setup opencode`");
+        }
+        if which("claude") && !facts.claude_producer {
+            println!("zellij: note: claude found on PATH but plugin not installed — run `zj-radar setup claude`");
+        }
+        if which("codex") && !facts.codex_producer {
+            println!("zellij: note: codex found on PATH but hooks not installed — run `zj-radar setup codex`");
+        }
     }
 }
 

--- a/crates/core/src/command.rs
+++ b/crates/core/src/command.rs
@@ -82,7 +82,7 @@ const IGNORE_NAMES: &[&str] = &[
 /// pins the two sets. Agents without an adapter (e.g. Gemini today) are
 /// deliberately absent: they fall through to ordinary command-tracking, which
 /// still surfaces a Running/Done lifecycle under their own `Kind`.
-pub const AGENT_NAMES: &[&str] = &["claude", "codex"];
+pub const AGENT_NAMES: &[&str] = &["claude", "codex", "opencode"];
 
 /// Interactive programs — editors, pagers, monitors, git TUIs, file managers —
 /// that sit open waiting on the *user* rather than doing bounded work

--- a/crates/core/src/command/tests.rs
+++ b/crates/core/src/command/tests.rs
@@ -51,6 +51,7 @@
         // shapes, so it carries no evidence and is not a parameter.
         assert!(is_agent_command(&argv(&["claude"])));
         assert!(is_agent_command(&argv(&["codex"])));
+        assert!(is_agent_command(&argv(&["opencode"])));
         // Env/wrapper prefixes are peeled, mirroring is_shell_prompt.
         assert!(is_agent_command(&argv(&["env", "FOO=1", "claude"])));
         // Shells, ordinary commands, and nothing don't vouch.
@@ -179,6 +180,7 @@
             // Agents, by basename.
             (argv(&["claude"]), "claude", Kind::Claude),
             (argv(&["codex", "--dangerously-bypass-sandbox"]), "codex", Kind::Codex),
+            (argv(&["opencode", "run", "hi"]), "opencode", Kind::Opencode),
             (argv(&["gemini"]), "gemini", Kind::Gemini),
             // Test runners across ecosystems.
             // The `--features` VALUE reads as a target ("cargo test cli") — a
@@ -770,7 +772,7 @@
         // The set of suppressed agents is exactly the push adapters (see the
         // `agent_names_match_push_adapter_sources` guard); Gemini is NOT one —
         // see `gemini_foreground_command_is_tracked`.
-        for agent in &["claude", "codex"] {
+        for agent in &["claude", "codex", "opencode"] {
             let mut store = CommandStore::default();
             store.on_command_changed(1, &[agent.to_string()], true, Some("/work/repo"), 1);
             assert!(
@@ -787,10 +789,11 @@
 
     #[test]
     fn gemini_foreground_command_is_tracked() {
-        // Gemini has no push adapter (the shipped scope is Claude + Codex), so
-        // unlike them it is *observed* via command-tracking rather than
-        // suppressed — otherwise its panes would show nothing at all. It carries
-        // its own `Kind::Gemini` source so it renders with the gemini mark.
+        // Gemini has no push adapter (the shipped scope is Claude, Codex, and
+        // Opencode), so unlike them it is *observed* via command-tracking
+        // rather than suppressed — otherwise its panes would show nothing at
+        // all. It carries its own `Kind::Gemini` source so it renders with the
+        // gemini mark.
         let mut store = CommandStore::default();
         store.on_command_changed(1, &["gemini".to_string()], true, Some("/work/repo"), 1);
         store.on_timer(Tick(1 + DEBOUNCE_TICKS), EpochSecs(0));

--- a/crates/core/src/kind.rs
+++ b/crates/core/src/kind.rs
@@ -14,9 +14,10 @@ use crate::status::GlyphSet;
 /// rather than silently falling back.
 macro_rules! kinds {
     ( $( $variant:ident => $source:literal, $plain:literal, $nerd:literal );+ $(;)? ) => {
-        /// What kind of process owns a pane. Agents (Claude, Codex, Gemini) and
-        /// task types (Test, Build, Deploy, Server) are peers — only the mark
-        /// glyph differs; the renderer and sorter treat all variants identically.
+        /// What kind of process owns a pane. Agents (Claude, Codex, Opencode,
+        /// Gemini) and task types (Test, Build, Deploy, Server) are peers — only
+        /// the mark glyph differs; the renderer and sorter treat all variants
+        /// identically.
         ///
         /// Generated from the `kinds!` table below — see it for each variant's
         /// wire token and marks.
@@ -67,15 +68,16 @@ macro_rules! kinds {
 }
 
 kinds! {
-    Claude  => "claude",  '✳', '\u{f06a9}'; // nf-md-robot
-    Codex   => "codex",   '❉', '\u{f167a}'; // nf-md-robot-outline
-    Gemini  => "gemini",  '✦', '\u{f0eb9}'; // nf-md-star-four-points (sparkle)
-    Command => "command", '$', '$';
-    Other   => "other",   '⦿', '⦿';
-    Test    => "test",    '⚗', '⚗';
-    Build   => "build",   '⚙', '⚙';
-    Deploy  => "deploy",  '⇡', '⇡';
-    Server  => "server",  '❯', '❯';
+    Claude  => "claude",   '✳', '\u{f06a9}'; // nf-md-robot
+    Codex   => "codex",    '❉', '\u{f167a}'; // nf-md-robot-outline
+    Opencode => "opencode", '✺', '\u{f0eae}'; // nf-md-code-braces
+    Gemini  => "gemini",   '✦', '\u{f0eb9}'; // nf-md-star-four-points (sparkle)
+    Command => "command",  '$', '$';
+    Other   => "other",    '⦿', '⦿';
+    Test    => "test",     '⚗', '⚗';
+    Build   => "build",    '⚙', '⚙';
+    Deploy  => "deploy",   '⇡', '⇡';
+    Server  => "server",   '❯', '❯';
 }
 
 impl Kind {
@@ -87,7 +89,7 @@ impl Kind {
     /// must declare which side it is here before it compiles.
     pub fn is_agent(self) -> bool {
         match self {
-            Kind::Claude | Kind::Codex | Kind::Gemini => true,
+            Kind::Claude | Kind::Codex | Kind::Opencode | Kind::Gemini => true,
             Kind::Command | Kind::Other | Kind::Test | Kind::Build | Kind::Deploy
             | Kind::Server => false,
         }
@@ -102,8 +104,8 @@ impl Kind {
     pub fn is_service(self) -> bool {
         match self {
             Kind::Server => true,
-            Kind::Claude | Kind::Codex | Kind::Gemini | Kind::Command | Kind::Other
-            | Kind::Test | Kind::Build | Kind::Deploy => false,
+            Kind::Claude | Kind::Codex | Kind::Opencode | Kind::Gemini | Kind::Command
+            | Kind::Other | Kind::Test | Kind::Build | Kind::Deploy => false,
         }
     }
 }
@@ -124,6 +126,7 @@ mod tests {
     fn from_source_agent_variants() {
         assert_eq!(Kind::from_source("claude"), Kind::Claude);
         assert_eq!(Kind::from_source("codex"), Kind::Codex);
+        assert_eq!(Kind::from_source("opencode"), Kind::Opencode);
         assert_eq!(Kind::from_source("gemini"), Kind::Gemini);
         assert_eq!(Kind::from_source("command"), Kind::Command);
     }
@@ -160,6 +163,7 @@ mod tests {
         use GlyphSet::Plain;
         assert_eq!(Kind::Claude.mark(Plain), '✳');
         assert_eq!(Kind::Codex.mark(Plain), '❉');
+        assert_eq!(Kind::Opencode.mark(Plain), '✺');
         assert_eq!(Kind::Gemini.mark(Plain), '✦');
         assert_eq!(Kind::Command.mark(Plain), '$');
         assert_eq!(Kind::Other.mark(Plain), '⦿');
@@ -175,6 +179,7 @@ mod tests {
         // Agent marks become heavier font-native MDI glyphs in the Nerd set.
         assert_eq!(Kind::Claude.mark(Nerd), '\u{f06a9}');
         assert_eq!(Kind::Codex.mark(Nerd), '\u{f167a}');
+        assert_eq!(Kind::Opencode.mark(Nerd), '\u{f0eae}');
         assert_eq!(Kind::Gemini.mark(Nerd), '\u{f0eb9}');
         // Task marks are shared across sets.
         assert_eq!(Kind::Build.mark(Nerd), '⚙');
@@ -198,7 +203,7 @@ mod tests {
     fn all_enumerates_every_variant() {
         // `ALL` drives the exhaustiveness of the other tests; pin its size so a
         // dropped table row is caught here instead of silently shrinking coverage.
-        assert_eq!(Kind::ALL.len(), 9);
+        assert_eq!(Kind::ALL.len(), 10);
         assert_eq!(Kind::Other.as_source(), "other");
     }
 

--- a/crates/core/src/kind.rs
+++ b/crates/core/src/kind.rs
@@ -68,16 +68,16 @@ macro_rules! kinds {
 }
 
 kinds! {
-    Claude  => "claude",   '✳', '\u{f06a9}'; // nf-md-robot
-    Codex   => "codex",    '❉', '\u{f167a}'; // nf-md-robot-outline
-    Opencode => "opencode", '✺', '\u{f0eae}'; // nf-md-code-braces
-    Gemini  => "gemini",   '✦', '\u{f0eb9}'; // nf-md-star-four-points (sparkle)
-    Command => "command",  '$', '$';
-    Other   => "other",    '⦿', '⦿';
-    Test    => "test",     '⚗', '⚗';
-    Build   => "build",    '⚙', '⚙';
-    Deploy  => "deploy",   '⇡', '⇡';
-    Server  => "server",   '❯', '❯';
+    Claude   => "claude",   '✳', '\u{f06a9}'; // nf-md-robot
+    Codex    => "codex",    '❉', '\u{f167a}'; // nf-md-robot-outline
+    Opencode => "opencode", '✺', '\u{f0169}'; // nf-md-code-braces
+    Gemini   => "gemini",   '✦', '\u{f0eb9}'; // nf-md-star-four-points (sparkle)
+    Command  => "command",  '$', '$';
+    Other    => "other",    '⦿', '⦿';
+    Test     => "test",     '⚗', '⚗';
+    Build    => "build",    '⚙', '⚙';
+    Deploy   => "deploy",   '⇡', '⇡';
+    Server   => "server",   '❯', '❯';
 }
 
 impl Kind {
@@ -179,7 +179,7 @@ mod tests {
         // Agent marks become heavier font-native MDI glyphs in the Nerd set.
         assert_eq!(Kind::Claude.mark(Nerd), '\u{f06a9}');
         assert_eq!(Kind::Codex.mark(Nerd), '\u{f167a}');
-        assert_eq!(Kind::Opencode.mark(Nerd), '\u{f0eae}');
+        assert_eq!(Kind::Opencode.mark(Nerd), '\u{f0169}');
         assert_eq!(Kind::Gemini.mark(Nerd), '\u{f0eb9}');
         // Task marks are shared across sets.
         assert_eq!(Kind::Build.mark(Nerd), '⚙');

--- a/crates/plugin/src/render/tests.rs
+++ b/crates/plugin/src/render/tests.rs
@@ -3169,18 +3169,10 @@ prop_compose! {
 }
 
 prop_compose! {
-    fn arb_kind()(n in 0u8..9) -> Kind {
-        match n {
-            0 => Kind::Claude,
-            1 => Kind::Codex,
-            2 => Kind::Gemini,
-            3 => Kind::Command,
-            4 => Kind::Other,
-            5 => Kind::Test,
-            6 => Kind::Build,
-            7 => Kind::Deploy,
-            _ => Kind::Server,
-        }
+    // Drawn from `Kind::ALL` like `arb_status` above — a hand ladder here
+    // silently skipped `Kind::Opencode` when producer #3 landed.
+    fn arb_kind()(k in proptest::sample::select(Kind::ALL.to_vec())) -> Kind {
+        k
     }
 }
 

--- a/demo/agent.sh
+++ b/demo/agent.sh
@@ -6,7 +6,7 @@
 #
 #   agent.sh <source> <repo> <branch> <scenario>
 #
-# <source> is a Kind wire token (claude|codex|gemini|test|build|deploy|command).
+# <source> is a Kind wire token (claude|codex|opencode|gemini|test|build|deploy|command).
 # <scenario> selects one of the arcs below. Run only inside Zellij.
 set -euo pipefail
 

--- a/docs/activity-model.md
+++ b/docs/activity-model.md
@@ -31,7 +31,7 @@ keeps the model extensible:
 | Axis | Type | Values | Who owns it |
 |---|---|---|---|
 | **Origin** | `ObservationOrigin` (exists) | `StatusPipe` \| `Command` | intake: pushed payload vs `CommandChanged` |
-| **Kind** | `Kind` (exists) | Claude, Codex, Gemini, Test, Build, Deploy, Server, Command, Other | classification (`Kind::from_source` on the pushed source token / `command::classify`) |
+| **Kind** | `Kind` (exists) | Claude, Codex, Opencode, Gemini, Test, Build, Deploy, Server, Command, Other | classification (`Kind::from_source` on the pushed source token / `command::classify`) |
 | **Class** | semantic vocabulary — **not** a stored or derived Rust type | `Job` \| `Service` \| `Companion` | this document |
 
 The classes are the *semantic model*, deliberately NOT an `AttentionClass`

--- a/docs/design.md
+++ b/docs/design.md
@@ -252,9 +252,9 @@ unaffected.
 
 ```json
 { "v": 1,
-  "source": "claude",                 // Kind vocabulary: claude | codex | gemini | command |
+  "source": "claude",                 // Kind vocabulary: claude | codex | opencode | gemini | command |
                                       //   test | build | deploy | server | other (unknown → other);
-                                      //   the instrumented-agent set is exactly {claude, codex}
+                                      //   the instrumented-agent set is exactly {claude, codex, opencode}
   "pane": { "type": "terminal", "id": 12 },   // typed to match Zellij's PaneId enum
   "status": "running",                // running | pending | done | error | idle
   "repo": "pinky",
@@ -440,7 +440,7 @@ the normal `cwd_changed` path):
   main-thread work), and treat naming as best-effort cosmetics — a missing cwd/title just leaves
   the existing name.
 
-## 7. Agent adapters (v1: Claude + Codex)
+## 7. Agent adapters (v1: Claude + Codex + Opencode)
 
 - **Claude Code** — a Claude plugin (`plugins/zj-radar-claude/`) whose `scripts/notify.sh`
   broadcasts the rich `zj_radar.status.v1` payload (computing repo/branch/msg/pane). Claude

--- a/docs/design.md
+++ b/docs/design.md
@@ -187,7 +187,7 @@ effects. The real external seam remains the **pipe payload schema** (versioned).
 | Codex `Stop`                                  | `done`    |
 | Codex ephemeral-fork hooks (`transcript_path: null`) | ignored (the main turn keeps owning the pane) |
 | Codex legacy `agent-turn-complete`            | `done`    |
-| Observed command exiting nonzero              | `error` — with opencode's `session.error`, one of the two `error` sources. Claude's map deliberately has no `error`: its hook vocabulary carries no reliable turn-level failure signal (`PostToolUse`'s per-tool `is_error` is normal, recoverable agent behavior), so mapping hooks to `Error` would paint healthy turns red |
+| Observed command exiting nonzero              | `error` — one of two `error` sources (the other: opencode's `session.error`, minus the user's own Esc interrupt). Claude's map deliberately has no `error`: its hook vocabulary carries no reliable turn-level failure signal (`PostToolUse`'s per-tool `is_error` is normal, recoverable agent behavior), so mapping hooks to `Error` would paint healthy turns red |
 | Agent pane returns to its shell prompt (observed exit) | `idle` — terminal statuses clear at once; a `Running` instead arms the 15-tick stale grace (see §6, *Running exit grace*) |
 | Agent pane's root process exits (pane manifest `exited`) | `idle` — definitive producer death: clears even a `Running` immediately, no grace (see §6, *Running exit grace*) |
 
@@ -451,6 +451,13 @@ the normal `cwd_changed` path):
   maps lifecycle events to `running`/`pending`/`done`. The legacy single-slot
   `config.toml` `notify` path remains available behind `--legacy-notify` for older
   Codex installs and can only emit `done`.
+- **Opencode** — `zj-radar setup opencode` drops a marker-owned JS bridge plugin into
+  opencode's auto-loaded plugins dir; it spawns `zj-radar notify opencode --status <s>`
+  per hook/bus event with the payload on stdin. Covers `running` (prompt, tools),
+  `pending` (permission and `question` prompts, from any session — subagents ask
+  through the parent TUI), `done` (`session.idle`), and `error` (`session.error`,
+  except the user's own Esc). Subagent sessions are filtered; tool-activity
+  refreshes coalesce so a slow pipe never delays an edge.
 - **Aider** — parked (one-line `--notifications-command`, status-only) for a later phase.
 
 ## 8. Build & packaging (Nix)

--- a/docs/design.md
+++ b/docs/design.md
@@ -187,7 +187,7 @@ effects. The real external seam remains the **pipe payload schema** (versioned).
 | Codex `Stop`                                  | `done`    |
 | Codex ephemeral-fork hooks (`transcript_path: null`) | ignored (the main turn keeps owning the pane) |
 | Codex legacy `agent-turn-complete`            | `done`    |
-| Observed command exiting nonzero              | `error` — the only `error` source. Claude's map deliberately has no `error`: its hook vocabulary carries no reliable turn-level failure signal (`PostToolUse`'s per-tool `is_error` is normal, recoverable agent behavior), so mapping hooks to `Error` would paint healthy turns red |
+| Observed command exiting nonzero              | `error` — with opencode's `session.error`, one of the two `error` sources. Claude's map deliberately has no `error`: its hook vocabulary carries no reliable turn-level failure signal (`PostToolUse`'s per-tool `is_error` is normal, recoverable agent behavior), so mapping hooks to `Error` would paint healthy turns red |
 | Agent pane returns to its shell prompt (observed exit) | `idle` — terminal statuses clear at once; a `Running` instead arms the 15-tick stale grace (see §6, *Running exit grace*) |
 | Agent pane's root process exits (pane manifest `exited`) | `idle` — definitive producer death: clears even a `Running` immediately, no grace (see §6, *Running exit grace*) |
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -119,10 +119,11 @@ Shipped agent wiring:
 |---|---|---|---|
 | Codex | `~/.codex/hooks.json` | command hooks with `ZJ_RADAR_CODEX_HOOK=v1 zj-radar notify codex` marker | `UserPromptSubmit` / tool hooks / subagents → running; `PermissionRequest` → pending; `Stop` → done |
 | Codex legacy | `~/.codex/config.toml` `notify` | `notify = ["zj-radar","notify","codex"]` only with `--legacy-notify` | `agent-turn-complete` → done |
+| Opencode | `~/.config/opencode/plugins/zj-radar.js` | vendored JS bridge with the `ZJ_RADAR_OPENCODE_PLUGIN=v1` marker (auto-loaded; no `opencode.json` edit) | `chat.message` / tool hooks → running; `permission.asked` → pending; `session.idle` → done; `session.error` → error |
 
 Other agents follow the same strip-own-then-re-add installer pattern against
-their native hook/plugin config; none beyond Codex (and the Claude Code plugin
-in §1) ship today.
+their native hook/plugin config; Codex, Opencode, and the Claude Code plugin
+(§1) are the three that ship today.
 
 ## 3. One universal notifier (not per-agent scripts)
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -109,7 +109,7 @@ Mirror Cmux/code-notify's proven shape:
 
 > **As shipped:** the declarative table with a `Format` enum and the per-agent
 > disable env var never materialized. The implementation is per-surface modules
-> (`crates/cli/src/setup/{claude,codex,zellij}.rs` over a shared `edit.rs`)
+> (`crates/cli/src/setup/{claude,codex,opencode,zellij}.rs` over a shared `edit.rs`)
 > that keep the rules that mattered: strip-own-then-re-add with markers,
 > refuse-to-write on unparseable files, atomic writes, diff preview + `--yes`
 > and `--dry-run`.

--- a/docs/install.md
+++ b/docs/install.md
@@ -250,7 +250,8 @@ modifies any file. Reported items (six always; two more only when applicable):
 - **wasm** — plugin file exists at the expected stable path.
 - **layout** — default layout contains the injected radar rail.
 - **grant** — `permissions.kdl` records a grant for the wasm path.
-- **producer** — Codex hooks and/or Claude plugin wired up (names which).
+- **producer** — Codex hooks, the Claude plugin, and/or the Opencode bridge
+  plugin wired up (names which).
 - **managed config** — emitted only when `config.kdl` is a symlink
   (home-manager); warns that direct edits may be overwritten.
 - **config env** — emitted only when `$ZELLIJ_CONFIG_FILE` points somewhere
@@ -339,9 +340,11 @@ Everything zj-radar touches, what creates it, and what `setup zellij
 | Per-session plugin state under Zellij's cache + `/tmp/zj-radar` fallback | the running plugin | self-pruning (24 h); safe to delete anytime |
 | `$CODEX_HOME/hooks.json` entries (+ optional `notify` slot in `config.toml`) | `setup codex` | **reversed** by `setup codex --uninstall` |
 | `zj-radar-claude` plugin + `zj-radar` marketplace entry, inside Claude Code's own plugin store | `setup claude` | plugin **reversed** by `setup claude --uninstall`; the marketplace entry stays — `claude plugin marketplace remove zj-radar` |
+| `$XDG_CONFIG_HOME/opencode/plugins/zj-radar.js` (or `~/.config/opencode/plugins/zj-radar.js`) | `setup opencode` | **reversed** by `setup opencode --uninstall` (deletes only when the marker is present) |
 
 So a complete removal is: `zj-radar setup zellij --uninstall && zj-radar setup
-claude --uninstall && zj-radar setup codex --uninstall`, then delete the wasm,
+claude --uninstall && zj-radar setup codex --uninstall && zj-radar setup
+opencode --uninstall`, then delete the wasm,
 the `zj-radar` data dir, and the grant block — plus
 `claude plugin marketplace remove zj-radar` and the binary itself, wherever you
 installed it.

--- a/docs/producers.md
+++ b/docs/producers.md
@@ -100,7 +100,10 @@ This writes the vendored bridge plugin to `$XDG_CONFIG_HOME/opencode/plugins/`
 (or `~/.config/opencode/plugins/` when `XDG_CONFIG_HOME` is unset). The bridge
 serializes each opencode hook/bus-event payload and spawns
 `zj-radar notify opencode --status <s>` with JSON on stdin; all classification
-stays in Rust (it requires the `zj-radar` binary — no JS-side derive twin).
+stays in Rust (it requires the `zj-radar` binary). The bridge picks the
+status *class* (it knows which event fired); the Rust adapter owns every
+refinement — tool activity, task capture, the trailing-question remap, the
+blank-permission backstop — so the JS never grows a second classifier.
 
 - **Requires the `zj-radar` binary on `PATH`.** Unlike Claude's `jq` fallback,
   opencode wiring has no script fallback: `setup opencode` implies the binary.

--- a/docs/producers.md
+++ b/docs/producers.md
@@ -104,9 +104,11 @@ stays in Rust (it requires the `zj-radar` binary — no JS-side derive twin).
 
 - **Requires the `zj-radar` binary on `PATH`.** Unlike Claude's `jq` fallback,
   opencode wiring has no script fallback: `setup opencode` implies the binary.
-  Under `--pure` / `OPENCODE_PURE`, opencode disables external plugins *and*
-  the pane's command tracking is suppressed, so the row goes dark under
-  `--pure` (same tradeoff class as claude/codex).
+  Because `opencode` is a recognized agent executable (`AGENT_NAMES`), uninstrumented
+  `opencode` panes are ignored by command tracking to prevent duplicate activity
+  rows. An `opencode` pane will remain dark until `zj-radar setup opencode` is run
+  and opencode is restarted (or if `--pure` / `OPENCODE_PURE` is passed, which disables
+  external plugins).
 - **Restart opencode after installing** — plugins load once at startup, so a
   write mid-session needs a restart (or plugin reload) to take effect.
 - The bridge covers `chat.message` (running + task), `tool.execute.before`/

--- a/docs/producers.md
+++ b/docs/producers.md
@@ -1,8 +1,8 @@
 # Producers — sending agent status to the sidebar
 
 The sidebar is just a display. A **producer** is whatever broadcasts agent
-status to it. zj-radar ships producers for Claude Code and Codex, and the wire
-format is a documented pipe payload so you can write your own.
+status to it. zj-radar ships producers for Claude Code, Codex, and Opencode,
+and the wire format is a documented pipe payload so you can write your own.
 
 Install the [sidebar](install.md) first, then add a producer below.
 
@@ -50,20 +50,21 @@ nix build github:marktoda/zj-radar#zj-radar-cli   # -> result/bin/zj-radar
 cargo install zj-radar
 ```
 
-- **`zj-radar notify <claude|codex>`** — broadcasts agent status. The Claude
+- **`zj-radar notify <claude|codex|opencode>`** — broadcasts agent status. The Claude
   plugin's hook script automatically prefers it when it's on `PATH` (jq-free);
   otherwise the plugin falls back to its bundled `bash`+`jq` script.
-- **`zj-radar setup [claude|codex]`** — idempotently wires the named agent
-  (bare `setup` wires every detected agent). Codex gets hook entries in
+- **`zj-radar setup [claude|codex|opencode]`** — idempotently wires the named
+  agent (bare `setup` wires every detected agent). Codex gets hook entries in
   `hooks.json` under `$CODEX_HOME` (or `~/.codex` when it's unset) calling
   `zj-radar notify codex`. This preserves any existing Codex `notify` program
   (e.g. a Computer Use notifier), because hooks are additive. Claude is wired
   through Claude Code's own `claude plugin` CLI (marketplace add + install —
   the same install as [above](#claude-code)) rather than by editing files.
-  Both take the same flags: `--dry-run` to preview, `--uninstall` to remove
+  Opencode gets a vendored JS bridge plugin (see [below](#opencode)).
+  All take the same flags: `--dry-run` to preview, `--uninstall` to remove
   only zj-radar's wiring, and `--check` to diagnose the current setup. After
-  installing or changing hooks, run `/hooks` inside Codex once to review and
-  trust the command hook.
+  installing or changing Codex hooks, run `/hooks` inside Codex once to review
+  and trust the command hook.
 - **`zj-radar setup codex --legacy-notify`** — opt-in fallback for older Codex
   setups that only support the single `notify` program. It refuses to replace a
   foreign notifier unless `--force` is also passed.
@@ -85,6 +86,44 @@ writes one entry per event across seven hook events (`UserPromptSubmit`,
 [below](#writing-your-own-producer)) — a `commandWindows` variant, and the
 `ZJ_RADAR_CODEX_HOOK=v1` marker that idempotency and `--uninstall` key on.
 
+## Opencode
+
+[Opencode](https://opencode.ai) auto-loads JS plugins from its global plugins
+dir, so wiring is one file drop — **no `opencode.json` editing**, clean
+uninstall = delete one file:
+
+```sh
+zj-radar setup opencode
+```
+
+This writes the vendored bridge plugin to `$XDG_CONFIG_HOME/opencode/plugins/`
+(or `~/.config/opencode/plugins/` when `XDG_CONFIG_HOME` is unset). The bridge
+serializes each opencode hook/bus-event payload and spawns
+`zj-radar notify opencode --status <s>` with JSON on stdin; all classification
+stays in Rust (it requires the `zj-radar` binary — no JS-side derive twin).
+
+- **Requires the `zj-radar` binary on `PATH`.** Unlike Claude's `jq` fallback,
+  opencode wiring has no script fallback: `setup opencode` implies the binary.
+  Under `--pure` / `OPENCODE_PURE`, opencode disables external plugins *and*
+  the pane's command tracking is suppressed, so the row goes dark under
+  `--pure` (same tradeoff class as claude/codex).
+- **Restart opencode after installing** — plugins load once at startup, so a
+  write mid-session needs a restart (or plugin reload) to take effect.
+- The bridge covers `chat.message` (running + task), `tool.execute.before`/
+  `after` (running + tool activity), `permission.ask` (pending),
+  `session.idle` (done, with the trailing-question → pending remap),
+  `session.error` (error — a real failure signal Claude's hook model lacks),
+  and `session.created`/`session.deleted` (idle). Spawns are strictly FIFO
+  (in-order / latest-wins), async-only (never synchronous — the bridge runs in
+  opencode's process and must not freeze the TUI), with a hard ~10 s kill
+  timer per child. The `ZJ_RADAR_OPENCODE_PLUGIN=v1` marker in the plugin
+  header is what idempotency, `--uninstall`, and `--check` key on; a foreign
+  plugin file (no marker) is refused unless `--force` replaces it.
+- **One TUI, many sessions, one pane:** latest event wins — same semantics as
+  Claude. The minimum verified opencode version is 1.18.x (the plugin is
+  vendored per zj-radar release; re-running `setup opencode` heals drift via
+  the marker rewrite).
+
 ## Any script: `zj-radar notify generic`
 
 Anything that isn't an instrumented agent — deploy scripts, cron jobs,
@@ -104,8 +143,8 @@ zj-radar notify generic --status done --msg "deploy finished" --source deploy
 - `--task`: the sticky task label (empty keeps the stored one).
 - `--source`: picks the kind mark — `test` ⚗ · `build` ⚙ · `deploy` ⇡ ·
   `server` ❯ · `command` $, and the agent tokens `claude` ✳ · `codex` ❉ ·
-  `gemini` ✦ — anything else (including the default `generic`) renders the
-  neutral `⦿`.
+  `opencode` ✺ · `gemini` ✦ — anything else (including the default `generic`)
+  renders the neutral `⦿`.
 - Repo/branch come from `git` in the calling directory; the pane id from
   `$ZELLIJ_PANE_ID`. Outside Zellij it's a silent no-op (safe under `set -e`).
   `--dry-run` prints the payload instead of broadcasting.

--- a/docs/producers.md
+++ b/docs/producers.md
@@ -89,8 +89,9 @@ writes one entry per event across seven hook events (`UserPromptSubmit`,
 ## Opencode
 
 [Opencode](https://opencode.ai) auto-loads JS plugins from its global plugins
-dir, so wiring is one file drop — **no `opencode.json` editing**, clean
-uninstall = delete one file:
+dir, so wiring is one file drop — **no `opencode.json` editing**; uninstall
+deletes that file (a `.zj-radar.bak` from an earlier rewrite may remain, and
+opencode ignores it):
 
 ```sh
 zj-radar setup opencode
@@ -121,14 +122,15 @@ blank-permission backstop — so the JS never grows a second classifier.
 - **Restart opencode after installing** — plugins load once at startup, so a
   write mid-session needs a restart (or plugin reload) to take effect.
 - The bridge covers `chat.message` (running + task), `tool.execute.before`/
-  `after` (running + tool activity), the `permission.asked` bus event
-  (pending; the pre-1.14 `permission.ask` hook is kept as a fallback) and
-  `permission.replied` (back to running), `session.idle` (done, with the
-  trailing-question → pending remap), `session.error` (error — a real failure
-  signal Claude's hook model lacks), and `session.created`/`session.deleted`
-  (idle). Events from subagent (task-tool) sessions are ignored — only the
-  root session drives the row — and the user's own prompt text is never
-  mistaken for assistant text. Sends are async-only (never synchronous — the
+  `after` (running + tool activity), the `permission.asked` and
+  `question.asked` bus events (pending — both block the TUI, from whichever
+  session raised them) and their `replied`/`rejected` edges (back to
+  running), `session.idle` (done, with the trailing-question → pending remap),
+  `session.error` (error — a real failure signal Claude's hook model lacks;
+  the user's own Esc interrupt is not an error and settles on done), and
+  `session.created`/`session.deleted` (idle). Events from subagent (task-tool)
+  sessions are ignored, and the user's own prompt text is never mistaken for
+  assistant text. Sends are async-only (never synchronous — the
   bridge runs in opencode's process and must not freeze the TUI), one child
   at a time, with a hard ~10 s kill timer per child. Status *edges*
   (pending/done/error/idle) are strictly FIFO; `running` refreshes coalesce to

--- a/docs/producers.md
+++ b/docs/producers.md
@@ -104,21 +104,33 @@ stays in Rust (it requires the `zj-radar` binary — no JS-side derive twin).
 
 - **Requires the `zj-radar` binary on `PATH`.** Unlike Claude's `jq` fallback,
   opencode wiring has no script fallback: `setup opencode` implies the binary.
-  Because `opencode` is a recognized agent executable (`AGENT_NAMES`), uninstrumented
-  `opencode` panes are ignored by command tracking to prevent duplicate activity
-  rows. An `opencode` pane will remain dark until `zj-radar setup opencode` is run
-  and opencode is restarted (or if `--pure` / `OPENCODE_PURE` is passed, which disables
-  external plugins).
+- **An unwired opencode pane is dark, not un-enriched.** `opencode` is an
+  instrumented agent (`AGENT_NAMES`), so the sidebar suppresses ordinary
+  command-tracking for its panes and relies on the bridge for every row. With
+  the bridge absent — a fresh install that skipped `setup opencode`, or
+  `--pure` / `OPENCODE_PURE`, which disables external plugins — the pane shows
+  no Running/Done row at all (same tradeoff class as claude/codex).
+  `zj-radar setup --check` and the `setup zellij` epilogue both report the
+  missing bridge when `opencode` is on `PATH`. **Upgrading from a release
+  before opencode support:** panes that previously fell through to
+  command-tracking go dark once the wasm is upgraded; run
+  `zj-radar setup opencode` and restart opencode.
 - **Restart opencode after installing** — plugins load once at startup, so a
   write mid-session needs a restart (or plugin reload) to take effect.
 - The bridge covers `chat.message` (running + task), `tool.execute.before`/
-  `after` (running + tool activity), `permission.ask` (pending),
-  `session.idle` (done, with the trailing-question → pending remap),
-  `session.error` (error — a real failure signal Claude's hook model lacks),
-  and `session.created`/`session.deleted` (idle). Spawns are strictly FIFO
-  (in-order / latest-wins), async-only (never synchronous — the bridge runs in
-  opencode's process and must not freeze the TUI), with a hard ~10 s kill
-  timer per child. The `ZJ_RADAR_OPENCODE_PLUGIN=v1` marker in the plugin
+  `after` (running + tool activity), the `permission.asked` bus event
+  (pending; the pre-1.14 `permission.ask` hook is kept as a fallback) and
+  `permission.replied` (back to running), `session.idle` (done, with the
+  trailing-question → pending remap), `session.error` (error — a real failure
+  signal Claude's hook model lacks), and `session.created`/`session.deleted`
+  (idle). Events from subagent (task-tool) sessions are ignored — only the
+  root session drives the row — and the user's own prompt text is never
+  mistaken for assistant text. Sends are async-only (never synchronous — the
+  bridge runs in opencode's process and must not freeze the TUI), one child
+  at a time, with a hard ~10 s kill timer per child. Status *edges*
+  (pending/done/error/idle) are strictly FIFO; `running` refreshes coalesce to
+  the latest unsent one so a slow or wedged pipe never queues stale refreshes
+  ahead of an edge. The `ZJ_RADAR_OPENCODE_PLUGIN=v1` marker in the plugin
   header is what idempotency, `--uninstall`, and `--check` key on; a foreign
   plugin file (no marker) is refused unless `--force` replaces it.
 - **One TUI, many sessions, one pane:** latest event wins — same semantics as

--- a/docs/rail-reference.md
+++ b/docs/rail-reference.md
@@ -51,7 +51,7 @@
 **Status glyphs (plain):** `○` idle · `⠋` working *(spins ⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏; a running
 **server** holds a steady `▸` instead — services don't spin)* · `◆` needs-you ·
 `●` done · `✗` error.
-**Kind marks:** `✳` claude · `❉` codex · `✦` gemini · `$` command · `⚙` build ·
+**Kind marks:** `✳` claude · `❉` codex · `✺` opencode · `✦` gemini · `$` command · `⚙` build ·
 `⚗` test · `⇡` deploy · `❯` server · `⦿` other.
 
 **Width ruler (32):**
@@ -986,7 +986,7 @@ tab <pos> "<name>" [active]
   ...
 ```
 
-- `kind` ∈ claude·codex·gemini·command·build·test·deploy·server·other
+- `kind` ∈ claude·codex·opencode·gemini·command·build·test·deploy·server·other
 - `status` ∈ running·pending·done·error·idle
 - `waiting <N>m` backdates the pane's waiting-on-you edge by N minutes so the
   `· Nm` wait tag renders (pending panes only; without it the pane applied

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,8 +52,8 @@ The rail and the status feed are separate installs (sidebar vs
 Diagnose in order:
 
 1. **`zj-radar setup zellij --check`** — the `producer` item says whether a
-   producer (the Claude plugin or Codex hooks) is wired at all; the `grant`
-   item catches a missing permission grant.
+   producer (the Claude plugin, Codex hooks, or Opencode bridge plugin) is
+   wired at all; the `grant` item catches a missing permission grant.
 2. **Bypass the producers with the smoke test** — broadcast a fake status
    straight from a shell *inside* the session (see
    [Writing your own producer](producers.md#writing-your-own-producer) for the

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,9 @@
           || (pkgs.lib.hasSuffix "/examples/radar-sidebar.kdl" path)
           # include_str!'d by the plugin (config.rs, control.rs docs guard tests).
           || (pkgs.lib.hasSuffix "/docs/configuration.md" path)
+          # include_str!'d by the CLI's opencode setup (crates/cli/src/setup/mod.rs)
+          # — the vendored JS bridge plugin written by `zj-radar setup opencode`.
+          || (pkgs.lib.hasSuffix "/crates/cli/src/setup/opencode_plugin.js" path)
           # include_str!'d by the plugin's producer-script guard test (lib.rs).
           || (pkgs.lib.hasSuffix "/plugins/zj-radar-claude/scripts/notify.sh" path)
           # include_str!'d by the plugin's hook-headroom guard (hooks_manifest_tests.rs).


### PR DESCRIPTION
## What & why

This pull request adds support for Opencode as a first-class producer in zj-radar, alongside Claude Code and Codex. It updates documentation, CLI code, and internal APIs to recognize and handle Opencode, including a vendored JS bridge plugin and corresponding setup instructions. The changes ensure Opencode is treated consistently throughout the project, both in user-facing docs and in the codebase.

**Opencode producer support:**

* Added Opencode as a recognized agent/producer in the CLI (`Agent` enum, `Agent::ALL`, parsing, and tests in `crates/cli/src/agents.rs`). [[1]](diffhunk://#diff-8d0bef6224dbbfc4a81a88d9d28344face6b4272d24b6dde0bfa3bcd2b5d1666R14) [[2]](diffhunk://#diff-8d0bef6224dbbfc4a81a88d9d28344face6b4272d24b6dde0bfa3bcd2b5d1666R53-R60) [[3]](diffhunk://#diff-8d0bef6224dbbfc4a81a88d9d28344face6b4272d24b6dde0bfa3bcd2b5d1666R73) [[4]](diffhunk://#diff-8d0bef6224dbbfc4a81a88d9d28344face6b4272d24b6dde0bfa3bcd2b5d1666R82) [[5]](diffhunk://#diff-8d0bef6224dbbfc4a81a88d9d28344face6b4272d24b6dde0bfa3bcd2b5d1666R233) [[6]](diffhunk://#diff-8d0bef6224dbbfc4a81a88d9d28344face6b4272d24b6dde0bfa3bcd2b5d1666L276-R284)
* Added and documented the Opencode JS bridge plugin, with setup instructions and workspace structure updates (`CONTRIBUTING.md`, `README.md`). [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L4-R6) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L14-R18) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R101) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L223-R231) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L241-R244) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L259-R265)

**Documentation and design updates:**

* Updated all relevant documentation to mention Opencode as a supported/first-class producer (including `CONTEXT.md`, `AGENTS.md`, and `README.md`). [[1]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14L270-R275) [[2]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14L386-R402) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L8-R9) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L50-R54)
* Clarified the wire format and setup-analysis seam to include Opencode, and described new facts and detection logic for the Opencode plugin. [[1]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14L270-R275) [[2]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14L386-R402)

**Internal API notes:**

* Documented that adding a new producer like Opencode introduces a new non-exhaustive `Kind` variant in the core API, affecting downstream exhaustive matches.

## How

Used Opencode with GLM 5.3 and GLM 5.2 support. Checklist review supported with Gemini 3.6 Flash

## Checklist

- [X] `just ci` passes (`just test` + `cargo clippy` + wasm build + `just test-bash`).
  - just test: PASS (all 258 workspace unit/doc tests pass).
  - cargo clippy: PASS (0 warnings across workspace with -D warnings).
  - Wasm build (cargo build --target wasm32-wasip1 -p zj-radar-plugin): PASS.
- [X] Did **not** run `cargo fmt` (this repo is hand-formatted — see CONTRIBUTING.md).
- [X] Tests added/updated at the right layer (snapshot / `rail-reference.md` for render changes, unit/proptest for wire/parse).
  - Unit tests added in crates/cli/src/agents/opencode.rs (intake/status mapping, tool normalization, task capture, backstop, trailing questions).
  - Core tests updated in crates/core/src/kind.rs and crates/core/src/command/tests.rs.
  - Setup & CLI tests updated in crates/cli/src/run.rs, crates/cli/src/setup/analyze.rs, crates/cli/src/setup/check.rs, and flake.nix.
- [X] Snapshots reviewed with `just review` if render output changed.
  - Render width and layout structure remain intact (Kind::Opencode renders as 1 cell width ✺), and all snapshot tests pass without drift. 
- [X] Docs updated (`README.md` / `docs/` / `CONTEXT.md`) if behavior or interfaces changed.
  - Thorough documentation updates across README.md, CONTEXT.md, CONTRIBUTING.md, docs/producers.md, docs/install.md, docs/design.md, docs/activity-model.md, docs/rail-reference.md, docs/troubleshooting.md, and RELEASING.md 
- [X] Preserves the **push-driven** (no host polling) and **rail lockstep** invariants.
  - Push-driven: opencode_plugin.js pushes events asynchronously via zj-radar notify opencode through zellij pipe. No host polling introduced.
  - Rail lockstep: Render output ANSI lines and click-target map remain 1:1.