### PR TITLE
refactor(cli): one producers module; opencode follow-ups from the PR #27 reviews

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -29,6 +29,7 @@ mod agents;
 mod fsutil;
 pub(crate) mod layout;
 mod notify;
+mod producers;
 mod run;
 mod setup;
 

--- a/crates/cli/src/producers.rs
+++ b/crates/cli/src/producers.rs
@@ -1,0 +1,115 @@
+//! Producer detection: which instrumented agents are wired to push status.
+//!
+//! One home for every detection route, read by `run`'s advisory, the doctor's
+//! `producer` item, and `setup zellij`'s epilogue — so "is agent X wired?"
+//! cannot drift between them. Each route is a marker check over a config file
+//! the matching `setup <agent>` writes; the evidence is gathered once
+//! ([`ProducerTexts::read`]) and graded purely ([`ProducerTexts::wired`]).
+
+use crate::agents::Agent;
+use crate::setup::{CODEX_HOOK_MARKER, CLAUDE_PLUGIN};
+
+/// Three producers, three wiring routes — name all, because `zj-radar setup`
+/// wires each agent symmetrically (claude drives Claude Code's plugin
+/// marketplace; opencode drops a vendored JS bridge into its plugins dir).
+pub(crate) const PRODUCER_HINT: &str = "Agent status off — no producer wired. Run `zj-radar setup claude` \
+    (Claude Code), `zj-radar setup codex` (Codex), or `zj-radar setup opencode` (Opencode).";
+
+/// The per-agent evidence, already read. `None` = the file is absent.
+#[derive(Default)]
+pub(crate) struct ProducerTexts {
+    /// Codex's `hooks.json`; wired when it carries our command-hook marker.
+    pub codex_hooks:     Option<String>,
+    /// Claude Code's `installed_plugins.json`; wired when it names our plugin.
+    pub claude_plugins:  Option<String>,
+    /// opencode's vendored bridge plugin; wired when it carries our header marker.
+    pub opencode_plugin: Option<String>,
+}
+
+impl ProducerTexts {
+    /// The one IO point: read every producer's evidence from its home.
+    pub(crate) fn read() -> Self {
+        ProducerTexts {
+            codex_hooks:     crate::setup::codex_hooks_text(),
+            claude_plugins:  crate::setup::claude_installed_plugins_text(),
+            opencode_plugin: crate::setup::opencode_plugin_text(),
+        }
+    }
+
+    /// The wired agents, in [`Agent::ALL`] order.
+    pub(crate) fn wired(&self) -> Vec<Agent> {
+        Agent::ALL.iter().copied().filter(|a| self.is_wired(*a)).collect()
+    }
+
+    /// Exhaustive on purpose: a new `Agent` variant does not compile until its
+    /// detection route is declared here — the one wiring point the agent
+    /// guard lattice can't otherwise reach.
+    pub(crate) fn is_wired(&self, agent: Agent) -> bool {
+        match agent {
+            Agent::Codex => self.codex_hooks.as_deref().is_some_and(|h| h.contains(CODEX_HOOK_MARKER)),
+            Agent::Claude => self.claude_plugins.as_deref().is_some_and(|p| p.contains(CLAUDE_PLUGIN)),
+            Agent::Opencode => self
+                .opencode_plugin
+                .as_deref()
+                .is_some_and(crate::setup::detect::opencode_plugin_is_ours),
+        }
+    }
+}
+
+/// `Some(hint)` when no producer is wired, else `None`.
+pub(crate) fn producer_hint(wired: &[Agent]) -> Option<String> {
+    wired.is_empty().then(|| PRODUCER_HINT.to_string())
+}
+
+/// "codex, opencode" — the wired agents by name, for status lines.
+pub(crate) fn names(agents: &[Agent]) -> String {
+    agents.iter().map(|a| a.source()).collect::<Vec<_>>().join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::setup::OPENCODE_PLUGIN_MARKER;
+
+    fn texts(codex: bool, claude: bool, opencode: bool) -> ProducerTexts {
+        ProducerTexts {
+            codex_hooks:     codex.then(|| format!("{{\"command\": \"{CODEX_HOOK_MARKER} zj-radar notify codex\"}}")),
+            claude_plugins:  claude.then(|| format!("{{\"plugins\":[\"{CLAUDE_PLUGIN}\"]}}")),
+            opencode_plugin: opencode.then(|| format!("// {OPENCODE_PLUGIN_MARKER}\n")),
+        }
+    }
+
+    #[test]
+    fn wired_lists_agents_in_declaration_order() {
+        assert_eq!(texts(true, true, true).wired(), Agent::ALL.to_vec());
+        assert_eq!(texts(true, false, true).wired(), vec![Agent::Codex, Agent::Opencode]);
+        assert!(texts(false, false, false).wired().is_empty());
+    }
+
+    #[test]
+    fn each_route_keys_on_its_marker_not_on_file_presence() {
+        let foreign = ProducerTexts {
+            codex_hooks:     Some("{\"command\": \"/other/notifier\"}".to_string()),
+            claude_plugins:  Some("{\"plugins\":[\"someone-else\"]}".to_string()),
+            opencode_plugin: Some("// some other plugin\n".to_string()),
+        };
+        assert!(foreign.wired().is_empty(), "present-but-foreign files are not wired");
+        assert!(ProducerTexts::default().wired().is_empty(), "absent files are not wired");
+    }
+
+    #[test]
+    fn hint_only_when_nothing_is_wired_and_names_every_route() {
+        assert!(producer_hint(&[Agent::Codex]).is_none());
+        let hint = producer_hint(&[]).unwrap();
+        for agent in Agent::ALL {
+            let route = format!("zj-radar setup {}", agent.source());
+            assert!(hint.contains(&route), "hint must name the {route} route: {hint}");
+        }
+    }
+
+    #[test]
+    fn names_joins_sources() {
+        assert_eq!(names(&[Agent::Claude, Agent::Opencode]), "claude, opencode");
+        assert_eq!(names(&[]), "");
+    }
+}

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -5,7 +5,7 @@
 //! pure-editor / thin-IO split that `setup.rs` uses.
 
 use super::fsutil::atomic_write;
-use super::setup::CODEX_HOOK_MARKER;
+use super::producers::{producer_hint, ProducerTexts};
 use std::path::{Path, PathBuf};
 
 /// Shown on first run (create OR attach) when the wasm isn't granted. The grant
@@ -17,11 +17,6 @@ use std::path::{Path, PathBuf};
 /// branching into a second, dead-end message.
 const GRANT_HINT: &str = "First run: a permission prompt opens — press y to enable agent status \
     (if it doesn't appear, press Ctrl-y in the session).";
-/// Three producers, three wiring routes — name all, because `zj-radar setup`
-/// wires each agent symmetrically (claude drives Claude Code's plugin
-/// marketplace; opencode drops a vendored JS bridge into its plugins dir).
-pub(crate) const PRODUCER_HINT: &str = "Agent status off — no producer wired. Run `zj-radar setup claude` \
-    (Claude Code), `zj-radar setup codex` (Codex), or `zj-radar setup opencode` (Opencode).";
 
 // ── Pure helpers ─────────────────────────────────────────────────────────────
 
@@ -180,41 +175,6 @@ pub(crate) fn wasm_is_granted(permissions_kdl: &str, wasm_abs_path: &str) -> boo
     last.is_some_and(|granted| {
         REQUIRED_PLUGIN_PERMISSIONS.iter().all(|required| granted.iter().any(|t| t == required))
     })
-}
-
-/// Producer-detection advisory: `Some(hint)` when NO producer is wired (Codex
-/// hooks lack our marker AND the Claude producer plugin is absent AND the
-/// opencode bridge plugin is absent), else `None`.
-pub(crate) fn producer_hint(
-    codex_hooks: Option<&str>,
-    claude_present: bool,
-    opencode_present: bool,
-) -> Option<String> {
-    if codex_producer_wired(codex_hooks) || claude_present || opencode_present {
-        None
-    } else {
-        Some(PRODUCER_HINT.to_string())
-    }
-}
-
-/// True iff Codex's hooks file carries our marker — the Codex producer's
-/// detection route, twin of [`claude_producer_wired`].
-pub(crate) fn codex_producer_wired(codex_hooks: Option<&str>) -> bool {
-    codex_hooks.is_some_and(|h| h.contains(CODEX_HOOK_MARKER))
-}
-
-/// True iff Claude Code's installed-plugins manifest lists zj-radar's producer
-/// plugin ([`crate::setup::CLAUDE_PLUGIN`]). `None`/empty input returns `false`.
-pub(crate) fn claude_producer_wired(installed_plugins_json: Option<&str>) -> bool {
-    installed_plugins_json.is_some_and(|s| s.contains(crate::setup::CLAUDE_PLUGIN))
-}
-
-/// True iff the opencode bridge plugin file carries our marker — the opencode
-/// producer's detection route, twin of [`codex_producer_wired`]. Reads the
-/// plugin text the caller already gathered (the shared `opencode_plugin_text`
-/// reader behind `run`'s advisory, `setup zellij`'s epilogue, and `--check`).
-pub(crate) fn opencode_producer_wired(opencode_plugin: Option<&str>) -> bool {
-    opencode_plugin.is_some_and(crate::setup::detect::opencode_plugin_is_ours)
 }
 
 /// Join argv into a copy-pasteable shell command. Every printed command hint
@@ -423,9 +383,7 @@ struct RunFacts {
     /// long gone — the marker they wait on will never land without help.
     resurrect_layout_defers: bool,
     permissions_kdl: Option<String>,
-    codex_hooks: Option<String>,
-    installed_plugins: Option<String>,
-    opencode_plugin: Option<String>,
+    producers: ProducerTexts,
 }
 
 /// What to launch and what to advise — the pure result of `plan_run`.
@@ -491,9 +449,7 @@ fn plan_run(facts: &RunFacts) -> RunPlan {
     if !granted {
         advisories.push(GRANT_HINT.to_string());
     }
-    let claude = claude_producer_wired(facts.installed_plugins.as_deref());
-    let opencode = opencode_producer_wired(facts.opencode_plugin.as_deref());
-    if let Some(hint) = producer_hint(facts.codex_hooks.as_deref(), claude, opencode) {
+    if let Some(hint) = producer_hint(&facts.producers.wired()) {
         advisories.push(hint);
     }
     RunPlan {
@@ -690,9 +646,7 @@ pub fn run(opts: RunOptions) {
         inside_zellij: std::env::var_os("ZELLIJ").is_some(),
         resurrect_layout_defers,
         permissions_kdl: zellij_permissions_text(),
-        codex_hooks: crate::setup::codex_hooks_text(),
-        installed_plugins: crate::setup::claude_installed_plugins_text(),
-        opencode_plugin: crate::setup::opencode_plugin_text(),
+        producers: ProducerTexts::read(),
     };
     let plan = plan_run(&facts);
 
@@ -834,7 +788,7 @@ pub fn run(opts: RunOptions) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::setup::OPENCODE_PLUGIN_MARKER;
+    use crate::setup::{CODEX_HOOK_MARKER, OPENCODE_PLUGIN_MARKER};
     use tempfile::tempdir;
 
     #[test]
@@ -1146,56 +1100,6 @@ mod tests {
     }
 
     #[test]
-    fn claude_producer_detection() {
-        let with_plugin = r#"{"plugins":["zj-radar-claude","some-other-plugin"]}"#;
-        assert!(claude_producer_wired(Some(with_plugin)));
-        let without_plugin = r#"{"plugins":["some-other-plugin","another-one"]}"#;
-        assert!(!claude_producer_wired(Some(without_plugin)));
-        assert!(!claude_producer_wired(None));
-    }
-
-    #[test]
-    fn opencode_producer_detection() {
-        let ours = format!("// {OPENCODE_PLUGIN_MARKER}\nexport const …");
-        assert!(opencode_producer_wired(Some(&ours)));
-        assert!(!opencode_producer_wired(Some("// some other plugin\n")));
-        assert!(!opencode_producer_wired(None));
-    }
-
-    #[test]
-    fn producer_hint_only_when_none_wired() {
-        let wired = format!("{CODEX_HOOK_MARKER} zj-radar notify codex");
-        assert!(producer_hint(Some(&wired), false, false).is_none());
-        assert!(producer_hint(None, true, false).is_none());
-        assert!(producer_hint(None, false, true).is_none());
-        // The hint must name EVERY wiring route — `setup <agent>` covers each
-        // agent symmetrically (claude drives Claude Code's plugin marketplace;
-        // opencode drops a vendored JS bridge into its plugins dir).
-        let hint = producer_hint(None, false, false).unwrap();
-        assert!(hint.contains("zj-radar setup codex"), "must name the Codex route: {hint}");
-        assert!(hint.contains("zj-radar setup claude"), "must name the Claude route: {hint}");
-        assert!(hint.contains("zj-radar setup opencode"), "must name the Opencode route: {hint}");
-    }
-
-    #[test]
-    fn producer_detection_covers_every_instrumented_agent() {
-        // Producer detection knows exactly three wiring routes: the Codex hooks
-        // marker (`codex_producer_wired`), the Claude plugin manifest
-        // (`claude_producer_wired`), and the opencode bridge plugin marker
-        // (`opencode_producer_wired`). This is the ONE wiring point the agent
-        // guard lattice doesn't reach: a new instrumented agent would wire
-        // fine but `run` would still say "no producer wired". If this list is
-        // out of date, teach detection the new agent's route (here, PRODUCER_HINT,
-        // and the doctor's producer item in setup/check.rs), then extend it.
-        let covered = ["claude", "codex", "opencode"];
-        let sources: Vec<&str> = crate::agents::Agent::ALL.iter().map(|a| a.source()).collect();
-        assert_eq!(
-            sources, covered,
-            "Agent::ALL grew — add a producer-detection route for the new agent"
-        );
-    }
-
-    #[test]
     fn bundled_layout_has_swaps_and_alias() {
         assert!(LAYOUT.contains("swap_tiled_layout"), "rail layout must declare swaps");
         assert!(LAYOUT.contains("location=\"radar\""), "rail must use the radar alias");
@@ -1294,9 +1198,11 @@ mod tests {
             permissions_kdl: granted.then(|| {
                 format!("\"{wasm}\" {{\n    {}\n}}\n", REQUIRED_PLUGIN_PERMISSIONS.join("\n    "))
             }),
-            codex_hooks: codex.then(|| format!("{CODEX_HOOK_MARKER} zj-radar notify codex")),
-            installed_plugins: claude.then(|| "zj-radar-claude".to_string()),
-            opencode_plugin: opencode.then(|| format!("// {OPENCODE_PLUGIN_MARKER}\n")),
+            producers: ProducerTexts {
+                codex_hooks:     codex.then(|| format!("{CODEX_HOOK_MARKER} zj-radar notify codex")),
+                claude_plugins:  claude.then(|| "zj-radar-claude".to_string()),
+                opencode_plugin: opencode.then(|| format!("// {OPENCODE_PLUGIN_MARKER}\n")),
+            },
         }
     }
 
@@ -1360,9 +1266,8 @@ mod tests {
     #[test]
     fn plan_run_is_quiet_when_only_opencode_is_wired() {
         // The opencode bridge is a producer in its own right: granted + only the
-        // opencode plugin present must yield no "no producer wired" advisory.
-        // This is the one call site exercising `RunFacts.opencode_plugin` →
-        // `opencode_producer_wired` → `producer_hint` end-to-end.
+        // opencode plugin present must yield no "no producer wired" advisory
+        // (`RunFacts.producers` → `wired()` → `producer_hint`, end-to-end).
         let p = plan_run(&facts4(true, false, false, true));
         assert!(p.advisories.is_empty(), "{:?}", p.advisories);
 

--- a/crates/cli/src/setup/analyze.rs
+++ b/crates/cli/src/setup/analyze.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use crate::agents::Agent;
+use crate::producers::ProducerTexts;
 use crate::setup::detect::{codex_hook_handler_is_ours, has_unmanaged_radar_alias, is_unmanaged_radar_alias_line, notify_is_ours, opencode_plugin_is_ours, strip_managed_zellij_alias};
 
 use std::path::{Path, PathBuf};
@@ -11,11 +13,8 @@ pub(crate) struct ZellijEnv {
     pub config_text:           Option<String>,
     pub layout_text:           Option<String>,
     pub permissions_text:      Option<String>,
-    pub codex_hooks_text:      Option<String>,
-    pub installed_plugins_text: Option<String>,
-    /// The opencode bridge plugin's text (`~/.config/opencode/plugins/zj-radar.js`),
-    /// read for producer detection — `None` when the file is absent.
-    pub opencode_plugin_text:  Option<String>,
+    /// Every producer's wiring evidence (`crate::producers`).
+    pub producers:             ProducerTexts,
     pub wasm_present:          bool,
     pub config_managed:        bool,
     pub wasm_path:             String,
@@ -49,9 +48,7 @@ pub(crate) fn read_zellij_env(config_dir: &Path, layout_name: Option<&str>) -> (
     let env = ZellijEnv {
         layout_text:            std::fs::read_to_string(&layout_path).ok(),
         permissions_text:       crate::run::zellij_permissions_text(),
-        codex_hooks_text:       codex_hooks_text(),
-        installed_plugins_text: claude_installed_plugins_text(),
-        opencode_plugin_text:   opencode_plugin_text(),
+        producers:              ProducerTexts::read(),
         wasm_present:           wasm_dest.is_file(),
         config_managed:         path_is_managed(&config_path),
         wasm_path:              wasm_dest.to_string_lossy().into_owned(),
@@ -71,19 +68,12 @@ pub(crate) struct ZellijFacts {
     pub wasm_present:            bool,
     pub has_rail:                Option<bool>,
     pub granted:                 Option<bool>,
-    pub codex_producer:          bool,
-    pub claude_producer:         bool,
-    pub opencode_producer:       bool,
+    /// The wired producers, in `Agent::ALL` order — empty means none, which
+    /// is what the doctor's pass/fail and `setup zellij`'s hint gate on; the
+    /// list lets them SAY which ones.
+    pub producers:               Vec<Agent>,
     pub config_managed:          bool,
     pub zellij_version:          Option<String>,
-}
-
-impl ZellijFacts {
-    /// Any producer at all — what install gating and the doctor's pass/fail
-    /// care about; the per-producer bools let the doctor SAY which one.
-    pub(crate) fn producer_wired(&self) -> bool {
-        self.codex_producer || self.claude_producer || self.opencode_producer
-    }
 }
 
 /// The oldest Zellij the rail works on — a floor, not a pinned minor: Zellij
@@ -174,9 +164,6 @@ pub(crate) fn analyze_zellij(env: &ZellijEnv) -> ZellijFacts {
         .permissions_text
         .as_deref()
         .map(|t| crate::run::wasm_is_granted(t, &env.wasm_path));
-    let claude_producer = crate::run::claude_producer_wired(env.installed_plugins_text.as_deref());
-    let codex_producer = crate::run::codex_producer_wired(env.codex_hooks_text.as_deref());
-    let opencode_producer = crate::run::opencode_producer_wired(env.opencode_plugin_text.as_deref());
     ZellijFacts {
         managed_alias_present,
         unmanaged_alias_present,
@@ -184,9 +171,7 @@ pub(crate) fn analyze_zellij(env: &ZellijEnv) -> ZellijFacts {
         wasm_present: env.wasm_present,
         has_rail,
         granted,
-        codex_producer,
-        claude_producer,
-        opencode_producer,
+        producers: env.producers.wired(),
         config_managed: env.config_managed,
         zellij_version: env.zellij_version.clone(),
     }
@@ -326,9 +311,7 @@ mod tests {
             config_text: Some(managed),
             layout_text: None,
             permissions_text: None,
-            codex_hooks_text: None,
-            installed_plugins_text: None,
-            opencode_plugin_text: None,
+            producers: ProducerTexts::default(),
             wasm_present: false,
             config_managed: false,
             wasm_path: "/x.wasm".to_string(),
@@ -359,9 +342,7 @@ mod tests {
             config_text: Some(config.to_string()),
             layout_text: None,
             permissions_text: None,
-            codex_hooks_text: None,
-            installed_plugins_text: None,
-            opencode_plugin_text: None,
+            producers: ProducerTexts::default(),
             wasm_present: false,
             config_managed: false,
             wasm_path: "/x.wasm".to_string(),
@@ -388,9 +369,7 @@ mod tests {
             config_text: None,
             layout_text: Some(layout.to_string()),
             permissions_text: Some(perms),
-            codex_hooks_text: None,
-            installed_plugins_text: None,
-            opencode_plugin_text: None,
+            producers: ProducerTexts::default(),
             wasm_present: true,
             config_managed: false,
             wasm_path: wasm_path.to_string(),
@@ -408,9 +387,7 @@ mod tests {
             config_text: None,
             layout_text: None,
             permissions_text: None,
-            codex_hooks_text: None,
-            installed_plugins_text: None,
-            opencode_plugin_text: None,
+            producers: ProducerTexts::default(),
             wasm_present: false,
             config_managed: false,
             wasm_path: "/x.wasm".to_string(),
@@ -419,7 +396,7 @@ mod tests {
         let f = analyze_zellij(&env);
         assert_eq!(f.has_rail, None, "no layout file -> None, distinct from Some(false)");
         assert_eq!(f.granted, None, "no permissions file -> None");
-        assert!(!f.producer_wired(), "no codex hooks and no claude plugin -> not wired");
+        assert!(f.producers.is_empty(), "no codex hooks and no claude plugin -> not wired");
     }
 
     #[test]
@@ -428,16 +405,17 @@ mod tests {
             config_text: None,
             layout_text: None,
             permissions_text: None,
-            codex_hooks_text: None,
-            installed_plugins_text: Some(r#"{"plugins":["zj-radar-claude"]}"#.to_string()),
-            opencode_plugin_text: None,
+            producers: ProducerTexts {
+                claude_plugins: Some(r#"{"plugins":["zj-radar-claude"]}"#.to_string()),
+                ..ProducerTexts::default()
+            },
             wasm_present: false,
             config_managed: false,
             wasm_path: "/x.wasm".to_string(),
             zellij_version: Some("zellij 0.44.3".to_string()),
         };
         let f = analyze_zellij(&env);
-        assert!(f.producer_wired(), "claude producer plugin present -> wired");
+        assert_eq!(f.producers, vec![Agent::Claude], "claude producer plugin present -> wired");
     }
 
     #[test]
@@ -446,16 +424,17 @@ mod tests {
             config_text: None,
             layout_text: None,
             permissions_text: None,
-            codex_hooks_text: Some(format!("{{\"command\": \"{CODEX_HOOK_MARKER} zj-radar notify codex\"}}")),
-            installed_plugins_text: None,
-            opencode_plugin_text: None,
+            producers: ProducerTexts {
+                codex_hooks: Some(format!("{{\"command\": \"{CODEX_HOOK_MARKER} zj-radar notify codex\"}}")),
+                ..ProducerTexts::default()
+            },
             wasm_present: false,
             config_managed: false,
             wasm_path: "/x.wasm".to_string(),
             zellij_version: Some("zellij 0.44.3".to_string()),
         };
         let f = analyze_zellij(&env);
-        assert!(f.producer_wired(), "codex hooks text containing the marker -> wired");
+        assert_eq!(f.producers, vec![Agent::Codex], "codex hooks text containing the marker -> wired");
     }
 
     #[test]

--- a/crates/cli/src/setup/check.rs
+++ b/crates/cli/src/setup/check.rs
@@ -136,19 +136,13 @@ pub(crate) fn zellij_check_items(f: &ZellijFacts, layout_name: &str) -> Vec<Chec
         Some(false) => CheckItem::missing("grant", "wasm not granted — run `zj-radar setup zellij -y` to pre-authorize (or `--grant` from inside Zellij)"),
     });
 
-    // 5. producer — diagnosis, not a guess: say WHICH producer the doctor saw.
-    items.push(match (f.codex_producer, f.claude_producer, f.opencode_producer) {
-        (true, true, true) => CheckItem::ok("producer", "Codex, Claude, and Opencode producers wired"),
-        (true, true, false) => CheckItem::ok("producer", "Codex hooks and Claude plugin wired"),
-        (true, false, true) => CheckItem::ok("producer", "Codex hooks and Opencode plugin wired"),
-        (false, true, true) => CheckItem::ok("producer", "Claude and Opencode plugins wired"),
-        (true, false, false) => CheckItem::ok("producer", "Codex hooks wired"),
-        (false, true, false) => CheckItem::ok("producer", "Claude plugin wired"),
-        (false, false, true) => CheckItem::ok("producer", "Opencode plugin wired"),
-        (false, false, false) => CheckItem::missing(
-            "producer",
-            "no producer detected — run `zj-radar setup claude`, `zj-radar setup codex`, or `zj-radar setup opencode`",
-        ),
+    // 5. producer — diagnosis, not a guess: say WHICH producers the doctor saw.
+    items.push(if f.producers.is_empty() {
+        let routes: Vec<String> =
+            crate::agents::Agent::ALL.iter().map(|a| format!("`zj-radar setup {}`", a.source())).collect();
+        CheckItem::missing("producer", format!("no producer detected — run one of {}", routes.join(", ")))
+    } else {
+        CheckItem::ok("producer", format!("wired: {}", crate::producers::names(&f.producers)))
     });
 
     // 6. managed config (only emit when true)
@@ -190,8 +184,7 @@ pub(crate) fn zellij_config_file_item(
 /// producer is wired through Claude Code's plugin marketplace, so the doctor
 /// has exactly two facts to verify: the binary and the installed plugin.
 pub(crate) fn check_claude() -> bool {
-    let wired =
-        crate::run::claude_producer_wired(claude_installed_plugins_text().as_deref());
+    let wired = crate::producers::ProducerTexts::read().is_wired(crate::agents::Agent::Claude);
     let items = claude_check_items(which("claude"), wired);
     println!("claude:");
     print_check_items(&items)
@@ -507,9 +500,7 @@ mod tests {
             wasm_present:            true,
             has_rail:                Some(true),
             granted:                 Some(true),
-            codex_producer:          true,
-            claude_producer:         false,
-            opencode_producer:       false,
+            producers:               vec![crate::agents::Agent::Codex],
             config_managed:          false,
             zellij_version:          Some("zellij 0.44.3".to_string()),
         }
@@ -644,12 +635,24 @@ mod tests {
 
     #[test]
     fn zellij_check_items_no_producer_is_missing() {
-        let mut f = all_good_facts();
-        f.codex_producer = false;
+        let f = ZellijFacts { producers: vec![], ..all_good_facts() };
         let items = zellij_check_items(&f, "default");
         let producer = items.iter().find(|i| i.name == "producer").expect("producer item");
         assert_eq!(producer.level, CheckLevel::Missing);
-        assert!(producer.detail.contains("setup codex"), "hint must mention setup codex");
+        for agent in crate::agents::Agent::ALL {
+            let route = format!("`zj-radar setup {}`", agent.source());
+            assert!(producer.detail.contains(&route), "hint must name the {route} route: {}", producer.detail);
+        }
+    }
+
+    #[test]
+    fn zellij_check_items_names_every_wired_producer() {
+        use crate::agents::Agent;
+        let f = ZellijFacts { producers: vec![Agent::Claude, Agent::Opencode], ..all_good_facts() };
+        let items = zellij_check_items(&f, "default");
+        let producer = items.iter().find(|i| i.name == "producer").expect("producer item");
+        assert_eq!(producer.level, CheckLevel::Ok);
+        assert_eq!(producer.detail, "wired: claude, opencode");
     }
 
     #[test]
@@ -780,8 +783,7 @@ mod tests {
             wasm_present: false,
             has_rail: Some(false),
             granted: Some(false),
-            codex_producer: false,
-            claude_producer: false,
+            producers: vec![],
             zellij_version: None,
             ..all_good_facts()
         };

--- a/crates/cli/src/setup/claude.rs
+++ b/crates/cli/src/setup/claude.rs
@@ -10,7 +10,7 @@
 use super::*;
 
 /// The plugin name as it appears installed (and in `installed_plugins.json`,
-/// where [`crate::run::claude_producer_wired`] detects it).
+/// where `crate::producers` detects it).
 pub(crate) const CLAUDE_PLUGIN: &str = "zj-radar-claude";
 
 /// The marketplace's NAME once added — Claude Code names it after the repo's
@@ -37,7 +37,7 @@ pub(crate) fn claude_installed_plugins_text() -> Option<String> {
 }
 
 pub(crate) fn setup_claude(uninstall: bool, dry_run: bool, yes: bool, is_tty: bool) {
-    let wired = crate::run::claude_producer_wired(claude_installed_plugins_text().as_deref());
+    let wired = crate::producers::ProducerTexts::read().is_wired(crate::agents::Agent::Claude);
     if uninstall {
         uninstall_claude(wired, dry_run, yes, is_tty);
     } else {

--- a/crates/cli/src/setup/detect.rs
+++ b/crates/cli/src/setup/detect.rs
@@ -29,7 +29,7 @@ pub(crate) fn codex_hook_handler_is_ours(handler: &Value) -> bool {
 
 /// True iff the opencode plugin file's text carries our ownership marker. The
 /// single reader behind `analyze_opencode`, the install/uninstall gating, the
-/// doctor, and `run`'s `opencode_producer_wired` (the `CODEX_HOOK_MARKER`
+/// doctor, and producer detection (`crate::producers`; the `CODEX_HOOK_MARKER`
 /// precedent: one shared source of truth so detection can't drift). A foreign
 /// plugin file (no marker) is never mistaken for ours.
 pub(crate) fn opencode_plugin_is_ours(plugin_text: &str) -> bool {

--- a/crates/cli/src/setup/opencode.rs
+++ b/crates/cli/src/setup/opencode.rs
@@ -185,6 +185,9 @@ pub(crate) fn setup_opencode(uninstall: bool, opts: OpencodeSetupOpts) {
         if let Err(e) = std::fs::remove_file(&path) {
             crate::exit::fail_report("opencode", format!("remove failed — {e}"));
         }
+        // The rewrite path's restore point is ours too: a clean uninstall leaves
+        // nothing of zj-radar in opencode's plugins dir.
+        let _ = std::fs::remove_file(path_with_suffix(&path, BACKUP_SUFFIX));
         println!("opencode: plugin removed ({})", path.display());
         return;
     }

--- a/crates/cli/src/setup/opencode_plugin.js
+++ b/crates/cli/src/setup/opencode_plugin.js
@@ -41,6 +41,23 @@ let CWD = "";
 // would freeze the rail on the old session forever.
 const childSessions = new Set();
 
+// Sessions already classified (child or not). The one gap in the stream is a
+// subagent *resumed* by `task_id` after an opencode restart: no
+// `session.created`, and its `chat.message` fires before `session.updated`.
+// For a never-seen session, `chat.message` asks the SDK once instead; an
+// unreachable SDK classifies it as the user's (today's behavior, never worse).
+const classifiedSessions = new Set();
+let sdk = null;
+
+async function classify(sessionID) {
+  if (typeof sessionID !== "string" || classifiedSessions.has(sessionID)) return;
+  classifiedSessions.add(sessionID);
+  try {
+    const { data } = await sdk.session.get({ sessionID });
+    if (data && data.parentID) childSessions.add(sessionID);
+  } catch {}
+}
+
 // messageID → role for the current turn. Part carries no role, and opencode
 // publishes `message.part.updated` for the user's own prompt parts too (and
 // for compaction's synthetic user message, which never passes `chat.message`)
@@ -183,14 +200,17 @@ function endTurn() {
   messageRoles.clear();
 }
 
-export const ZjRadarPlugin = async ({ directory }) => {
+export const ZjRadarPlugin = async ({ directory, client }) => {
   CWD = typeof directory === "string" ? directory : "";
+  sdk = client;
   return {
     // User submitted a prompt → running, with the prompt text for task capture.
     // Fires before the message is stored, so the role is known before any of
     // its parts arrive via `message.part.updated`.
     "chat.message": async (input, output) => {
-      if (!output || isChild(input && input.sessionID)) return;
+      const sessionID = input && input.sessionID;
+      await classify(sessionID);
+      if (!output || isChild(sessionID)) return;
       lastAssistantText = "";
       if (output.message && output.message.id) messageRoles.set(output.message.id, "user");
       enqueue("running", { event: "chat.message", prompt: promptText(output.parts) });
@@ -235,12 +255,15 @@ export const ZjRadarPlugin = async ({ directory }) => {
         // Learn subagent sessions from their lifecycle; forget them on delete.
         case "session.created":
         case "session.updated":
-          if (props.info && props.info.parentID && sessionID) {
+          if (!sessionID) break;
+          classifiedSessions.add(sessionID);
+          if (props.info && props.info.parentID) {
             childSessions.add(sessionID);
             return;
           }
           break;
         case "session.deleted":
+          classifiedSessions.delete(sessionID);
           if (childSessions.delete(sessionID)) return;
           break;
       }

--- a/crates/cli/src/setup/zellij.rs
+++ b/crates/cli/src/setup/zellij.rs
@@ -528,22 +528,18 @@ fn print_grant_hint_if_needed(facts: &ZellijFacts) {
     );
 }
 
-/// Emit a producer hint at the tail of `setup zellij` when no producer is wired,
-/// per `facts.producer_wired` (derived from Codex hooks + the Claude plugin
-/// manifest + the opencode bridge plugin, same as `run`'s detection — see
-/// `analyze_zellij`).
+/// Emit a producer hint at the tail of `setup zellij`: the full "no producer
+/// wired" hint when nothing is, else one note per agent that is on PATH but
+/// not wired (same detection as `run` and the doctor — `crate::producers`).
 fn print_producer_hint_if_needed(facts: &ZellijFacts) {
-    if !facts.producer_wired() {
-        println!("zellij: {}", crate::run::PRODUCER_HINT);
-    } else {
-        if which("opencode") && !facts.opencode_producer {
-            println!("zellij: note: opencode found on PATH but bridge plugin not installed — run `zj-radar setup opencode`");
-        }
-        if which("claude") && !facts.claude_producer {
-            println!("zellij: note: claude found on PATH but plugin not installed — run `zj-radar setup claude`");
-        }
-        if which("codex") && !facts.codex_producer {
-            println!("zellij: note: codex found on PATH but hooks not installed — run `zj-radar setup codex`");
+    if let Some(hint) = crate::producers::producer_hint(&facts.producers) {
+        println!("zellij: {hint}");
+        return;
+    }
+    for agent in crate::agents::Agent::ALL {
+        let name = agent.source();
+        if which(name) && !facts.producers.contains(agent) {
+            println!("zellij: note: {name} found on PATH but not wired — run `zj-radar setup {name}`");
         }
     }
 }

--- a/crates/cli/tests/cli_setup.rs
+++ b/crates/cli/tests/cli_setup.rs
@@ -1598,3 +1598,111 @@ fn setup_zellij_dry_run_never_contradicts_itself_about_the_grant() {
         "the BLANK-rail warning contradicts the would-pre-authorize line; stdout:\n{stdout}"
     );
 }
+
+// ── opencode: the vendored bridge plugin under $XDG_CONFIG_HOME/opencode ─────
+//
+// `opencode_installed()` accepts a populated config dir, so an empty
+// `<xdg>/opencode/` stands in for the binary. The marker is the header line
+// the CLI keys idempotency / --uninstall / --check on.
+
+const OPENCODE_MARKER: &str = "ZJ_RADAR_OPENCODE_PLUGIN=v1";
+
+fn isolated_opencode_xdg() -> (TempDir, std::path::PathBuf) {
+    let xdg = TempDir::new().unwrap();
+    fs::create_dir_all(xdg.path().join("opencode")).unwrap();
+    let plugin = xdg.path().join("opencode/plugins/zj-radar.js");
+    (xdg, plugin)
+}
+
+fn opencode_cmd(xdg: &TempDir, args: &[&str]) -> assert_cmd::assert::Assert {
+    Command::cargo_bin("zj-radar")
+        .unwrap()
+        .args(["setup", "opencode"])
+        .args(args)
+        .env("XDG_CONFIG_HOME", xdg.path())
+        .env("HOME", xdg.path())
+        .assert()
+}
+
+#[test]
+fn setup_opencode_installs_the_marked_bridge_and_is_idempotent() {
+    let (xdg, plugin) = isolated_opencode_xdg();
+    let bak = plugin.with_file_name("zj-radar.js.zj-radar.bak");
+
+    opencode_cmd(&xdg, &["--yes"]).success();
+    let first = fs::read_to_string(&plugin).unwrap();
+    assert!(first.contains(OPENCODE_MARKER), "install must write the marked bridge: {first:?}");
+    assert!(!bak.exists(), "a fresh install has nothing to back up");
+
+    let out = opencode_cmd(&xdg, &["--yes"]).success().get_output().clone();
+    assert_eq!(fs::read_to_string(&plugin).unwrap(), first, "second run must be a no-op");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("already up to date"), "stdout:\n{stdout}");
+    assert!(!stdout.contains("restart opencode"), "nothing was written, so no restart hint:\n{stdout}");
+}
+
+#[test]
+fn setup_opencode_refuses_a_foreign_plugin_unless_forced() {
+    let (xdg, plugin) = isolated_opencode_xdg();
+    fs::create_dir_all(plugin.parent().unwrap()).unwrap();
+    fs::write(&plugin, "export const Other = async () => ({});\n").unwrap();
+
+    opencode_cmd(&xdg, &["--yes"]).failure();
+    assert!(!fs::read_to_string(&plugin).unwrap().contains(OPENCODE_MARKER), "refused: file untouched");
+
+    opencode_cmd(&xdg, &["--yes", "--force"]).success();
+    assert!(fs::read_to_string(&plugin).unwrap().contains(OPENCODE_MARKER));
+    let bak = plugin.with_file_name("zj-radar.js.zj-radar.bak");
+    assert!(bak.exists(), "--force over a foreign file keeps a restore point");
+}
+
+#[test]
+fn setup_opencode_uninstall_removes_the_bridge_and_its_backup() {
+    let (xdg, plugin) = isolated_opencode_xdg();
+    fs::create_dir_all(plugin.parent().unwrap()).unwrap();
+    fs::write(&plugin, format!("// {OPENCODE_MARKER}\n// stale ours\n")).unwrap();
+    opencode_cmd(&xdg, &["--yes"]).success(); // stale-ours rewrite leaves a .bak
+    let bak = plugin.with_file_name("zj-radar.js.zj-radar.bak");
+    assert!(bak.exists(), "precondition: the rewrite backed up the stale bridge");
+
+    opencode_cmd(&xdg, &["--uninstall", "--yes"]).success();
+    assert!(!plugin.exists(), "uninstall removes the bridge");
+    assert!(!bak.exists(), "uninstall removes its backup too — a clean uninstall leaves nothing of ours");
+}
+
+#[test]
+fn setup_opencode_uninstall_without_consent_leaves_the_bridge() {
+    let (xdg, plugin) = isolated_opencode_xdg();
+    opencode_cmd(&xdg, &["--yes"]).success();
+
+    // Non-tty, no -y: same skip as every other setup write/remove.
+    let out = opencode_cmd(&xdg, &["--uninstall"]).success().get_output().clone();
+    assert!(plugin.exists(), "declined uninstall must not delete");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("skipped"), "stdout:\n{stdout}");
+}
+
+#[test]
+fn setup_opencode_dry_run_writes_nothing() {
+    let (xdg, plugin) = isolated_opencode_xdg();
+    let out = opencode_cmd(&xdg, &["--dry-run"]).success().get_output().clone();
+    assert!(!plugin.exists());
+    assert!(!plugin.parent().unwrap().exists(), "dry-run must not create the plugins dir either");
+    assert!(String::from_utf8_lossy(&out.stdout).contains(OPENCODE_MARKER));
+}
+
+#[test]
+fn setup_opencode_check_reports_the_bridge_state() {
+    // The binary item stays Missing here (no `opencode` on the test PATH), so
+    // the doctor exits non-zero throughout; the plugin item is what flips.
+    let (xdg, _plugin) = isolated_opencode_xdg();
+    let out = opencode_cmd(&xdg, &["--check"]).failure().get_output().clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("missing plugin:"), "stdout:\n{stdout}");
+    assert!(stdout.contains("`zj-radar setup opencode`"), "the remedy must be named:\n{stdout}");
+
+    opencode_cmd(&xdg, &["--yes"]).success();
+    let out = opencode_cmd(&xdg, &["--check"]).failure().get_output().clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("ok plugin: zj-radar bridge plugin installed"), "stdout:\n{stdout}");
+}

--- a/docs/producers.md
+++ b/docs/producers.md
@@ -89,9 +89,9 @@ writes one entry per event across seven hook events (`UserPromptSubmit`,
 ## Opencode
 
 [Opencode](https://opencode.ai) auto-loads JS plugins from its global plugins
-dir, so wiring is one file drop — **no `opencode.json` editing**; uninstall
-deletes that file (a `.zj-radar.bak` from an earlier rewrite may remain, and
-opencode ignores it):
+dir, so wiring is one file drop — **no `opencode.json` editing**, and
+`--uninstall` removes that file (and the `.zj-radar.bak` an earlier rewrite
+left beside it):
 
 ```sh
 zj-radar setup opencode
@@ -142,6 +142,15 @@ blank-permission backstop — so the JS never grows a second classifier.
   Claude. The minimum verified opencode version is 1.18.x (the plugin is
   vendored per zj-radar release; re-running `setup opencode` heals drift via
   the marker rewrite).
+- **The bridge runs where the server runs.** The default `opencode` TUI hosts
+  its server in-process, so status lands on that pane. With `opencode serve`
+  plus `opencode attach`, the plugin runs in the *server's* process: status is
+  attributed to the server's pane, or dropped when the server isn't under
+  Zellij.
+- **Slash commands label the task with their expansion.** opencode expands a
+  `/command` template before the bridge sees the prompt (there is no marker
+  left on the message), so the sticky task line reads the template's first
+  line rather than skipping the command the way Claude's producer does.
 
 ## Any script: `zj-radar notify generic`
 


### PR DESCRIPTION
## What & why

Follow-ups deferred from the PR #27 (OpenCode producer) reviews, done with an eye to simplification.

**One producers module.** Producer detection had a positional-bool copy per consumer: three `*_producer_wired` fns + `PRODUCER_HINT` in run.rs, three bools on `ZellijFacts`, three text fields on `ZellijEnv` and `RunFacts`, an 8-arm tuple match in the doctor, a hand-typed per-agent loop in `setup zellij`, and a `covered` list test to keep them in step. `crates/cli/src/producers.rs` replaces all of it: `ProducerTexts` (evidence, read once) → `wired() -> Vec<Agent>` with an exhaustive `match Agent`, so a fourth producer is a compile error. Doctor prints `wired: codex, opencode`; its remedy list derives from `Agent::ALL`.

**Bridge: subagent resumed by `task_id`.** After an opencode restart a resumed child announces no `session.created` and its `chat.message` fires before `session.updated`, so it slipped the child filter. The bridge asks the SDK once per never-seen session (`client.session.get` → `parentID`); an unreachable SDK means "the user's session" (today's behavior, never worse).

**`setup opencode --uninstall`** removes the `.zj-radar.bak` the rewrite path leaves.

**Tests:** six opencode integration tests in `cli_setup.rs` (install + idempotency, foreign refusal/`--force`, uninstall + .bak, declined uninstall, dry-run, `--check`); the bun harness gains the SDK-classify cases (16/16, run locally — no JS test infra in-repo).

**Docs:** the `opencode serve`/`attach` pane-attribution caveat, and the slash-command task-label limitation — opencode expands the template before the bridge sees it and leaves no marker on the message (verified against `prompt.ts` `command()`), so it is documented rather than papered over.

## Checklist
- [x] `cargo test --workspace`, clippy `-D warnings`, wasm build green locally
- [x] No `cargo fmt`
- [x] Tests at the right layer (unit in producers.rs/check.rs/analyze.rs; integration in cli_setup.rs)
- [x] Docs updated (producers.md)
- [x] Push-driven + rail lockstep untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)