### PR TITLE
chore: bump to v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3332,7 +3332,7 @@ dependencies = [
 
 [[package]]
 name = "zj-radar"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "assert_cmd",
  "clap 4.6.1",
@@ -3347,7 +3347,7 @@ dependencies = [
 
 [[package]]
 name = "zj-radar-core"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "proptest",
  "serde",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "zj-radar-plugin"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "insta",
  "portable-pty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/core", "crates/cli", "crates/plugin"]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/marktoda/zj-radar"
@@ -22,7 +22,7 @@ rust-version = "1.95"
 # would let an older published CLI resolve a newer, incompatible core and stop
 # compiling. Bump this in lockstep with [workspace.package] version — the
 # release checklist (RELEASING.md) walks through it.
-zj-radar-core = { path = "crates/core", version = "=0.4.1" }
+zj-radar-core = { path = "crates/core", version = "=0.5.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 unicode-width = "0.2"

--- a/plugins/zj-radar-claude/.claude-plugin/plugin.json
+++ b/plugins/zj-radar-claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zj-radar-claude",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Broadcast Claude Code agent status to the zj-radar Zellij sidebar (working/waiting/done), with zero settings.json editing.",
   "author": { "name": "Mark Toda" },
   "homepage": "https://github.com/marktoda/zj-radar"


### PR DESCRIPTION
Version bump for the v0.5.0 release: OpenCode as producer #3 (PR #27, #32).

Bumps `[workspace.package] version`, the exact `zj-radar-core` pin, and `plugins/zj-radar-claude/.claude-plugin/plugin.json` together (RELEASING.md step 1). `just ci` green locally (incl. the 72-case bats suite).

After merge: publish core → CLI, signed tag `v0.5.0`, watch `release.yml` + `verify-funnel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)