### PR TITLE
test(e2e): fix manual-rename flake by renaming via tab id (#34)

### DIFF
--- a/crates/plugin/tests/e2e/harness.rs
+++ b/crates/plugin/tests/e2e/harness.rs
@@ -598,6 +598,52 @@ impl ZellijSession {
         let _ = self.action(args);
     }
 
+    /// Like [`run_action`], but panic with the action's own stderr when it
+    /// exits non-zero. `run_action` swallows the status, so a `zellij action`
+    /// that the host rejected (e.g. a rename against an id that raced a tab
+    /// close) becomes a silent no-op and later surfaces as a confusing
+    /// "name never changed". Use this for the actions a test's outcome hinges
+    /// on, so a rejected action names itself instead.
+    pub fn run_action_checked(&self, args: &[&str]) {
+        let output = self.action(args);
+        assert!(
+            output.status.success(),
+            "`zellij action {}` failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// Poll [`tab_names`] until `cond` holds, returning a timeline of every
+    /// distinct snapshot seen (one entry per change, timestamped from the
+    /// start). The bool says whether `cond` was met before `timeout`. Built
+    /// for tab-name assertions: on failure the timeline shows whether a name
+    /// ever appeared and was then replaced, or never appeared at all — the
+    /// distinction between a host-side overwrite and an action that never
+    /// landed, which a single final snapshot cannot tell apart.
+    pub fn sample_tab_names_until(
+        &self,
+        timeout: Duration,
+        mut cond: impl FnMut(&[String]) -> bool,
+    ) -> (bool, Vec<(Duration, Vec<String>)>) {
+        let start = Instant::now();
+        let deadline = start + timeout;
+        let mut timeline: Vec<(Duration, Vec<String>)> = Vec::new();
+        loop {
+            let names = self.tab_names();
+            if timeline.last().map(|(_, n)| n) != Some(&names) {
+                timeline.push((start.elapsed(), names.clone()));
+            }
+            if cond(&names) {
+                return (true, timeline);
+            }
+            if Instant::now() >= deadline {
+                return (false, timeline);
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+
     /// Names held by Zellij's authoritative tab model, in position order.
     /// Unlike sidebar text, this does not read any plugin instance's possibly
     /// stale render; `query-tab-names` asks the session host directly.

--- a/crates/plugin/tests/e2e/harness.rs
+++ b/crates/plugin/tests/e2e/harness.rs
@@ -600,10 +600,14 @@ impl ZellijSession {
 
     /// Like [`run_action`], but panic with the action's own stderr when it
     /// exits non-zero. `run_action` swallows the status, so a `zellij action`
-    /// that the host rejected (e.g. a rename against an id that raced a tab
-    /// close) becomes a silent no-op and later surfaces as a confusing
-    /// "name never changed". Use this for the actions a test's outcome hinges
-    /// on, so a rejected action names itself instead.
+    /// that failed at the CLI boundary — a dead or missing session, an IPC
+    /// error, or a bad argument clap rejected — becomes a silent no-op that
+    /// later surfaces as a confusing "the state never changed". Use it for the
+    /// actions a test's outcome hinges on, so such a failure names itself.
+    /// Note: mutating actions like `rename-tab` are fire-and-forget — the CLI
+    /// exits 0 once the message is sent, so a server-side no-op (e.g. an
+    /// out-of-range tab id) does NOT trip this; the paired state assertion is
+    /// the real detector for that.
     pub fn run_action_checked(&self, args: &[&str]) {
         let output = self.action(args);
         assert!(

--- a/crates/plugin/tests/e2e/main.rs
+++ b/crates/plugin/tests/e2e/main.rs
@@ -784,12 +784,21 @@ fn manual_tab_name_survives_switch_to_another_plugin_instance() {
         session.tab_names()
     );
 
+    // Rename tab 2 by its stable id, not the focused tab. `rename-tab` with no
+    // id targets whatever tab the attached client has focused, and after
+    // `new-tab` that focus can still be settling — the rename then lands on
+    // nothing observable and the test flakes with "never landed" (issue #34).
+    // Zellij tab ids are 0-based (the first tab is id 0), so the second tab is
+    // id 1 — distinct from `go-to-tab`, which is 1-based by position.
     let manual_name = "keep-this-manual-name";
-    session.run_action(&["rename-tab", manual_name]);
-    let renamed = session.wait_until(Duration::from_secs(5), |s| {
-        s.tab_names().get(1).is_some_and(|name| name == manual_name)
+    session.run_action_checked(&["rename-tab", "--tab-id", "1", manual_name]);
+    let (renamed, timeline) = session.sample_tab_names_until(Duration::from_secs(5), |names| {
+        names.get(1).is_some_and(|name| name == manual_name)
     });
-    assert!(renamed, "manual rename never landed; got {:?}", session.tab_names());
+    assert!(
+        renamed,
+        "manual rename never landed; tab-name timeline (elapsed → names) was {timeline:?}"
+    );
 
     // Switch to tab 1 (a different instance) and hold on Zellij's authoritative
     // tab names for a few seconds: a rename from any instance would show here.


### PR DESCRIPTION
Closes #34.

## Root cause

The v0.5.0 tag run flaked on ubuntu E2E with `manual rename never landed; got ["tmp", "home"]`. The test renamed tab 2 with `zellij action rename-tab <name>` (no id), which targets the **attached client's focused tab**. After `new-tab --cwd /home`, that focus can still be settling, so under CI timing the rename's `TabNameInput` landed on nothing observable — neither tab showed the manual name (the "never appeared" shape, not "appeared then overwritten").

This is a **harness race, not a product bug**. A tab's own sidebar instance provably does not clobber a manual rename, and that invariant is pinned deterministically at three layers:
- `tab_namer`: `managed_skips_manual_name_but_force_overrides`
- `radar_state`: `manual_rename_is_preserved_through_focus_and_cwd_changes`, `managed_naming_skips_manual_names_but_force_overrides`
- `runtime` (foreign side): `sidebar_instance_never_renames_a_foreign_tab`

## Fix

Rename tab 2 by its **stable id** (`rename-tab --tab-id 1 <name>`), which the host applies via `get_tab_by_id_mut` directly, independent of client focus. Zellij tab ids are 0-based (`get_new_tab_id` starts at 0), so the second tab is id 1 — verified empirically against zellij 0.44.3 (`--tab-id 1` renamed the second tab, `--tab-id 2` hit nothing). This still establishes a name the plugin did not apply, so the invariant under test is unchanged.

Per the issue's request, the single final-snapshot assert is replaced with a sampled timeline (`sample_tab_names_until`), so a future flake shows whether the name ever appeared and was replaced (host overwrite → cause 2) or never appeared (lost action → cause 1). `run_action_checked` surfaces a rejected `zellij action` that `run_action` silently swallowed.

## Test plan

- [x] Full e2e suite green locally (15/15, `just test-e2e` equivalent).
- [x] The target test run 5x locally, green each time (was already green on macOS; the flake was ubuntu-timing-specific and low-frequency).
- [x] `cargo clippy --features e2e --test e2e -- -D warnings` clean.
- [x] Only the two e2e test files change; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)