### PR TITLE
fix: address tab renames by stable TabId, not position

### DIFF
--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -207,7 +207,7 @@ impl State {
                 Effect::HeartbeatPermissionLock => {
                     self.session_files.heartbeat_permission_lock()
                 }
-                Effect::RenameTab { position, name } => rename_tab(position as u32 + 1, &name),
+                Effect::RenameTab { tab_id, name } => rename_tab_with_id(tab_id.raw() as u64, &name),
                 Effect::SwitchTab { position } => switch_tab_to(position as u32 + 1),
                 Effect::ShowPane { pane_id } => {
                     show_pane_with_id(PaneId::Terminal(pane_id), false, true);

--- a/crates/plugin/src/radar_state.rs
+++ b/crates/plugin/src/radar_state.rs
@@ -71,6 +71,12 @@ impl TabId {
     pub(crate) fn new(raw: usize) -> Self {
         Self(raw)
     }
+
+    /// The host's raw id, for id-addressed host calls (`rename_tab_with_id`).
+    #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+    pub(crate) fn raw(self) -> usize {
+        self.0
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1182,7 +1188,6 @@ impl RadarState {
                 TabFacts {
                     id: tab.id,
                     name: tab.name.clone(),
-                    position: tab.position,
                     panes: panes
                         .iter()
                         .map(|p| PaneFacts {

--- a/crates/plugin/src/radar_state/tests.rs
+++ b/crates/plugin/src/radar_state/tests.rs
@@ -288,7 +288,7 @@ fn rename_ownership_follows_stable_tab_id_across_reorder() {
     assert_eq!(
         rename.renames,
         vec![TabRename {
-            position: 0,
+            id: TabId::new(10),
             name: "alpha".into(),
         }]
     );
@@ -301,7 +301,7 @@ fn rename_ownership_follows_stable_tab_id_across_reorder() {
     assert_eq!(
         rename.renames,
         vec![TabRename {
-            position: 1,
+            id: TabId::new(10),
             name: "beta".into(),
         }]
     );
@@ -342,7 +342,7 @@ fn managed_naming_skips_manual_names_but_force_overrides() {
     assert_eq!(
         forced,
         vec![TabRename {
-            position: 0,
+            id: TabId::new(10),
             name: "repo".into(),
         }]
     );
@@ -659,7 +659,7 @@ fn bootstrapped_cwd_names_the_tab_and_later_cd_still_renames() {
     assert_eq!(
         bootstrapped.renames,
         vec![TabRename {
-            position: 0,
+            id: TabId::new(10),
             name: "alpha".into(),
         }]
     );
@@ -678,7 +678,7 @@ fn bootstrapped_cwd_names_the_tab_and_later_cd_still_renames() {
     assert_eq!(
         moved.renames,
         vec![TabRename {
-            position: 0,
+            id: TabId::new(10),
             name: "beta".into(),
         }]
     );
@@ -1112,7 +1112,7 @@ fn applied_tab_name_repicks_when_the_naming_pane_closes() {
     assert_eq!(
         change.renames,
         vec![TabRename {
-            position: 0,
+            id: TabId::new(10),
             name: "beta".into(),
         }]
     );

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -46,7 +46,7 @@ use crate::control::Verb;
 use crate::config;
 use crate::permission::{PermissionMarker, PermissionPolicy, PermissionProbe, PermissionState, Transition};
 use crate::presence::Presence;
-use crate::radar_state::{Direction, PaneUpdate, RadarChange, RadarState, RadarTab, SnapshotWrite};
+use crate::radar_state::{Direction, PaneUpdate, RadarChange, RadarState, RadarTab, SnapshotWrite, TabId};
 use crate::render::{self, RenderedRail};
 use crate::rollup::{LedgerLine, TabRow};
 use crate::sessions::{BadgeEntry, CommitTarget, Sessions};
@@ -116,7 +116,7 @@ pub(crate) enum Effect {
     SetTimeout(Cadence),
     PersistSnapshot,
     PersistPermissionMarker(PermissionMarker),
-    RenameTab { position: usize, name: String },
+    RenameTab { tab_id: TabId, name: String },
     SwitchTab { position: usize },
     ShowPane { pane_id: u32 },
     /// Read these panes' working directories once (blocking `get_pane_cwd`) to
@@ -1182,7 +1182,7 @@ impl PluginRuntime {
     fn effects_from_renames(&self, renames: Vec<TabRename>) -> Vec<Effect> {
         renames
             .into_iter()
-            .map(|TabRename { position, name }| Effect::RenameTab { position, name })
+            .map(|TabRename { id, name }| Effect::RenameTab { tab_id: id, name })
             .collect()
     }
 

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -657,7 +657,7 @@ fn cwd_change_renames_default_named_tab_and_command_uses_cwd() {
     assert_eq!(
         rename.effects,
         vec![Effect::RenameTab {
-            position: 0,
+            tab_id: TabId::new(1),
             name: "myrepo".into(),
         }]
     );
@@ -730,7 +730,7 @@ fn sidebar_instance_never_renames_a_foreign_tab() {
     let foreign = runtime.cwd_changed(11, "/work/foreign".into());
     assert!(
         foreign.effects.iter().all(|effect| {
-            !matches!(effect, Effect::RenameTab { position: 1, .. })
+            !matches!(effect, Effect::RenameTab { tab_id, .. } if *tab_id == TabId::new(2))
         }),
         "tab 1's sidebar must not rename tab 2: {:?}",
         foreign.effects
@@ -738,7 +738,7 @@ fn sidebar_instance_never_renames_a_foreign_tab() {
 
     let owned = runtime.cwd_changed(10, "/work/owned".into());
     assert!(owned.effects.iter().any(|effect| {
-        matches!(effect, Effect::RenameTab { position: 0, name } if name == "owned")
+        matches!(effect, Effect::RenameTab { tab_id, name } if *tab_id == TabId::new(1) && name == "owned")
     }));
 }
 
@@ -1779,7 +1779,7 @@ fn project_emits_effects_in_canonical_order() {
     let change = RadarChange {
         render: true,
         snapshot: SnapshotWrite::Now,
-        renames: vec![TabRename { position: 0, name: "renamed".into() }],
+        renames: vec![TabRename { id: TabId::new(1), name: "renamed".into() }],
         cwd_bootstrap: vec![7],
         settle: true,
         ..RadarChange::default()

--- a/crates/plugin/src/tab_namer.rs
+++ b/crates/plugin/src/tab_namer.rs
@@ -30,21 +30,26 @@ pub(crate) struct PaneFacts {
     pub focused: bool,
 }
 
-/// The naming facts for one tab: its identity, current name, position, and the
-/// per-pane facts to draw a name from.
+/// The naming facts for one tab: its identity, current name, and the per-pane
+/// facts to draw a name from.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct TabFacts {
     pub id: TabId,
     pub name: String,
-    pub position: usize,
     pub panes: Vec<PaneFacts>,
 }
 
 /// A requested tab rename — this module's output vocabulary. `radar_state` uses
-/// it in `RadarChange`; the runtime turns it into a `RenameTab` effect.
+/// it in `RadarChange`; the runtime turns it into a `RenameTab` effect. Addressed
+/// by stable `TabId`, never position: facts are joined from a `PaneUpdate` and
+/// the *previous* `TabUpdate`, so a position computed here can point at a
+/// neighbour for one event after a tab closes or moves — an id cannot. (The
+/// pane join in `name_facts` is still position-keyed — Zellij's manifest is —
+/// so the *name* can be a neighbour's for that one event; the next pane/cwd
+/// event re-picks.)
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct TabRename {
-    pub position: usize,
+    pub id: TabId,
     pub name: String,
 }
 
@@ -95,7 +100,7 @@ impl TabNamer {
             if force || is_default_name(&tab.name) || ours {
                 self.applied.insert(tab.id, desired.clone());
                 out.push(TabRename {
-                    position: tab.position,
+                    id: tab.id,
                     name: desired,
                 });
             }
@@ -241,19 +246,18 @@ mod tests {
         }
     }
 
-    /// Build a single-position tab with the given current name and panes.
+    /// Build a tab with the given id, current name, and panes.
     fn tab(id: usize, name: &str, panes: Vec<PaneFacts>) -> TabFacts {
         TabFacts {
             id: TabId::new(id),
             name: name.into(),
-            position: 0,
             panes,
         }
     }
 
     fn renamed_to(name: &str) -> Vec<TabRename> {
         vec![TabRename {
-            position: 0,
+            id: TabId::new(1),
             name: name.into(),
         }]
     }

--- a/docs/design.md
+++ b/docs/design.md
@@ -308,7 +308,7 @@ hooks' `timeout` values must clear the cap plus 2s slack (welded by
 ## 6. Plugin ↔ Zellij wiring
 
 - **Permissions:** `ReadApplicationState` (tab/pane state), `ReadCliPipes` (broadcast),
-  `ChangeApplicationState` (`switch_tab_to`, `rename_tab`), and `RunCommands` — the plugin now
+  `ChangeApplicationState` (`switch_tab_to`, `rename_tab_with_id`), and `RunCommands` — the plugin now
   owns OS desktop notifications and hands each one to the host via `run_command` (see §12; a
   reversal of the original "notifications stay in the adapters, no `RunCommands`" stance). When
   the grant is absent, `run_command` is a silent host no-op, so notifications simply don't fire.
@@ -428,15 +428,16 @@ the normal `cwd_changed` path):
 - **v1.x (optional auto-naming, push-sourced only):** if generic names on plain tabs feel like a
   regression, derive names from **events we already receive**, never from queries:
   - *Agent tabs* — the hook payload already carries `repo`; on a status change, optionally
-    `rename_tab(position+1, repo)`. `rename_tab` is a fire-and-forget `ChangeApplicationState`
+    `rename_tab_with_id(tab_id, repo)`. It is a fire-and-forget `ChangeApplicationState`
     action (no blocking return), and it fires only on change, not per tick — so it cannot
-    recreate the poll storm.
+    recreate the poll storm. Addressed by Zellij's stable tab id, never position — see
+    `TabRename` in `tab_namer.rs` for why.
   - *Plain tabs* — subscribe to **`CwdChanged`** (pushed) to learn a pane's cwd → git-root
     basename; read program from **`PaneInfo.title`** in the `PaneUpdate` manifest we already
     consume. Both are push signals; the only `get_pane_*` call anywhere is the once-per-pane
     `ResolveCwd` bootstrap above.
 
-  Guardrails: only `rename_tab` when the derived name actually differs (avoid redundant
+  Guardrails: only rename when the derived name actually differs (avoid redundant
   main-thread work), and treat naming as best-effort cosmetics — a missing cwd/title just leaves
   the existing name. Write authority is local: each sidebar instance may rename only the tab
   containing its own plugin pane. It resolves that ownership to stable `TabId` from pushed


### PR DESCRIPTION
## What & why

`Effect::RenameTab` carried a tab *position* and executed as `rename_tab(position + 1, name)`. The namer already keys everything by Zellij's stable `TabId` — its `applied` map and the per-tab ownership latch from #29 — and the position was derived at emission time from the cached `tabs` list.

That list is the *previous* `TabUpdate`, joined with the *current* `PaneUpdate` (Zellij reports the two from one screen-thread snapshot in that order). For the one event after a tab closes or moves the pair is mixed, and a position-addressed rename can land on a neighbour.

Closes #30.

## How

- `TabRename { id: TabId, name }` and `Effect::RenameTab { tab_id, name }`; `position` dropped from `TabFacts`.
- `lib.rs` executes via `rename_tab_with_id` — shipped in zellij-tile 0.44.3 (the version floor) and in the same `ChangeApplicationState` permission group as `rename_tab`, so the pre-seeded grant covers it (the live E2E confirms: tabs auto-name under the existing grant).
- `TabId::raw()` for the host call, cfg-gated like the other wasm-only surface.
- design.md updated.

## Verification

- `cargo test --workspace --all-features` — 949 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo build --release --target wasm32-wasip1 -p zj-radar-plugin`
- Live E2E — 15/15 (macOS, zellij 0.44.3)

## Checklist

- [x] `just ci` equivalents pass (test-bash unaffected — no shell changes)
- [x] Did **not** run `cargo fmt`
- [x] Tests updated at the namer / radar_state / runtime seams
- [x] No rendering snapshots changed
- [x] Updated `docs/design.md`
- [x] Preserves the push-driven and rail-lockstep invariants

🤖 Generated with [Claude Code](https://claude.com/claude-code)
