### PR TITLE
feat(cli): zj-radar update — move CLI and sidebar wasm together

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ zj-radar setup opencode  # Opencode bridge plugin; then restart opencode
 ```
 
 Want to look before you commit? `zj-radar run` starts a throwaway session with
-the rail wired in and leaves your config alone. Source builds, Nix, manual
-setup, and the full removal list are in
+the rail wired in and leaves your config alone. Later, `zj-radar update` moves
+the CLI and the sidebar to the latest release together. Source builds, Nix,
+manual setup, and the full removal list are in
 [`docs/install.md`](https://github.com/marktoda/zj-radar/blob/main/docs/install.md).
 
 ## What you get

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,6 +1,6 @@
 //! Native CLI (`zj-radar`): the host front door for the sidebar.
 //!
-//! Three subcommands, one per module:
+//! Four subcommands, one per module:
 //! - `notify <agent>` ([`notify`]) — the *pushed* information source. Reads an
 //!   agent's hook payload and broadcasts a `zj_radar.status.v1` update. Each
 //!   agent is a peer adapter behind the [`agents::Agent::derive`] seam, so
@@ -11,6 +11,9 @@
 //!   into a Zellij layout ([`layout`]).
 //! - `run` ([`run`]) — turnkey launch of a Zellij session that owns its own
 //!   config with the rail preinstalled.
+//! - `update` ([`update`]) — move the CLI and the sidebar wasm to a newer
+//!   release together (self-replace, then re-exec `setup zellij --download`);
+//!   hands Nix/cargo-managed binaries back to their package manager.
 
 // Re-export the shared core so the CLI submodules keep addressing these as
 // `crate::status`, `crate::payload`, … with no per-reference churn.

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -32,6 +32,7 @@ mod notify;
 mod producers;
 mod run;
 mod setup;
+mod update;
 
 /// Process-wide failure flag. The setup/run orchestrators report refusals and
 /// write failures by printing a diagnostic and returning early through several
@@ -157,6 +158,14 @@ enum Command {
         #[arg(long, conflicts_with_all = ["wasm", "download", "inject", "layout", "uninstall", "dry_run", "check"])]
         grant: bool,
     },
+    /// Update the CLI and the sidebar wasm to the latest release together
+    /// (set ZJ_RADAR_VERSION to pin a specific release tag).
+    Update {
+        /// Report whether an update is available without writing anything;
+        /// exits non-zero when one is.
+        #[arg(long)]
+        check: bool,
+    },
 }
 
 /// CLI entry point (called by `src/main.rs`). Returns the process exit code:
@@ -226,6 +235,9 @@ pub fn run() -> std::process::ExitCode {
                 layout: layout.as_deref(),
                 grant,
             });
+        }
+        Command::Update { check } => {
+            update::run(update::UpdateOptions { check });
         }
     }
     if exit::failed() {

--- a/crates/cli/src/setup/download.rs
+++ b/crates/cli/src/setup/download.rs
@@ -9,11 +9,13 @@ use std::path::{Path, PathBuf};
 /// different versions otherwise can). Pure so the version→asset mapping is
 /// unit-tested; the fetch itself is thin IO below.
 fn wasm_release_url(version: &str) -> String {
-    format!(
-        "https://github.com/{}/releases/download/v{version}/{}",
-        repo_slug(),
-        crate::WASM_FILE_NAME
-    )
+    release_asset_url(version, crate::WASM_FILE_NAME)
+}
+
+/// Any asset of the `v{version}` GitHub release — the one place the URL shape
+/// lives (the wasm here, the CLI tarball in `update`).
+pub(crate) fn release_asset_url(version: &str, asset: &str) -> String {
+    format!("https://github.com/{}/releases/download/v{version}/{asset}", repo_slug())
 }
 
 /// The `.sha256` sidecar published next to the wasm asset (same release, same
@@ -98,18 +100,17 @@ pub(crate) fn checksum_url(asset_url: &str) -> String {
 }
 
 /// Fetch the published digest for an asset, or `None` when the release has no
-/// sidecar (predates checksums) or it is unreadable. Stages the sidecar next to
-/// `beside` (a user-owned dir on every call path) rather than at a predictable
-/// shared-temp path another local user could pre-plant.
-pub(crate) fn fetch_published_sha256(sidecar_url: &str, beside: &Path) -> Option<String> {
-    let name = beside.file_name().and_then(|n| n.to_str())?;
-    let sidecar = beside.with_file_name(format!("{name}.sha256"));
-    let _ = std::fs::remove_file(&sidecar); // clear any stale sidecar first
-    if !try_download(sidecar_url, &sidecar) {
+/// sidecar (predates checksums) or it is unreadable. `stage_at` is where the
+/// sidecar lands in transit — a user-owned dir on every call path (next to the
+/// asset being verified, or the private download dir), never a predictable
+/// shared-temp path another local user could pre-plant. Removed afterwards.
+pub(crate) fn fetch_published_sha256(sidecar_url: &str, stage_at: &Path) -> Option<String> {
+    let _ = std::fs::remove_file(stage_at); // clear any stale sidecar first
+    if !try_download(sidecar_url, stage_at) {
         return None;
     }
-    let expected = std::fs::read_to_string(&sidecar).ok().and_then(|s| parse_sha256(&s));
-    let _ = std::fs::remove_file(&sidecar);
+    let expected = std::fs::read_to_string(stage_at).ok().and_then(|s| parse_sha256(&s));
+    let _ = std::fs::remove_file(stage_at);
     expected
 }
 
@@ -124,10 +125,11 @@ pub(crate) fn fetch_published_sha256(sidecar_url: &str, beside: &Path) -> Option
 /// floor, and every new release publishes the sidecar (see
 /// `.github/workflows/release.yml`), so absence is the exception, not the norm.
 fn verify_checksum(sidecar_url: &str, asset: &Path, describe: &str) -> Result<(), String> {
-    if asset.file_name().and_then(|n| n.to_str()).is_none() {
+    let Some(name) = asset.file_name().and_then(|n| n.to_str()) else {
         return Err(format!("invalid asset path {}", asset.display()));
-    }
-    let Some(expected) = fetch_published_sha256(sidecar_url, asset) else {
+    };
+    let stage_at = asset.with_file_name(format!("{name}.sha256"));
+    let Some(expected) = fetch_published_sha256(sidecar_url, &stage_at) else {
         eprintln!(
             "zj-radar: warning — no readable checksum published for {describe}; \
              installed file is TLS-verified only (integrity not checked)"
@@ -249,7 +251,7 @@ fn run_download(url: &str, dest: &Path) -> Result<(), String> {
             Err(format!("wget failed for {url}"))
         };
     }
-    Err("need curl or wget on PATH to --download".to_string())
+    Err("need curl or wget on PATH to download".to_string())
 }
 
 /// Best-effort HTTPS fetch for *optional* assets (the checksum sidecar): returns

--- a/crates/cli/src/setup/download.rs
+++ b/crates/cli/src/setup/download.rs
@@ -17,9 +17,9 @@ fn wasm_release_url(version: &str) -> String {
 }
 
 /// The `.sha256` sidecar published next to the wasm asset (same release, same
-/// version). Generated and uploaded by `.github/workflows/release.yml`.
-fn wasm_checksum_url(version: &str) -> String {
-    format!("{}.sha256", wasm_release_url(version))
+/// version). Also what `update --check` compares the installed wasm against.
+pub(crate) fn wasm_checksum_url(version: &str) -> String {
+    checksum_url(&wasm_release_url(version))
 }
 
 /// The `owner/repo` slug release assets are fetched from. Defaults to the
@@ -41,30 +41,37 @@ pub(crate) fn repo_slug() -> String {
     }
 }
 
-/// Fetch the wasm matching `version` to `dest` (creating its parent dir). Shells
-/// out to curl (or wget) rather than linking a Rust TLS stack — keeping the host
-/// build free of openssl/rustls, and curl is already assumed by the install flow.
+/// Fetch the wasm matching `version` to `dest` (creating its parent dir).
 /// Shared by `setup zellij --download` and `run`'s first-use fallback (when the
 /// CLI shipped without an embedded wasm).
 pub(crate) fn download_wasm_to(version: &str, dest: &Path) -> Result<(), String> {
-    if let Some(parent) = dest.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| format!("create dir failed — {e}"))?;
-    }
-    let url = wasm_release_url(version);
     // Progress is prose → stderr: `run` reaches this download BEFORE its
     // `--print-cmd` branch prints, so anything on stdout here would be
     // captured by `$(zj-radar run --print-cmd)` and corrupt the command.
-    eprintln!("zj-radar: downloading wasm {version} from {url}");
-    // Download to a `.part` sibling and rename into place only after the
-    // transfer AND checksum both succeed. curl/wget write `dest` incrementally,
-    // so an interrupted transfer straight to `dest` would leave a partial file
-    // that the `exists()`/up-to-date gates treat as a valid wasm forever after —
-    // and Zellij would then load it with permissions.
+    eprintln!("zj-radar: downloading wasm {version} from {}", wasm_release_url(version));
+    download_verified_asset(&wasm_release_url(version), dest, &format!("zj_radar.wasm v{version}"))
+}
+
+/// Fetch a release asset at `url` to `dest` (creating its parent dir) and
+/// verify it against the `.sha256` sidecar published beside it. Shells out to
+/// curl (or wget) rather than linking a Rust TLS stack — keeping the host build
+/// free of openssl/rustls, and curl is already assumed by the install flow.
+/// `describe` names the asset in diagnostics (e.g. `zj_radar.wasm v0.5.0`).
+///
+/// The transfer lands in a `.part` sibling and is renamed into place only
+/// after the download AND checksum both succeed. curl/wget write incrementally,
+/// so an interrupted transfer straight to `dest` would leave a partial file
+/// that the `exists()`/up-to-date gates treat as a valid asset forever after —
+/// and Zellij would then load a partial wasm with permissions.
+pub(crate) fn download_verified_asset(url: &str, dest: &Path, describe: &str) -> Result<(), String> {
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create dir failed — {e}"))?;
+    }
     let part = match dest.file_name().and_then(|n| n.to_str()) {
         Some(name) => dest.with_file_name(format!("{name}.part")),
         None => return Err(format!("invalid download destination {}", dest.display())),
     };
-    let fetched = run_download(&url, &part)
+    let fetched = run_download(url, &part)
         .and_then(|()| {
             if !part.is_file() {
                 return Err(format!(
@@ -72,7 +79,7 @@ pub(crate) fn download_wasm_to(version: &str, dest: &Path) -> Result<(), String>
                     part.display()
                 ));
             }
-            verify_checksum(version, &part)
+            verify_checksum(&checksum_url(url), &part, describe)
         })
         .and_then(|()| {
             std::fs::rename(&part, dest)
@@ -84,53 +91,65 @@ pub(crate) fn download_wasm_to(version: &str, dest: &Path) -> Result<(), String>
     fetched
 }
 
-/// Verify the freshly-downloaded wasm against its published `.sha256` sidecar.
-///
-/// Strict when the sidecar is fetchable: a mismatch is a hard error and the bad
-/// wasm is removed — Zellij runs this wasm with permissions, so a payload that
-/// doesn't match its published digest must never be installed. When the sidecar
-/// is absent (a release predating checksums) or no local sha256 tool is on PATH,
-/// this warns and continues rather than blocking install — TLS + GitHub release
-/// storage remain the floor, and every new release publishes the sidecar (see
-/// `.github/workflows/release.yml`), so absence is the exception, not the norm.
-fn verify_checksum(version: &str, wasm: &Path) -> Result<(), String> {
-    // The sidecar stages NEXT TO the wasm being verified (a user-owned dir on
-    // every call path: the private download dir, or the owned config dir), not
-    // at a predictable shared-temp path another local user could pre-plant.
-    let Some(name) = wasm.file_name().and_then(|n| n.to_str()) else {
-        return Err(format!("invalid wasm path {}", wasm.display()));
-    };
-    let sidecar = wasm.with_file_name(format!("{name}.sha256"));
+/// The `.sha256` sidecar `.github/workflows/release.yml` publishes next to
+/// every binary asset (wasm and CLI tarballs alike).
+pub(crate) fn checksum_url(asset_url: &str) -> String {
+    format!("{asset_url}.sha256")
+}
+
+/// Fetch the published digest for an asset, or `None` when the release has no
+/// sidecar (predates checksums) or it is unreadable. Stages the sidecar next to
+/// `beside` (a user-owned dir on every call path) rather than at a predictable
+/// shared-temp path another local user could pre-plant.
+pub(crate) fn fetch_published_sha256(sidecar_url: &str, beside: &Path) -> Option<String> {
+    let name = beside.file_name().and_then(|n| n.to_str())?;
+    let sidecar = beside.with_file_name(format!("{name}.sha256"));
     let _ = std::fs::remove_file(&sidecar); // clear any stale sidecar first
-    if !try_download(&wasm_checksum_url(version), &sidecar) {
-        eprintln!(
-            "zj-radar: warning — no checksum published for v{version}; \
-             installed wasm is TLS-verified only (integrity not checked)"
-        );
-        return Ok(());
+    if !try_download(sidecar_url, &sidecar) {
+        return None;
     }
     let expected = std::fs::read_to_string(&sidecar).ok().and_then(|s| parse_sha256(&s));
     let _ = std::fs::remove_file(&sidecar);
-    let Some(expected) = expected else {
-        eprintln!("zj-radar: warning — checksum for v{version} was unreadable; skipping integrity check");
+    expected
+}
+
+/// Verify a freshly-downloaded asset against its published `.sha256` sidecar.
+///
+/// Strict when the sidecar is fetchable: a mismatch is a hard error and the bad
+/// file is removed — Zellij runs the wasm with permissions and the CLI tarball
+/// becomes an executable, so a payload that doesn't match its published digest
+/// must never be installed. When the sidecar is absent (a release predating
+/// checksums) or no local sha256 tool is on PATH, this warns and continues
+/// rather than blocking install — TLS + GitHub release storage remain the
+/// floor, and every new release publishes the sidecar (see
+/// `.github/workflows/release.yml`), so absence is the exception, not the norm.
+fn verify_checksum(sidecar_url: &str, asset: &Path, describe: &str) -> Result<(), String> {
+    if asset.file_name().and_then(|n| n.to_str()).is_none() {
+        return Err(format!("invalid asset path {}", asset.display()));
+    }
+    let Some(expected) = fetch_published_sha256(sidecar_url, asset) else {
+        eprintln!(
+            "zj-radar: warning — no readable checksum published for {describe}; \
+             installed file is TLS-verified only (integrity not checked)"
+        );
         return Ok(());
     };
-    let Some(actual) = compute_sha256(wasm) else {
+    let Some(actual) = compute_sha256(asset) else {
         eprintln!(
             "zj-radar: warning — no sha256 tool (sha256sum/shasum) on PATH; \
-             skipping integrity check for v{version}"
+             skipping integrity check for {describe}"
         );
         return Ok(());
     };
     if actual.eq_ignore_ascii_case(&expected) {
         // Prose → stderr, like the download progress line above.
-        eprintln!("zj-radar: wasm checksum verified");
+        eprintln!("zj-radar: {describe} checksum verified");
         Ok(())
     } else {
-        let _ = std::fs::remove_file(wasm); // don't leave a mismatched wasm staged
+        let _ = std::fs::remove_file(asset); // don't leave a mismatched file staged
         Err(format!(
-            "checksum mismatch for zj_radar.wasm v{version}\n  expected {expected}\n  got      {actual}\n\
-             Refusing to install a wasm that does not match its published checksum."
+            "checksum mismatch for {describe}\n  expected {expected}\n  got      {actual}\n\
+             Refusing to install a file that does not match its published checksum."
         ))
     }
 }
@@ -148,7 +167,7 @@ fn parse_sha256(raw: &str) -> Option<String> {
 /// (Linux/coreutils), else `shasum -a 256` (macOS). `None` when neither is on
 /// PATH. Shelling out keeps the host build free of a crypto dependency, the same
 /// reason the download itself uses curl/wget rather than a Rust TLS stack.
-fn compute_sha256(path: &Path) -> Option<String> {
+pub(crate) fn compute_sha256(path: &Path) -> Option<String> {
     use std::process::Command;
     let out = if which("sha256sum") {
         Command::new("sha256sum").arg(path).output().ok()?
@@ -176,7 +195,7 @@ pub(crate) fn download_wasm(version: &str) -> Result<PathBuf, String> {
 /// verification and the install copy (TOCTOU) by another local user. Fails
 /// closed: if the dir can't be made ours-only (someone else owns the name, or
 /// it's a symlink), we refuse rather than stage downloads in it.
-fn private_download_dir() -> Result<PathBuf, String> {
+pub(crate) fn private_download_dir() -> Result<PathBuf, String> {
     let user = std::env::var("USER").unwrap_or_else(|_| "user".to_string());
     let dir = std::env::temp_dir().join(format!("zj-radar-{user}"));
     std::fs::create_dir_all(&dir)
@@ -212,8 +231,7 @@ fn run_download(url: &str, dest: &Path) -> Result<(), String> {
             Ok(())
         } else {
             Err(format!(
-                "curl failed for {url} — is v{} released? See https://github.com/{}/releases",
-                env!("CARGO_PKG_VERSION"),
+                "curl failed for {url} — is that release published? See https://github.com/{}/releases",
                 repo_slug()
             ))
         };

--- a/crates/cli/src/setup/zellij.rs
+++ b/crates/cli/src/setup/zellij.rs
@@ -167,6 +167,44 @@ pub(crate) fn path_is_managed(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// Install `src` at `wasm_dest` on the re-run path — the alias was already in
+/// config.kdl, so no config write (and no prompt) follows, but the wasm just
+/// passed or downloaded may be newer than the one on disk. Every upgrade goes
+/// through here: `zj-radar update` re-execs `setup zellij --download` for
+/// exactly this. Identical bytes are left alone (no rewrite, no message); a
+/// symlinked destination gets the same Nix / home-manager guard as config.kdl
+/// (a rename would replace the link with a file the next switch reverts). The
+/// write is atomic — a live session may load the wasm mid-copy otherwise.
+fn refresh_wasm(src: Option<&Path>, wasm_dest: &Path, dry_run: bool) {
+    let Some(src) = src else { return }; // no wasm source: uninstall, or a dry-run --download
+    if path_is_managed(wasm_dest) {
+        eprintln!(
+            "zellij: wasm at {} is a symlink (managed by Nix / home-manager) — zj-radar will not \
+             overwrite it; update the wasm via your Nix config instead. See docs/install.md.",
+            wasm_dest.display()
+        );
+        return;
+    }
+    let bytes = match std::fs::read(src) {
+        Ok(b) => b,
+        Err(e) => {
+            crate::exit::fail_report("zellij", format!("could not read wasm {} — {e}", src.display()));
+            return;
+        }
+    };
+    if std::fs::read(wasm_dest).is_ok_and(|current| current == bytes) {
+        return;
+    }
+    if dry_run {
+        println!("zellij: would copy {} -> {} (dry-run)", src.display(), wasm_dest.display());
+        return;
+    }
+    match crate::fsutil::atomic_write(wasm_dest, &bytes) {
+        Ok(()) => println!("zellij: wasm updated at {}", wasm_dest.display()),
+        Err(e) => crate::exit::fail_report("zellij", format!("wasm copy failed — {e}")),
+    }
+}
+
 /// Refusal for a bare `setup zellij` with no wasm source: name the install
 /// routes AND the supported wasm-less invocations, so the message is a menu,
 /// not a dead end.
@@ -357,6 +395,9 @@ pub(crate) fn setup_zellij(uninstall: bool, opts: ZellijSetupOpts<'_>) {
                 "zellij: config already up to date ({})",
                 config_path.display()
             );
+            // The alias is in place, but the wasm may not be the one just
+            // passed/downloaded — this arm is every upgrade's path.
+            refresh_wasm(src, &wasm_dest, dry_run);
             // alias already up to date — still offer injection and the grant.
             run_layout_inject(&layout_path, inject_flag, yes, dry_run, is_tty);
             if !run_preseed(&wasm_dest, facts.granted, yes, dry_run, is_tty) {
@@ -414,7 +455,10 @@ pub(crate) fn setup_zellij(uninstall: bool, opts: ZellijSetupOpts<'_>) {
                         .map_err(|e| format!("create plugin dir failed — {e}"))?;
                 }
                 let src = src.ok_or("refused — pass --wasm <path-to-zj_radar.wasm> or --download")?;
-                std::fs::copy(src, &wasm_dest).map_err(|e| format!("wasm copy failed — {e}"))?;
+                // Atomic (read + temp-file rename), not `fs::copy` onto the
+                // destination: a live session may load the wasm mid-copy.
+                let bytes = std::fs::read(src).map_err(|e| format!("could not read wasm {} — {e}", src.display()))?;
+                crate::fsutil::atomic_write(&wasm_dest, &bytes).map_err(|e| format!("wasm copy failed — {e}"))?;
                 Ok(())
             };
             if !confirm_and_write("zellij", &config_path, &new, yes, is_tty, &prompt, copy_wasm) {

--- a/crates/cli/src/update.rs
+++ b/crates/cli/src/update.rs
@@ -53,8 +53,11 @@ pub fn run(options: UpdateOptions) {
             "update",
             format!(
                 "ZJ_RADAR_VERSION=v{target} is older than this CLI (v{current}) — update only moves forward. \
-                 To downgrade, reinstall that release: ZJ_RADAR_VERSION=v{target} …/install.sh | sh, \
-                 then `zj-radar setup zellij --download`"
+                 To downgrade, reinstall that release:\n  \
+                 ZJ_RADAR_VERSION=v{target} curl --proto '=https' --tlsv1.2 -LsSf \
+                 https://github.com/{}/releases/latest/download/install.sh | sh\n  \
+                 zj-radar setup zellij --download",
+                crate::setup::repo_slug()
             ),
         );
         return;
@@ -75,22 +78,27 @@ pub fn run(options: UpdateOptions) {
         }
         WasmState::Current => println!("wasm: matches v{target} (up to date)"),
         WasmState::Stale => println!("wasm: differs from v{target} — will be refreshed"),
-        WasmState::Unknown(why) => println!("wasm: could not compare ({why})"),
+        WasmState::Unknown(why) => println!("wasm: could not compare ({why}) — will be refreshed"),
     }
 
     let wasm_stale = wasm == WasmState::Stale;
     if options.check {
-        if cli_behind {
-            println!("run `zj-radar update` to apply");
-            crate::exit::fail_report("update", format!("v{target} is available"));
+        let behind = if cli_behind {
+            Some(format!("v{target} is available"))
         } else if wasm_stale {
+            Some(format!("the installed sidebar wasm does not match v{target}"))
+        } else {
+            None
+        };
+        if let Some(why) = behind {
             println!("run `zj-radar update` to apply");
-            crate::exit::fail_report("update", format!("the installed sidebar wasm does not match v{target}"));
+            crate::exit::fail_report("update", why);
         }
         return;
     }
 
-    if !cli_behind && !wasm_stale {
+    let refresh_wasm = needs_wasm_refresh(&wasm);
+    if !cli_behind && !refresh_wasm {
         println!("zj-radar: everything is up to date");
         return;
     }
@@ -119,29 +127,41 @@ pub fn run(options: UpdateOptions) {
 
     // The pin travels with the re-exec so a release landing between the
     // lookup above and this step can't split the two halves across versions.
-    let mut refreshed_wasm = false;
-    if wasm != WasmState::NotInstalled {
-        refreshed_wasm = rerun(&exe, &target, &["setup", "zellij", "--download", "-y"]);
-    }
-    if cli_behind {
-        // Producer wiring is idempotent and cheap; a release may have changed
-        // the codex hook shape or the vendored opencode bridge.
-        rerun(&exe, &target, &["setup", "-y"]);
-    }
-    if refreshed_wasm {
+    if refresh_wasm && rerun(&exe, &target, &["setup", "zellij", "--download", "-y"]) && wasm_stale {
         println!("zj-radar: restart Zellij (or open a new session) to load the updated sidebar");
     }
     if cli_behind {
+        // Re-wire only the producers already wired — a release may have changed
+        // the codex hook shape or the vendored opencode bridge — never one the
+        // user hasn't chosen (bare `setup` would install for every agent on PATH).
+        let wired = crate::producers::ProducerTexts::read().wired();
+        if !wired.is_empty() {
+            let mut args = vec!["setup"];
+            args.extend(wired.iter().map(|a| a.source()));
+            args.push("-y");
+            rerun(&exe, &target, &args);
+        }
         println!("zj-radar: the Claude Code plugin updates from inside Claude — `/plugin update zj-radar-claude@zj-radar`");
     }
     // The doctor's exit code grades install completeness (a machine with no
     // producer wired reads "missing"), not this update — its items are the
     // report; only a failure to *run* it is ours.
-    let _ = std::process::Command::new(&exe)
+    if let Err(e) = std::process::Command::new(&exe)
         .args(["setup", "--check"])
         .env("ZJ_RADAR_VERSION", &target)
         .status()
-        .map_err(|e| crate::exit::fail_report("update", format!("could not run {} — {e}", exe.display())));
+    {
+        crate::exit::fail_report("update", format!("could not run {} — {e}", exe.display()));
+    }
+}
+
+/// Which wasm states `setup zellij --download` should be re-run for: a real
+/// file that differs from the target, or one we couldn't compare (setup itself
+/// skips identical bytes, so the re-run is harmless when it turns out current).
+/// Never a symlink — home-manager owns it — and never a missing file, which is
+/// a `setup` decision the user hasn't made yet.
+fn needs_wasm_refresh(wasm: &WasmState) -> bool {
+    matches!(wasm, WasmState::Stale | WasmState::Unknown(_))
 }
 
 /// Run a follow-up `zj-radar` step through `exe`, inheriting stdio so its own
@@ -173,6 +193,13 @@ fn target_version() -> Result<String, String> {
     if let Ok(v) = std::env::var("ZJ_RADAR_VERSION") {
         let v = v.trim_start_matches('v');
         if !v.is_empty() {
+            // Validate here so a prerelease or typo is named as such, rather
+            // than failing the `is_newer` comparison and reading as "older".
+            if parse_version(v).is_none() {
+                return Err(format!(
+                    "ZJ_RADAR_VERSION={v} is not a MAJOR.MINOR.PATCH release version (e.g. v0.5.0)"
+                ));
+            }
             return Ok(v.to_string());
         }
     }
@@ -228,11 +255,11 @@ fn wasm_state(target: &str) -> WasmState {
     if !installed.is_file() {
         return WasmState::NotInstalled;
     }
-    let staging = match crate::setup::private_download_dir() {
-        Ok(dir) => dir.join(crate::WASM_FILE_NAME),
+    let sidecar = match crate::setup::private_download_dir() {
+        Ok(dir) => dir.join(format!("{}.sha256", crate::WASM_FILE_NAME)),
         Err(e) => return WasmState::Unknown(e),
     };
-    let Some(expected) = crate::setup::fetch_published_sha256(&crate::setup::wasm_checksum_url(target), &staging)
+    let Some(expected) = crate::setup::fetch_published_sha256(&crate::setup::wasm_checksum_url(target), &sidecar)
     else {
         return WasmState::Unknown(format!("no published checksum for v{target}"));
     };
@@ -367,10 +394,7 @@ pub(crate) fn is_newer(candidate: &str, current: &str) -> bool {
 /// The release tarball for a CLI version and Rust target triple — the same
 /// naming `scripts/install.sh` and `[package.metadata.binstall]` use.
 pub(crate) fn cli_release_url(version: &str, triple: &str) -> String {
-    format!(
-        "https://github.com/{}/releases/download/v{version}/zj-radar-{triple}.tar.gz",
-        crate::setup::repo_slug()
-    )
+    crate::setup::release_asset_url(version, &format!("zj-radar-{triple}.tar.gz"))
 }
 
 /// The Rust target triple the release workflow publishes for this host, fixed
@@ -523,6 +547,17 @@ mod tests {
             cli_release_url("0.5.1", "aarch64-apple-darwin"),
             "https://github.com/marktoda/zj-radar/releases/download/v0.5.1/zj-radar-aarch64-apple-darwin.tar.gz"
         );
+    }
+
+    #[test]
+    fn wasm_refresh_runs_only_for_a_real_file_that_differs_or_cannot_be_compared() {
+        assert!(needs_wasm_refresh(&WasmState::Stale));
+        assert!(needs_wasm_refresh(&WasmState::Unknown("no checksum".into())));
+        // Current: nothing to do. NotInstalled: a setup job, not ours. Managed:
+        // home-manager's — writing through the symlink is the bug this guards.
+        assert!(!needs_wasm_refresh(&WasmState::Current));
+        assert!(!needs_wasm_refresh(&WasmState::NotInstalled));
+        assert!(!needs_wasm_refresh(&WasmState::Managed));
     }
 
     #[test]

--- a/crates/cli/src/update.rs
+++ b/crates/cli/src/update.rs
@@ -23,6 +23,10 @@ pub(crate) struct UpdateOptions {
 #[derive(Debug, PartialEq, Eq)]
 enum WasmState {
     NotInstalled,
+    /// A symlink (home-manager / Nix): the same guard `setup zellij` applies to
+    /// a symlinked config.kdl — writing through it is reverted on the next
+    /// switch, and the bytes are that build's, not the release's.
+    Managed,
     Current,
     Stale,
     /// Couldn't tell (no config dir, no published checksum, no sha256 tool).
@@ -40,6 +44,21 @@ pub fn run(options: UpdateOptions) {
         }
     };
     let cli_behind = is_newer(&target, current);
+    // Forward only: a pin older than this CLI would refresh the wasm to the
+    // pin while the binary stays put — exactly the version split `update`
+    // exists to prevent. Downgrades go through the installer, which replaces
+    // the CLI first (then `setup zellij --download` follows its version).
+    if !cli_behind && target != current {
+        crate::exit::fail_report(
+            "update",
+            format!(
+                "ZJ_RADAR_VERSION=v{target} is older than this CLI (v{current}) — update only moves forward. \
+                 To downgrade, reinstall that release: ZJ_RADAR_VERSION=v{target} …/install.sh | sh, \
+                 then `zj-radar setup zellij --download`"
+            ),
+        );
+        return;
+    }
     if cli_behind {
         println!("cli:  v{current} → v{target} available");
     } else {
@@ -51,6 +70,9 @@ pub fn run(options: UpdateOptions) {
         WasmState::NotInstalled => {
             println!("wasm: not installed — run `zj-radar setup zellij --download` to add the sidebar")
         }
+        WasmState::Managed => {
+            println!("wasm: a symlink (managed by Nix / home-manager) — update it through your Nix config")
+        }
         WasmState::Current => println!("wasm: matches v{target} (up to date)"),
         WasmState::Stale => println!("wasm: differs from v{target} — will be refreshed"),
         WasmState::Unknown(why) => println!("wasm: could not compare ({why})"),
@@ -58,9 +80,12 @@ pub fn run(options: UpdateOptions) {
 
     let wasm_stale = wasm == WasmState::Stale;
     if options.check {
-        if cli_behind || wasm_stale {
+        if cli_behind {
             println!("run `zj-radar update` to apply");
-            crate::exit::fail_report("update", "a newer release is available");
+            crate::exit::fail_report("update", format!("v{target} is available"));
+        } else if wasm_stale {
+            println!("run `zj-radar update` to apply");
+            crate::exit::fail_report("update", format!("the installed sidebar wasm does not match v{target}"));
         }
         return;
     }
@@ -109,12 +134,19 @@ pub fn run(options: UpdateOptions) {
     if cli_behind {
         println!("zj-radar: the Claude Code plugin updates from inside Claude — `/plugin update zj-radar-claude@zj-radar`");
     }
-    rerun(&exe, &target, &["setup", "--check"]);
+    // The doctor's exit code grades install completeness (a machine with no
+    // producer wired reads "missing"), not this update — its items are the
+    // report; only a failure to *run* it is ours.
+    let _ = std::process::Command::new(&exe)
+        .args(["setup", "--check"])
+        .env("ZJ_RADAR_VERSION", &target)
+        .status()
+        .map_err(|e| crate::exit::fail_report("update", format!("could not run {} — {e}", exe.display())));
 }
 
 /// Run a follow-up `zj-radar` step through `exe`, inheriting stdio so its own
 /// output lands in the user's terminal. `false` (with the failure reported)
-/// when it didn't exit cleanly — steps after it still run, since a doctor
+/// when it didn't exit cleanly — steps after it still run, since the doctor
 /// report is most useful exactly when something went wrong.
 fn rerun(exe: &Path, target: &str, args: &[&str]) -> bool {
     println!("zj-radar: running `zj-radar {}`", args.join(" "));
@@ -190,6 +222,9 @@ fn wasm_state(target: &str) -> WasmState {
         return WasmState::Unknown("no Zellij config dir — set $HOME".to_string());
     };
     let installed = crate::setup::zellij_wasm_dest(&config_dir);
+    if crate::setup::path_is_managed(&installed) {
+        return WasmState::Managed;
+    }
     if !installed.is_file() {
         return WasmState::NotInstalled;
     }

--- a/crates/cli/src/update.rs
+++ b/crates/cli/src/update.rs
@@ -1,0 +1,585 @@
+//! `zj-radar update` — move the CLI and the sidebar wasm to a newer release
+//! together.
+//!
+//! The two halves share the status contract and setup expectations, so they
+//! must move as one: the CLI is replaced in place, then the *new* binary is
+//! re-executed to run `setup zellij --download` (fetching the wasm built from
+//! its own version) and the idempotent producer setups. `--check` reports both
+//! halves without writing — the wasm half by comparing the installed file's
+//! sha256 against the release's published sidecar, so a wasm that drifted from
+//! the CLI shows up even when the CLI itself is current.
+//!
+//! `update` moves what is *installed*: a missing sidebar is a `setup` job, and
+//! a binary owned by Nix or cargo is handed back to that tool rather than
+//! overwritten behind its back (see [`InstallKind`]).
+
+use std::path::{Path, PathBuf};
+
+pub(crate) struct UpdateOptions {
+    pub check: bool,
+}
+
+/// Where the installed sidebar wasm stands relative to the target release.
+#[derive(Debug, PartialEq, Eq)]
+enum WasmState {
+    NotInstalled,
+    Current,
+    Stale,
+    /// Couldn't tell (no config dir, no published checksum, no sha256 tool).
+    Unknown(String),
+}
+
+/// Entry point for `zj-radar update`.
+pub fn run(options: UpdateOptions) {
+    let current = env!("CARGO_PKG_VERSION");
+    let target = match target_version() {
+        Ok(v) => v,
+        Err(e) => {
+            crate::exit::fail_report("update", e);
+            return;
+        }
+    };
+    let cli_behind = is_newer(&target, current);
+    if cli_behind {
+        println!("cli:  v{current} → v{target} available");
+    } else {
+        println!("cli:  v{current} (up to date)");
+    }
+
+    let wasm = wasm_state(&target);
+    match &wasm {
+        WasmState::NotInstalled => {
+            println!("wasm: not installed — run `zj-radar setup zellij --download` to add the sidebar")
+        }
+        WasmState::Current => println!("wasm: matches v{target} (up to date)"),
+        WasmState::Stale => println!("wasm: differs from v{target} — will be refreshed"),
+        WasmState::Unknown(why) => println!("wasm: could not compare ({why})"),
+    }
+
+    let wasm_stale = wasm == WasmState::Stale;
+    if options.check {
+        if cli_behind || wasm_stale {
+            println!("run `zj-radar update` to apply");
+            crate::exit::fail_report("update", "a newer release is available");
+        }
+        return;
+    }
+
+    if !cli_behind && !wasm_stale {
+        println!("zj-radar: everything is up to date");
+        return;
+    }
+
+    // Which binary runs the follow-up setup steps: the freshly installed one
+    // when the CLI moved (so the wasm it fetches matches ITS version), else
+    // this one.
+    let exe = if cli_behind {
+        match self_replace(&target) {
+            Ok(Some(exe)) => exe,
+            Ok(None) => return, // handed off to Nix/cargo — printed already
+            Err(e) => {
+                crate::exit::fail_report("update", e);
+                return;
+            }
+        }
+    } else {
+        match std::env::current_exe() {
+            Ok(exe) => exe,
+            Err(e) => {
+                crate::exit::fail_report("update", format!("could not locate this executable — {e}"));
+                return;
+            }
+        }
+    };
+
+    // The pin travels with the re-exec so a release landing between the
+    // lookup above and this step can't split the two halves across versions.
+    let mut refreshed_wasm = false;
+    if wasm != WasmState::NotInstalled {
+        refreshed_wasm = rerun(&exe, &target, &["setup", "zellij", "--download", "-y"]);
+    }
+    if cli_behind {
+        // Producer wiring is idempotent and cheap; a release may have changed
+        // the codex hook shape or the vendored opencode bridge.
+        rerun(&exe, &target, &["setup", "-y"]);
+    }
+    if refreshed_wasm {
+        println!("zj-radar: restart Zellij (or open a new session) to load the updated sidebar");
+    }
+    if cli_behind {
+        println!("zj-radar: the Claude Code plugin updates from inside Claude — `/plugin update zj-radar-claude@zj-radar`");
+    }
+    rerun(&exe, &target, &["setup", "--check"]);
+}
+
+/// Run a follow-up `zj-radar` step through `exe`, inheriting stdio so its own
+/// output lands in the user's terminal. `false` (with the failure reported)
+/// when it didn't exit cleanly — steps after it still run, since a doctor
+/// report is most useful exactly when something went wrong.
+fn rerun(exe: &Path, target: &str, args: &[&str]) -> bool {
+    println!("zj-radar: running `zj-radar {}`", args.join(" "));
+    match std::process::Command::new(exe)
+        .args(args)
+        .env("ZJ_RADAR_VERSION", target)
+        .status()
+    {
+        Ok(s) if s.success() => true,
+        Ok(s) => {
+            crate::exit::fail_report("update", format!("`zj-radar {}` exited with {s}", args.join(" ")));
+            false
+        }
+        Err(e) => {
+            crate::exit::fail_report("update", format!("could not run {} — {e}", exe.display()));
+            false
+        }
+    }
+}
+
+/// The release to move to: `ZJ_RADAR_VERSION` when pinned (no network), else
+/// whatever GitHub's `releases/latest` redirects to.
+fn target_version() -> Result<String, String> {
+    if let Ok(v) = std::env::var("ZJ_RADAR_VERSION") {
+        let v = v.trim_start_matches('v');
+        if !v.is_empty() {
+            return Ok(v.to_string());
+        }
+    }
+    latest_release_version()
+}
+
+/// Ask GitHub for the latest release tag by following the `releases/latest`
+/// redirect (HEAD only, no API call — so no token, no rate-limit budget).
+fn latest_release_version() -> Result<String, String> {
+    use std::process::Command;
+    let url = format!("https://github.com/{}/releases/latest", crate::setup::repo_slug());
+    let effective = if crate::setup::which("curl") {
+        let out = Command::new("curl")
+            .args(["--proto", "=https", "--proto-redir", "=https", "--tlsv1.2", "-fsSLI", "-o", "/dev/null", "-w", "%{url_effective}"])
+            .arg(&url)
+            .output()
+            .map_err(|e| format!("failed to run curl — {e}"))?;
+        if !out.status.success() {
+            return Err(format!("could not reach {url} to find the latest release"));
+        }
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    } else if crate::setup::which("wget") {
+        // `--spider -S` prints the response headers (stderr); the last
+        // `Location:` is the redirect target.
+        let out = Command::new("wget")
+            .args(["--https-only", "--spider", "-S", "-q"])
+            .arg(&url)
+            .output()
+            .map_err(|e| format!("failed to run wget — {e}"))?;
+        let headers = String::from_utf8_lossy(&out.stderr);
+        headers
+            .lines()
+            .filter_map(|l| l.trim().strip_prefix("Location: "))
+            .next_back()
+            .map(|s| s.trim().to_string())
+            .ok_or_else(|| format!("could not reach {url} to find the latest release"))?
+    } else {
+        return Err("need curl or wget on PATH to look up the latest release".to_string());
+    };
+    tag_from_latest_redirect(&effective)
+        .ok_or_else(|| format!("could not read a release version from {effective}"))
+}
+
+/// Compare the installed wasm's sha256 with the digest published for `target`.
+fn wasm_state(target: &str) -> WasmState {
+    let Some(config_dir) = crate::setup::zellij_config_dir() else {
+        return WasmState::Unknown("no Zellij config dir — set $HOME".to_string());
+    };
+    let installed = crate::setup::zellij_wasm_dest(&config_dir);
+    if !installed.is_file() {
+        return WasmState::NotInstalled;
+    }
+    let staging = match crate::setup::private_download_dir() {
+        Ok(dir) => dir.join(crate::WASM_FILE_NAME),
+        Err(e) => return WasmState::Unknown(e),
+    };
+    let Some(expected) = crate::setup::fetch_published_sha256(&crate::setup::wasm_checksum_url(target), &staging)
+    else {
+        return WasmState::Unknown(format!("no published checksum for v{target}"));
+    };
+    let Some(actual) = crate::setup::compute_sha256(&installed) else {
+        return WasmState::Unknown("no sha256 tool (sha256sum/shasum) on PATH".to_string());
+    };
+    if actual.eq_ignore_ascii_case(&expected) {
+        WasmState::Current
+    } else {
+        WasmState::Stale
+    }
+}
+
+/// Replace this executable with the `target` release build. `Ok(None)` when
+/// the binary belongs to a package manager and the hand-off was printed;
+/// `Ok(Some(path))` with the (unchanged) executable path once the new binary
+/// sits there.
+fn self_replace(target: &str) -> Result<Option<PathBuf>, String> {
+    let exe = std::env::current_exe()
+        .and_then(|p| p.canonicalize())
+        .map_err(|e| format!("could not locate this executable — {e}"))?;
+    let cargo_home = std::env::var_os("CARGO_HOME").map(PathBuf::from);
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    match classify_install(&exe, cargo_home.as_deref(), home.as_deref()) {
+        InstallKind::Nix => {
+            println!(
+                "zj-radar: this binary is managed by Nix ({}) — update the zj-radar input in your flake instead",
+                exe.display()
+            );
+            return Ok(None);
+        }
+        InstallKind::Cargo => {
+            println!(
+                "zj-radar: this binary is managed by cargo ({}) — run `cargo install zj-radar` \
+                 (or `cargo binstall zj-radar`), then `zj-radar setup zellij --download`",
+                exe.display()
+            );
+            return Ok(None);
+        }
+        InstallKind::SelfManaged => {}
+    }
+    let Some(triple) = target_triple() else {
+        return Err(
+            "no prebuilt binary is published for this platform — build from source: \
+             cargo install zj-radar, then zj-radar setup zellij --download"
+                .to_string(),
+        );
+    };
+    let staging = crate::setup::private_download_dir()?.join(format!("cli-{target}"));
+    let tarball = staging.join(format!("zj-radar-{triple}.tar.gz"));
+    let url = cli_release_url(target, triple);
+    eprintln!("zj-radar: downloading zj-radar v{target} ({triple}) from {url}");
+    let installed = crate::setup::download_verified_asset(&url, &tarball, &format!("zj-radar v{target} ({triple})"))
+        .and_then(|()| extract_cli_tarball(&tarball, &staging))
+        .and_then(|bin| replace_binary(&bin, &exe));
+    let _ = std::fs::remove_dir_all(&staging);
+    installed?;
+    println!("zj-radar: installed v{target} to {}", exe.display());
+    Ok(Some(exe))
+}
+
+/// How this binary got onto the machine — decides whether `update` may
+/// overwrite it. Classified from the executable's path alone (no package
+/// database is consulted), so it is unit-testable and cheap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InstallKind {
+    /// Under `/nix/store`: immutable, owned by the user's flake — never write.
+    Nix,
+    /// Under cargo's bin dir: `cargo install` tracks this binary in
+    /// `.crates.toml`; overwriting it behind cargo's back would leave cargo's
+    /// record lying about the version.
+    Cargo,
+    /// Anything else (the curl|sh installer's `~/.local/bin`, a hand copy):
+    /// ours to replace in place.
+    SelfManaged,
+}
+
+/// Classify `exe` (already canonicalized by the caller) against the two
+/// package-manager locations we refuse to write into. `cargo_home` is
+/// `$CARGO_HOME` when set; the default `~/.cargo` derives from `home`.
+pub(crate) fn classify_install(exe: &Path, cargo_home: Option<&Path>, home: Option<&Path>) -> InstallKind {
+    if exe.starts_with("/nix/store") {
+        return InstallKind::Nix;
+    }
+    let cargo_bin = match (cargo_home, home) {
+        (Some(c), _) => Some(c.join("bin")),
+        (None, Some(h)) => Some(h.join(".cargo").join("bin")),
+        (None, None) => None,
+    };
+    // `exe` arrives canonical (symlinks resolved), so the candidate must be
+    // compared in the same form — `$HOME` through a symlink (macOS `/var` →
+    // `/private/var`, a symlinked home dir) would otherwise never prefix-match
+    // and a cargo-managed binary would be overwritten. A dir that doesn't exist
+    // can't contain `exe`, so the raw path is fine there.
+    let cargo_bin = cargo_bin.map(|b| b.canonicalize().unwrap_or(b));
+    if cargo_bin.is_some_and(|b| exe.starts_with(b)) {
+        return InstallKind::Cargo;
+    }
+    InstallKind::SelfManaged
+}
+
+/// The version behind GitHub's `releases/latest` redirect: its target is
+/// `…/releases/tag/<tag>`, so the tag is the last non-empty path segment.
+/// `None` when the URL isn't a tag page (a repo with no releases lands on the
+/// releases index) or the tag isn't a plain `MAJOR.MINOR.PATCH` version we can
+/// compare against. A leading `v` is optional, matching `ZJ_RADAR_VERSION`.
+pub(crate) fn tag_from_latest_redirect(url_effective: &str) -> Option<String> {
+    let (_, tag) = url_effective.trim_end_matches('/').rsplit_once("/releases/tag/")?;
+    let version = tag.trim_start_matches('v');
+    parse_version(version).map(|_| version.to_string())
+}
+
+/// `MAJOR.MINOR.PATCH` as numbers; `None` for anything else (prerelease tags,
+/// `nightly`, garbage). Releases here are always plain triples, so a stricter
+/// parser is simpler than a semver dependency and fails closed on surprises.
+fn parse_version(v: &str) -> Option<[u64; 3]> {
+    let mut parts = v.split('.').map(|p| p.parse::<u64>().ok());
+    let out = [parts.next()??, parts.next()??, parts.next()??];
+    parts.next().is_none().then_some(out)
+}
+
+/// Is `candidate` strictly newer than `current`? Unparseable input on either
+/// side is "not newer" — the safe answer for a tool that would otherwise
+/// download and replace a binary.
+pub(crate) fn is_newer(candidate: &str, current: &str) -> bool {
+    match (parse_version(candidate), parse_version(current)) {
+        (Some(c), Some(cur)) => c > cur,
+        _ => false,
+    }
+}
+
+/// The release tarball for a CLI version and Rust target triple — the same
+/// naming `scripts/install.sh` and `[package.metadata.binstall]` use.
+pub(crate) fn cli_release_url(version: &str, triple: &str) -> String {
+    format!(
+        "https://github.com/{}/releases/download/v{version}/zj-radar-{triple}.tar.gz",
+        crate::setup::repo_slug()
+    )
+}
+
+/// The Rust target triple the release workflow publishes for this host, fixed
+/// at compile time (no `uname` parsing). `None` where no prebuilt binary
+/// exists — Intel macOS and anything the installer doesn't cover.
+pub(crate) fn target_triple() -> Option<&'static str> {
+    if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+        Some("x86_64-unknown-linux-musl")
+    } else if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
+        Some("aarch64-unknown-linux-musl")
+    } else if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        Some("aarch64-apple-darwin")
+    } else {
+        None
+    }
+}
+
+/// Unpack a release tarball into `out` with the system `tar` (already a hard
+/// requirement of the installer, and it keeps this crate free of an archive
+/// dependency) and return the path of the `zj-radar` binary it contained.
+pub(crate) fn extract_cli_tarball(tarball: &Path, out: &Path) -> Result<PathBuf, String> {
+    std::fs::create_dir_all(out).map_err(|e| format!("create {} failed — {e}", out.display()))?;
+    let status = std::process::Command::new("tar")
+        .arg("-xzf")
+        .arg(tarball)
+        .arg("-C")
+        .arg(out)
+        .status()
+        .map_err(|e| format!("failed to run tar — {e}"))?;
+    if !status.success() {
+        return Err(format!("tar failed to unpack {}", tarball.display()));
+    }
+    let bin = out.join("zj-radar");
+    if !bin.is_file() {
+        return Err(format!("archive {} did not contain a zj-radar binary", tarball.display()));
+    }
+    Ok(bin)
+}
+
+/// Install `fresh` over `current` without a window where `current` is missing
+/// or half-written. The staged copy is written as a sibling (`zj-radar.new`)
+/// so the final `rename` is a same-filesystem atomic swap; the running process
+/// keeps its mapped inode and only the *next* invocation sees the new binary
+/// — the property a self-updater needs on both Linux and macOS. Any failure
+/// removes the staging file so nothing stale sits next to the binary.
+pub(crate) fn replace_binary(fresh: &Path, current: &Path) -> Result<(), String> {
+    let Some(name) = current.file_name().and_then(|n| n.to_str()) else {
+        return Err(format!("invalid binary path {}", current.display()));
+    };
+    let staged = current.with_file_name(format!("{name}.new"));
+    let result = std::fs::copy(fresh, &staged)
+        .map_err(|e| format!("staging into {} failed — {e}", current.parent().unwrap_or(current).display()))
+        .and_then(|_| {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o755))
+                    .map_err(|e| format!("chmod {} failed — {e}", staged.display()))?;
+            }
+            std::fs::rename(&staged, current)
+                .map_err(|e| format!("replacing {} failed — {e}", current.display()))
+        });
+    if result.is_err() {
+        let _ = std::fs::remove_file(&staged);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn tag_from_latest_redirect_parses_the_tag_page_url() {
+        assert_eq!(
+            tag_from_latest_redirect("https://github.com/marktoda/zj-radar/releases/tag/v0.5.1"),
+            Some("0.5.1".to_string())
+        );
+        // A trailing slash or a tag without the `v` prefix still resolves.
+        assert_eq!(
+            tag_from_latest_redirect("https://github.com/o/r/releases/tag/0.6.0/"),
+            Some("0.6.0".to_string())
+        );
+    }
+
+    #[test]
+    fn tag_from_latest_redirect_rejects_non_tag_urls() {
+        // No releases yet: GitHub serves the releases index instead of redirecting.
+        assert_eq!(tag_from_latest_redirect("https://github.com/o/r/releases"), None);
+        assert_eq!(tag_from_latest_redirect("https://github.com/o/r/releases/latest"), None);
+        assert_eq!(tag_from_latest_redirect(""), None);
+        // A tag that isn't a version is not something we can compare against.
+        assert_eq!(tag_from_latest_redirect("https://github.com/o/r/releases/tag/nightly"), None);
+    }
+
+    #[test]
+    fn is_newer_compares_numeric_semver_components() {
+        assert!(is_newer("0.5.1", "0.5.0"));
+        assert!(is_newer("0.10.0", "0.9.9")); // numeric, not lexical
+        assert!(is_newer("1.0.0", "0.99.99"));
+        assert!(!is_newer("0.5.0", "0.5.0"));
+        assert!(!is_newer("0.4.9", "0.5.0"));
+    }
+
+    #[test]
+    fn is_newer_treats_unparseable_versions_as_not_newer() {
+        assert!(!is_newer("nightly", "0.5.0"));
+        assert!(!is_newer("0.5.1", "garbage"));
+    }
+
+    #[test]
+    fn classify_install_recognizes_nix_store_paths() {
+        let exe = Path::new("/nix/store/abc123-zj-radar-cli-0.5.0/bin/zj-radar");
+        assert_eq!(classify_install(exe, None, Some(Path::new("/home/u"))), InstallKind::Nix);
+    }
+
+    #[test]
+    fn classify_install_recognizes_cargo_bin_via_cargo_home_then_default() {
+        let home = Path::new("/home/u");
+        // Explicit CARGO_HOME wins.
+        let exe = Path::new("/opt/cargo/bin/zj-radar");
+        assert_eq!(classify_install(exe, Some(Path::new("/opt/cargo")), Some(home)), InstallKind::Cargo);
+        // Default ~/.cargo/bin when CARGO_HOME is unset.
+        let exe = Path::new("/home/u/.cargo/bin/zj-radar");
+        assert_eq!(classify_install(exe, None, Some(home)), InstallKind::Cargo);
+    }
+
+    #[test]
+    fn classify_install_defaults_to_self_managed() {
+        let home = Path::new("/home/u");
+        assert_eq!(
+            classify_install(Path::new("/home/u/.local/bin/zj-radar"), None, Some(home)),
+            InstallKind::SelfManaged
+        );
+        assert_eq!(
+            classify_install(Path::new("/usr/local/bin/zj-radar"), None, None),
+            InstallKind::SelfManaged
+        );
+        // A `.cargo` directory elsewhere in the path is not cargo's bin dir.
+        assert_eq!(
+            classify_install(Path::new("/home/u/.cargo-backup/zj-radar"), None, Some(home)),
+            InstallKind::SelfManaged
+        );
+    }
+
+    #[test]
+    fn cli_release_urls_follow_the_release_asset_naming() {
+        assert_eq!(
+            cli_release_url("0.5.1", "aarch64-apple-darwin"),
+            "https://github.com/marktoda/zj-radar/releases/download/v0.5.1/zj-radar-aarch64-apple-darwin.tar.gz"
+        );
+    }
+
+    #[test]
+    fn replace_binary_swaps_contents_atomically_and_keeps_exec_bit() {
+        let dir = tempfile::tempdir().unwrap();
+        let current = dir.path().join("bin").join("zj-radar");
+        std::fs::create_dir_all(current.parent().unwrap()).unwrap();
+        std::fs::write(&current, b"old").unwrap();
+        let fresh = dir.path().join("staged").join("zj-radar");
+        std::fs::create_dir_all(fresh.parent().unwrap()).unwrap();
+        std::fs::write(&fresh, b"new").unwrap();
+
+        replace_binary(&fresh, &current).unwrap();
+
+        assert_eq!(std::fs::read(&current).unwrap(), b"new");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&current).unwrap().permissions().mode();
+            assert_eq!(mode & 0o111, 0o111, "installed binary must be executable (mode {mode:o})");
+        }
+        // No staging leftovers next to the binary.
+        let siblings: Vec<_> = std::fs::read_dir(current.parent().unwrap())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().into_string().unwrap())
+            .collect();
+        assert_eq!(siblings, vec!["zj-radar".to_string()]);
+    }
+
+    #[test]
+    fn replace_binary_reports_an_unwritable_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let fresh = dir.path().join("zj-radar.new");
+        std::fs::write(&fresh, b"new").unwrap();
+        // A destination whose parent doesn't exist can't be renamed into.
+        let current = dir.path().join("missing-dir").join("zj-radar");
+        let err = replace_binary(&fresh, &current).unwrap_err();
+        assert!(err.contains("missing-dir"), "error should name the destination: {err}");
+    }
+
+    /// Build a `.tar.gz` holding the given entries with the system `tar`, the
+    /// same tool the extractor shells out to.
+    fn make_tarball(dir: &Path, entries: &[(&str, &[u8])]) -> std::path::PathBuf {
+        let src = dir.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        for (name, bytes) in entries {
+            std::fs::write(src.join(name), bytes).unwrap();
+        }
+        let tarball = dir.join("zj-radar-test.tar.gz");
+        let status = std::process::Command::new("tar")
+            .arg("-czf")
+            .arg(&tarball)
+            .arg("-C")
+            .arg(&src)
+            .args(entries.iter().map(|(n, _)| *n))
+            .status()
+            .unwrap();
+        assert!(status.success());
+        tarball
+    }
+
+    #[test]
+    fn extract_cli_tarball_returns_the_binary_inside() {
+        let dir = tempfile::tempdir().unwrap();
+        let tarball = make_tarball(dir.path(), &[("zj-radar", b"#!/bin/sh\necho hi\n")]);
+        let out = dir.path().join("out");
+        let bin = extract_cli_tarball(&tarball, &out).unwrap();
+        assert_eq!(bin, out.join("zj-radar"));
+        assert_eq!(std::fs::read(&bin).unwrap(), b"#!/bin/sh\necho hi\n");
+    }
+
+    #[test]
+    fn extract_cli_tarball_rejects_an_archive_without_the_binary() {
+        let dir = tempfile::tempdir().unwrap();
+        let tarball = make_tarball(dir.path(), &[("README", b"nope")]);
+        let err = extract_cli_tarball(&tarball, &dir.path().join("out")).unwrap_err();
+        assert!(err.contains("zj-radar"), "error should say what was missing: {err}");
+    }
+
+    #[test]
+    fn target_triple_is_one_of_the_published_release_targets() {
+        // Whatever host runs this test must map onto a triple the release
+        // workflow publishes (or None where we ship no prebuilt binary).
+        let published = [
+            "x86_64-unknown-linux-musl",
+            "aarch64-unknown-linux-musl",
+            "aarch64-apple-darwin",
+        ];
+        let has_prebuilt = cfg!(unix) && !cfg!(all(target_os = "macos", target_arch = "x86_64"));
+        assert_eq!(target_triple().is_some(), has_prebuilt);
+        if let Some(t) = target_triple() {
+            assert!(published.contains(&t), "unexpected triple {t}");
+        }
+    }
+}

--- a/crates/cli/tests/cli_setup.rs
+++ b/crates/cli/tests/cli_setup.rs
@@ -1706,3 +1706,84 @@ fn setup_opencode_check_reports_the_bridge_state() {
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("ok plugin: zj-radar bridge plugin installed"), "stdout:\n{stdout}");
 }
+
+// ── re-running setup zellij with a new wasm refreshes the installed file ────
+//
+// The alias in config.kdl is already managed on every machine that ran setup
+// once, so the second run lands in the "config already up to date" arm. That
+// arm must still install a NEW wasm — `zj-radar update` relies on exactly this
+// re-run to move the sidebar, and until it did, "re-run setup zellij
+// --download" upgraded nothing.
+
+fn setup_zellij_wasm(config_dir: &TempDir, wasm: &std::path::Path) -> assert_cmd::assert::Assert {
+    Command::cargo_bin("zj-radar")
+        .unwrap()
+        .args(["setup", "zellij", "--wasm"])
+        .arg(wasm)
+        .arg("--yes")
+        .env("ZELLIJ_CONFIG_DIR", config_dir.path())
+        .assert()
+}
+
+#[test]
+fn setup_zellij_rerun_with_a_different_wasm_replaces_the_installed_one() {
+    let config_dir = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let a = src.path().join("a.wasm");
+    let b = src.path().join("b.wasm");
+    fs::write(&a, b"\0asm-A").unwrap();
+    fs::write(&b, b"\0asm-B").unwrap();
+    let dest = config_dir.path().join("plugins").join("zj_radar.wasm");
+
+    setup_zellij_wasm(&config_dir, &a).success();
+    assert_eq!(fs::read(&dest).unwrap(), b"\0asm-A");
+
+    let out = setup_zellij_wasm(&config_dir, &b).success().get_output().clone();
+    assert_eq!(fs::read(&dest).unwrap(), b"\0asm-B", "second run must install the new wasm");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("wasm updated"), "should say the wasm was refreshed: {stdout}");
+}
+
+#[test]
+fn setup_zellij_rerun_with_the_same_wasm_does_not_rewrite() {
+    let config_dir = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let a = src.path().join("a.wasm");
+    fs::write(&a, b"\0asm-A").unwrap();
+    let dest = config_dir.path().join("plugins").join("zj_radar.wasm");
+
+    setup_zellij_wasm(&config_dir, &a).success();
+    let before = fs::metadata(&dest).unwrap().modified().unwrap();
+    let out = setup_zellij_wasm(&config_dir, &a).success().get_output().clone();
+    assert_eq!(fs::metadata(&dest).unwrap().modified().unwrap(), before, "identical bytes must not rewrite");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(!stdout.contains("wasm updated"), "{stdout}");
+}
+
+#[cfg(unix)]
+#[test]
+fn setup_zellij_rerun_never_writes_through_a_symlinked_wasm() {
+    // home-manager installs the wasm as a symlink into /nix/store. Writing
+    // through (or renaming over) it would either fail or replace the link with
+    // a file the next `home-manager switch` reverts — same guard as config.kdl.
+    let config_dir = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let a = src.path().join("a.wasm");
+    let b = src.path().join("b.wasm");
+    fs::write(&a, b"\0asm-A").unwrap();
+    fs::write(&b, b"\0asm-B").unwrap();
+    setup_zellij_wasm(&config_dir, &a).success();
+
+    // Swap the installed file for a symlink to a "store" copy.
+    let dest = config_dir.path().join("plugins").join("zj_radar.wasm");
+    let store = src.path().join("store.wasm");
+    fs::write(&store, b"\0asm-STORE").unwrap();
+    fs::remove_file(&dest).unwrap();
+    std::os::unix::fs::symlink(&store, &dest).unwrap();
+
+    let out = setup_zellij_wasm(&config_dir, &b).success().get_output().clone();
+    assert!(fs::symlink_metadata(&dest).unwrap().file_type().is_symlink(), "symlink must survive");
+    assert_eq!(fs::read(&store).unwrap(), b"\0asm-STORE", "store target must be untouched");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("Nix"), "should explain why the wasm was skipped: {stderr}");
+}

--- a/crates/cli/tests/cli_update.rs
+++ b/crates/cli/tests/cli_update.rs
@@ -72,6 +72,25 @@ fn update_refuses_a_pin_older_than_the_running_cli() {
     assert!(stderr.contains("install.sh"), "should point at the installer for downgrades: {stderr}");
 }
 
+#[test]
+fn update_rejects_a_pin_that_is_not_a_plain_version() {
+    let home = TempDir::new().unwrap();
+    let out = Command::cargo_bin("zj-radar")
+        .unwrap()
+        .args(["update", "--check"])
+        .env("HOME", home.path())
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("ZELLIJ_CONFIG_DIR")
+        .env("ZJ_RADAR_VERSION", "v0.6.0-rc1")
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(stderr.contains("MAJOR.MINOR.PATCH"), "should name the expected shape, not call it older: {stderr}");
+    assert!(!stderr.contains("older"), "{stderr}");
+}
+
 #[cfg(unix)]
 #[test]
 fn update_leaves_a_symlinked_wasm_to_its_manager() {

--- a/crates/cli/tests/cli_update.rs
+++ b/crates/cli/tests/cli_update.rs
@@ -52,6 +52,58 @@ fn update_check_exits_nonzero_when_a_newer_release_is_pinned() {
 }
 
 #[test]
+fn update_refuses_a_pin_older_than_the_running_cli() {
+    // `update` only moves forward: refreshing the wasm to an older pin while
+    // the CLI stays put would split the two halves across versions.
+    let home = TempDir::new().unwrap();
+    let out = Command::cargo_bin("zj-radar")
+        .unwrap()
+        .arg("update")
+        .env("HOME", home.path())
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("ZELLIJ_CONFIG_DIR")
+        .env("ZJ_RADAR_VERSION", "0.0.1")
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(stderr.contains("older"), "should explain the refusal: {stderr}");
+    assert!(stderr.contains("install.sh"), "should point at the installer for downgrades: {stderr}");
+}
+
+#[cfg(unix)]
+#[test]
+fn update_leaves_a_symlinked_wasm_to_its_manager() {
+    // home-manager installs the wasm as a symlink into /nix/store. Same rule
+    // `setup zellij` applies to a symlinked config.kdl: never write through
+    // it (the next `home-manager switch` would revert it anyway) — and no
+    // checksum comparison either, so this stays offline.
+    let home = TempDir::new().unwrap();
+    let plugins = home.path().join(".config/zellij/plugins");
+    fs::create_dir_all(&plugins).unwrap();
+    let store_copy = home.path().join("store").join("zj_radar.wasm");
+    fs::create_dir_all(store_copy.parent().unwrap()).unwrap();
+    fs::write(&store_copy, b"\0asm").unwrap();
+    std::os::unix::fs::symlink(&store_copy, plugins.join("zj_radar.wasm")).unwrap();
+
+    let out = Command::cargo_bin("zj-radar")
+        .unwrap()
+        .args(["update", "--check"])
+        .env("HOME", home.path())
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("ZELLIJ_CONFIG_DIR")
+        .env("ZJ_RADAR_VERSION", CURRENT)
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(stdout.contains("managed"), "wasm line should say it is managed elsewhere: {stdout}");
+    assert!(!stdout.contains("differs"), "{stdout}");
+}
+
+#[test]
 fn update_with_nothing_newer_does_not_reinstall_a_missing_wasm() {
     let home = TempDir::new().unwrap();
     let out = Command::cargo_bin("zj-radar")

--- a/crates/cli/tests/cli_update.rs
+++ b/crates/cli/tests/cli_update.rs
@@ -1,0 +1,104 @@
+//! Integration tests for `zj-radar update` — the offline paths only. Pinning
+//! `ZJ_RADAR_VERSION` skips the GitHub "latest" lookup, and an isolated HOME
+//! with no installed wasm skips the checksum fetch, so nothing here touches the
+//! network. The download/replace path is covered by unit tests on its pieces.
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::TempDir;
+
+/// This test binary is built from the same package as the CLI, so this is the
+/// version the CLI under test reports.
+const CURRENT: &str = env!("CARGO_PKG_VERSION");
+
+#[test]
+fn update_check_reports_current_cli_and_missing_wasm_without_network() {
+    let home = TempDir::new().unwrap();
+    let out = Command::cargo_bin("zj-radar")
+        .unwrap()
+        .args(["update", "--check"])
+        .env("HOME", home.path())
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("ZELLIJ_CONFIG_DIR")
+        .env("ZJ_RADAR_VERSION", CURRENT)
+        .assert()
+        .success() // nothing to update → exit 0
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(stdout.contains(&format!("v{CURRENT}")), "should print the current version: {stdout}");
+    assert!(stdout.contains("up to date"), "cli line should say up to date: {stdout}");
+    assert!(stdout.contains("not installed"), "wasm line should say not installed: {stdout}");
+    assert!(stdout.contains("setup zellij --download"), "should point at the install command: {stdout}");
+}
+
+#[test]
+fn update_check_exits_nonzero_when_a_newer_release_is_pinned() {
+    let home = TempDir::new().unwrap();
+    let out = Command::cargo_bin("zj-radar")
+        .unwrap()
+        .args(["update", "--check"])
+        .env("HOME", home.path())
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("ZELLIJ_CONFIG_DIR")
+        .env("ZJ_RADAR_VERSION", "99.0.0")
+        .assert()
+        .failure() // an update is available → exit 1, scriptable
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(stdout.contains("99.0.0"), "should name the available version: {stdout}");
+    assert!(stdout.contains("zj-radar update"), "should point at the command that applies it: {stdout}");
+}
+
+#[test]
+fn update_with_nothing_newer_does_not_reinstall_a_missing_wasm() {
+    let home = TempDir::new().unwrap();
+    let out = Command::cargo_bin("zj-radar")
+        .unwrap()
+        .arg("update")
+        .env("HOME", home.path())
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("ZELLIJ_CONFIG_DIR")
+        .env("ZJ_RADAR_VERSION", CURRENT)
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(stdout.contains("up to date"), "{stdout}");
+    // `update` moves what is installed; a missing sidebar is a setup job.
+    assert!(stdout.contains("setup zellij --download"), "{stdout}");
+    assert!(!home.path().join(".config/zellij/plugins/zj_radar.wasm").exists());
+}
+
+#[test]
+fn update_refuses_to_overwrite_a_cargo_installed_binary() {
+    // Relocate the built CLI into a fake ~/.cargo/bin so `current_exe()`
+    // classifies it as cargo-managed, then pin a newer version so the
+    // classification is actually consulted.
+    let home = TempDir::new().unwrap();
+    let cargo_bin = home.path().join(".cargo").join("bin");
+    fs::create_dir_all(&cargo_bin).unwrap();
+    let relocated = cargo_bin.join("zj-radar");
+    fs::copy(assert_cmd::cargo::cargo_bin("zj-radar"), &relocated).unwrap();
+
+    let out = Command::new(&relocated)
+        .arg("update")
+        .env("HOME", home.path())
+        .env_remove("CARGO_HOME")
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("ZELLIJ_CONFIG_DIR")
+        .env("ZJ_RADAR_VERSION", "99.0.0")
+        .assert()
+        .success() // a redirect, not a failure
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(stdout.contains("cargo install zj-radar"), "should hand off to cargo: {stdout}");
+    // The binary itself is untouched.
+    assert_eq!(
+        fs::read(&relocated).unwrap(),
+        fs::read(assert_cmd::cargo::cargo_bin("zj-radar")).unwrap()
+    );
+}

--- a/docs/design.md
+++ b/docs/design.md
@@ -554,6 +554,17 @@ choice is a flag the consumer projects on, never a fact.
   in CI. Consuming from Nix: [`install.md`](install.md#nix--home-manager).
 - Releases: one tag ships the wasm, static CLI tarballs, and the crates
   ([`RELEASING.md`](../RELEASING.md)).
+- `zj-radar update` moves the CLI and the wasm as one, because they share the
+  status contract and the setup expectations, and a hand-run upgrade of only
+  one half is the drift that broke installs before. It replaces the binary
+  first, then re-executes the *new* binary for `setup zellij --download`, so
+  the wasm it fetches is its own version; the resolved tag travels with the
+  re-exec as `ZJ_RADAR_VERSION` so a release landing mid-run cannot split
+  them. Nix and cargo installs are handed back to their tool rather than
+  overwritten behind its record; `--check` grades the wasm by sha256 against
+  the release sidecar, the only version signal a wasm file carries. Pins move
+  forward only: refreshing the wasm to an older pin while the binary stays
+  put would recreate the split.
 
 ## 16. Non-goals and follow-ups
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -218,6 +218,48 @@ Items are `ok`, `warn`, or `missing`:
 - **config env** (only when `$ZELLIJ_CONFIG_FILE` points elsewhere): Zellij
   reads that file, not the one setup edits.
 
+## Upgrade (`zj-radar update`)
+
+```sh
+zj-radar update            # move the CLI and the sidebar to the latest release
+zj-radar update --check    # report only; exit 1 when an update is available
+```
+
+`update` does four things:
+
+1. Finds the latest release (`ZJ_RADAR_VERSION` pins a tag) and compares it
+   to this CLI. If newer, it downloads the binary for this platform, verifies
+   the release's `.sha256` checksum, and swaps it in place. The running
+   process is unaffected; the next `zj-radar` is the new one.
+2. Runs `setup zellij --download` through the new binary, so the wasm at
+   `~/.config/zellij/plugins/zj_radar.wasm` comes from the same release. The
+   file is rewritten only when its bytes differ.
+3. Runs `setup` for the producers already wired (Codex hooks, Opencode
+   bridge), never for one you have not set up. The Claude Code plugin updates
+   from inside Claude: `/plugin update zj-radar-claude@zj-radar`.
+4. Runs the doctor (`setup --check`).
+
+Restart Zellij, or open a new session, to load the new sidebar. A running
+session keeps the old plugin.
+
+`--check` compares both halves: the CLI version against the release tag, and
+the installed wasm's checksum against the release's published `.sha256`. A
+wasm built from source reads as differing, since it is not byte-identical to
+the release artifact.
+
+What `update` does with each kind of install:
+
+| Install | Behavior |
+|---|---|
+| `curl \| sh` installer (`~/.local/bin`) | Replaced in place. |
+| `cargo install` (`~/.cargo/bin` or `$CARGO_HOME/bin`) | Left alone. Run `cargo install zj-radar` (or `cargo binstall zj-radar`), then `zj-radar setup zellij --download`. |
+| Nix / home-manager (`/nix/store` binary, or a symlinked wasm) | Left alone. Update the flake input. |
+| No sidebar installed | Reported; run `zj-radar setup zellij --download` to add one. |
+| No prebuilt binary (Intel macOS) | Build from source, then `zj-radar setup zellij --download`. |
+| `ZJ_RADAR_VERSION` older than this CLI | Refused. Downgrade with the installer and that tag. |
+
+Re-running `zj-radar setup zellij --download` by hand refreshes the wasm alone.
+
 ## Loading straight from a release URL
 
 Zellij can load a plugin from an `https://` URL and cache it:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -189,6 +189,13 @@ tests). Ghostty's window padding is drawn over the trailing columns.
 
 **Fix:** in Ghostty's config, `window-padding-color = extend`.
 
+## Sidebar is still the old version after `zj-radar update`
+
+A running session keeps the plugin it loaded. Restart Zellij, or open a new
+session. `zj-radar update --check` confirms the installed wasm matches the
+release. If it reports the wasm as a symlink managed by Nix or home-manager,
+`update` left it alone; update the flake input instead.
+
 ## Zellij plugin-reload quirks
 
 **Symptom:** during development, reloading the plugin opens an extra tiled


### PR DESCRIPTION
## Summary

New `zj-radar update` subcommand so users have a first-class upgrade path (previously: re-run the installer, then remember `setup zellij --download`).

- Resolves the latest release by following GitHub's `releases/latest` redirect (no API, no token, no rate limit); `ZJ_RADAR_VERSION` pins a tag (validated as MAJOR.MINOR.PATCH; forward only).
- Self-managed binaries (the curl|sh install) are downloaded as the release tarball for the compile-time target triple, verified against the published `.sha256`, and swapped in place via same-directory staging + atomic rename.
- The **new** binary is then re-exec'd for `setup zellij --download -y` (wasm matches its version), `setup <already-wired producers> -y`, and `setup --check`. Prints the restart-Zellij reminder and the Claude plugin's `/plugin update` hint.
- `--check` reports both halves without writing: CLI version vs. release tag, and installed wasm sha256 vs. the release sidecar. Exit 1 when either is behind, so it is scriptable.
- Hands back what it does not own: `/nix/store` binaries and symlinked (home-manager) wasm → pointer to the Nix config; `~/.cargo/bin` / `$CARGO_HOME/bin` → `cargo install zj-radar`. A missing sidebar is a `setup` job, not an install-from-scratch.
- `setup::download` generalized: `download_verified_asset` (the `.part` + sidecar flow) now serves both the wasm and the CLI tarball.

## Pre-existing bug fixed along the way

`setup zellij`'s "config already up to date" arm never copied the wasm. On any machine that had run setup once, re-running `setup zellij --download` (the documented upgrade path, and what `update` re-execs) upgraded nothing. Now that arm installs a differing wasm (atomic write, identical bytes skipped, symlinked destination left to Nix). Three `cli_setup` integration tests pin this.

## Test plan

- [x] Unit: redirect-tag parsing, semver compare, install classification (Nix / cargo / self-managed incl. symlinked `$HOME`), release URL naming, compile-time triple, tarball extract (real `tar`), atomic replace (content + exec bit + no leftovers), wasm refresh gate.
- [x] Integration (offline, pinned): `--check` current + missing wasm; `--check` newer pin → exit 1; nothing newer → no wasm install; cargo-relocated binary refused and untouched; symlinked wasm reported as managed; older pin refused; prerelease pin rejected by shape. Setup: re-run with a new wasm replaces it, same wasm is a no-op, symlinked wasm is never written through.
- [x] **Live end-to-end of the self-replace path**: built this branch stamped as v0.4.9, ran `update` unpinned → downloaded the real v0.5.0 tarball, checksum verified, binary swapped (`--version` reports 0.5.0), re-exec'd v0.5.0 fetched the wasm (sha matches the release sidecar), no producers wired → producer step skipped, doctor ran.
- [x] Live on a home-manager machine: `--check` → CLI current, wasm managed, exit 0.
- [x] `cargo clippy --workspace --all-targets --all-features -D warnings`, `cargo test --workspace` (1011 tests).
- [x] Independent review pass (fresh-eyes + reviewer subagent); all Critical/Important findings fixed in 2a5d048.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
