### PR TITLE
test: suite hardening — close coverage gaps and de-duplicate fixtures

### DIFF
--- a/crates/cli/src/agents.rs
+++ b/crates/cli/src/agents.rs
@@ -402,39 +402,20 @@ mod tests {
     }
 
     #[test]
-    fn tool_bash_git_push() {
-        let input = json(r#"{"command": "git push origin main"}"#);
-        assert_eq!(tool_activity("Bash", &input).unwrap(), "pushing");
-    }
-
-    #[test]
-    fn tool_bash_git_commit() {
-        let input = json(r#"{"command": "git commit -m x"}"#);
-        assert_eq!(tool_activity("Bash", &input).unwrap(), "committing");
-    }
-
-    #[test]
-    fn tool_bash_git_pull() {
-        let input = json(r#"{"command": "git pull"}"#);
-        assert_eq!(tool_activity("Bash", &input).unwrap(), "syncing");
-    }
-
-    #[test]
-    fn tool_bash_cargo_test() {
-        let input = json(r#"{"command": "cargo test --features cli"}"#);
-        assert_eq!(tool_activity("Bash", &input).unwrap(), "running tests");
-    }
-
-    #[test]
-    fn tool_bash_npm_run_build() {
-        let input = json(r#"{"command": "npm run build"}"#);
-        assert_eq!(tool_activity("Bash", &input).unwrap(), "building");
-    }
-
-    #[test]
-    fn tool_bash_pip_install() {
-        let input = json(r#"{"command": "pip install foo"}"#);
-        assert_eq!(tool_activity("Bash", &input).unwrap(), "installing");
+    fn tool_bash_verbs_derive_their_activity() {
+        // The positive half of the word-bounded classification below: each verb
+        // maps to its activity. Table-driven, matching that sibling test's shape.
+        for (cmd, expected) in [
+            ("git push origin main", "pushing"),
+            ("git commit -m x", "committing"),
+            ("git pull", "syncing"),
+            ("cargo test --features cli", "running tests"),
+            ("npm run build", "building"),
+            ("pip install foo", "installing"),
+        ] {
+            let input = json(&format!(r#"{{"command": {cmd:?}}}"#));
+            assert_eq!(tool_activity("Bash", &input).as_deref(), Some(expected), "cmd={cmd}");
+        }
     }
 
     #[test]

--- a/crates/cli/src/setup/download.rs
+++ b/crates/cli/src/setup/download.rs
@@ -330,4 +330,27 @@ mod tests {
         assert_eq!(parse_sha256(&"a".repeat(65)), None); // too long
         assert_eq!(parse_sha256(&format!("{}g", "a".repeat(63))), None); // 64 chars, one non-hex
     }
+
+    #[test]
+    fn compute_sha256_matches_the_known_digest_of_a_file() {
+        // `parse_sha256` is unit-tested, but the shell-out + parse composition
+        // that feeds it is not — a regression in how `sha256sum`/`shasum -a 256`
+        // output is consumed would slip the checksum guard.
+        let Some(dir) = std::env::var_os("TMPDIR")
+            .map(std::path::PathBuf::from)
+            .or_else(|| Some(std::env::temp_dir()))
+        else {
+            return;
+        };
+        let f = dir.join(format!("zj-radar-sha-probe-{}", std::process::id()));
+        std::fs::write(&f, b"abc").unwrap();
+        let got = compute_sha256(&f);
+        let _ = std::fs::remove_file(&f);
+        // SHA-256("abc"), the canonical NIST test vector. `None` = no sha256
+        // tool on PATH, where the checksum guard already degrades to a TLS-only
+        // warning, so an absent tool is not a failure.
+        if let Some(hex) = got {
+            assert_eq!(hex, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+        }
+    }
 }

--- a/crates/cli/src/update.rs
+++ b/crates/cli/src/update.rs
@@ -504,6 +504,11 @@ mod tests {
     fn is_newer_treats_unparseable_versions_as_not_newer() {
         assert!(!is_newer("nightly", "0.5.0"));
         assert!(!is_newer("0.5.1", "garbage"));
+        // A four-component version is not a plain MAJOR.MINOR.PATCH, so it is
+        // unparseable and never "newer" — the guard `parse_version` enforces so
+        // a `ZJ_RADAR_VERSION` pin is validated, not silently mis-ordered.
+        assert!(!is_newer("1.2.3.4", "1.2.3"));
+        assert!(!is_newer("1.2", "1.1.9")); // too few components
     }
 
     #[test]

--- a/crates/cli/tests/cli_setup.rs
+++ b/crates/cli/tests/cli_setup.rs
@@ -257,21 +257,98 @@ fn interrupted_download_leaves_no_partial_wasm() {
 
     // Downloads stage in a per-user `zj-radar-<user>/` subdir of the temp root;
     // sweep the whole tree so a leftover wasm/.part/.sha256 anywhere is caught.
-    fn sweep(dir: &std::path::Path, hits: &mut Vec<String>) {
-        for entry in fs::read_dir(dir).unwrap().filter_map(|e| e.ok()) {
-            let path = entry.path();
-            if path.is_dir() {
-                sweep(&path, hits);
-            } else {
-                hits.push(path.display().to_string());
-            }
-        }
-    }
     let mut leftovers = Vec::new();
-    sweep(tmp.path(), &mut leftovers);
+    sweep_files(tmp.path(), &mut leftovers);
     assert!(
         leftovers.is_empty(),
         "a failed download must leave neither the wasm nor a .part behind, found {leftovers:?}"
+    );
+}
+
+/// Collect every file path under `dir`, recursively. Shared by the download
+/// tests that assert a failed/rejected fetch stages nothing durable.
+fn sweep_files(dir: &std::path::Path, hits: &mut Vec<String>) {
+    for entry in fs::read_dir(dir).unwrap().filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if path.is_dir() {
+            sweep_files(&path, hits);
+        } else {
+            hits.push(path.display().to_string());
+        }
+    }
+}
+
+// A downloaded wasm whose bytes do not match the release's published `.sha256`
+// must be refused, not installed — Zellij loads the wasm with permissions, so a
+// payload that fails its digest is the security boundary of the whole download
+// path. The generalization to `download_verified_asset` shipped without a test
+// for this branch; this pins it.
+
+#[test]
+fn checksum_mismatch_refuses_to_install_the_wasm() {
+    let fakebin = TempDir::new().unwrap();
+    let config_dir = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+
+    // A fake `curl` that serves BOTH fetches this flow makes: real-looking wasm
+    // bytes for the `.wasm` URL, and a digest that cannot match those bytes
+    // (all zeros) for the `.sha256` sidecar. Distinguished by the URL suffix.
+    let curl = fakebin.path().join("curl");
+    fs::write(
+        &curl,
+        "#!/bin/sh\nurl=\"\"; out=\"\"; prev=\"\"\n\
+         for a in \"$@\"; do\n\
+         \x20 case \"$a\" in *github.com*) url=\"$a\";; esac\n\
+         \x20 [ \"$prev\" = \"-o\" ] && out=\"$a\"\n\
+         \x20 prev=\"$a\"\n\
+         done\n\
+         case \"$url\" in\n\
+         \x20 *.sha256) printf '%s' 0000000000000000000000000000000000000000000000000000000000000000 > \"$out\";;\n\
+         \x20 *) printf 'not-the-real-wasm' > \"$out\";;\n\
+         esac\n\
+         exit 0\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&curl, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    // Prepend the fake curl but keep the inherited PATH, so `sha256sum`/`shasum`
+    // still resolve — without a hash tool the code degrades to a TLS-only
+    // warning and the mismatch would never be caught (a different path).
+    let path = format!(
+        "{}:{}",
+        fakebin.path().display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    Command::cargo_bin("zj-radar")
+        .unwrap()
+        .args(["setup", "zellij", "--download", "--yes"])
+        .env("ZELLIJ_CONFIG_DIR", config_dir.path())
+        .env("PATH", path)
+        .env("TMPDIR", tmp.path())
+        .assert()
+        .failure();
+
+    // Nothing installed at the destination, and no staged bytes left behind.
+    assert!(
+        !config_dir.path().join("plugins").join("zj_radar.wasm").exists(),
+        "a checksum mismatch must not leave an installed wasm"
+    );
+    // Keep only download artifacts: `zellij --version` (real zellij is on PATH
+    // here) writes its own log under TMPDIR, which is not our concern.
+    let mut swept = Vec::new();
+    sweep_files(tmp.path(), &mut swept);
+    let staged: Vec<_> = swept
+        .into_iter()
+        .filter(|p| p.contains("zj_radar") || p.ends_with(".part") || p.ends_with(".sha256"))
+        .collect();
+    assert!(
+        staged.is_empty(),
+        "a rejected download must leave no wasm/.part/.sha256 behind, found {staged:?}"
     );
 }
 

--- a/crates/cli/tests/cli_update.rs
+++ b/crates/cli/tests/cli_update.rs
@@ -132,20 +132,40 @@ fn update_refuses_to_overwrite_a_cargo_installed_binary() {
     let cargo_bin = home.path().join(".cargo").join("bin");
     fs::create_dir_all(&cargo_bin).unwrap();
     let relocated = cargo_bin.join("zj-radar");
-    fs::copy(assert_cmd::cargo::cargo_bin("zj-radar"), &relocated).unwrap();
+    let src = assert_cmd::cargo::cargo_bin("zj-radar");
+    // Hard-link, don't copy: `fs::copy` opens the destination for writing, and
+    // under a parallel test runner a concurrent test's fork can inherit that
+    // descriptor and make the exec below fail with ETXTBSY ("Text file busy")
+    // on Linux. A hard link opens no writable fd. Fall back to copy only across
+    // filesystems (EXDEV), where the retry below covers the rare race.
+    if fs::hard_link(&src, &relocated).is_err() {
+        fs::copy(&src, &relocated).unwrap();
+    }
 
-    let out = Command::new(&relocated)
-        .arg("update")
-        .env("HOME", home.path())
-        .env_remove("CARGO_HOME")
-        .env_remove("XDG_CONFIG_HOME")
-        .env_remove("ZELLIJ_CONFIG_DIR")
-        .env("ZJ_RADAR_VERSION", "99.0.0")
-        .assert()
-        .success() // a redirect, not a failure
-        .get_output()
-        .clone();
-    let stdout = String::from_utf8(out.stdout).unwrap();
+    // Spawn, tolerating a transient ETXTBSY from the copy-fallback path: retry a
+    // few times as the concurrent writer's fd closes. The hard-link path never
+    // hits this.
+    let mut attempt = 0;
+    let output = loop {
+        let result = Command::new(&relocated)
+            .arg("update")
+            .env("HOME", home.path())
+            .env_remove("CARGO_HOME")
+            .env_remove("XDG_CONFIG_HOME")
+            .env_remove("ZELLIJ_CONFIG_DIR")
+            .env("ZJ_RADAR_VERSION", "99.0.0")
+            .output();
+        match result {
+            Ok(o) => break o,
+            Err(e) if e.raw_os_error() == Some(26) && attempt < 20 => {
+                attempt += 1;
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Err(e) => panic!("spawning relocated binary failed: {e}"),
+        }
+    };
+    assert!(output.status.success(), "update should redirect (exit 0), got {:?}", output.status);
+    let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("cargo install zj-radar"), "should hand off to cargo: {stdout}");
     // The binary itself is untouched.
     assert_eq!(

--- a/crates/cli/tests/cli_update.rs
+++ b/crates/cli/tests/cli_update.rs
@@ -11,16 +11,26 @@ use tempfile::TempDir;
 /// version the CLI under test reports.
 const CURRENT: &str = env!("CARGO_PKG_VERSION");
 
-#[test]
-fn update_check_reports_current_cli_and_missing_wasm_without_network() {
-    let home = TempDir::new().unwrap();
-    let out = Command::cargo_bin("zj-radar")
-        .unwrap()
-        .args(["update", "--check"])
+/// `zj-radar update <args>` in an isolated HOME with `ZJ_RADAR_VERSION` pinned
+/// (which skips the network "latest" lookup) and the Zellij config-dir env
+/// cleared, so the resolved dir is `HOME/.config/zellij` and nothing here
+/// touches the network. Every test shares this env; only the args and version
+/// vary.
+fn update_cmd(home: &TempDir, version: &str, args: &[&str]) -> Command {
+    let mut cmd = Command::cargo_bin("zj-radar").unwrap();
+    cmd.arg("update")
+        .args(args)
         .env("HOME", home.path())
         .env_remove("XDG_CONFIG_HOME")
         .env_remove("ZELLIJ_CONFIG_DIR")
-        .env("ZJ_RADAR_VERSION", CURRENT)
+        .env("ZJ_RADAR_VERSION", version);
+    cmd
+}
+
+#[test]
+fn update_check_reports_current_cli_and_missing_wasm_without_network() {
+    let home = TempDir::new().unwrap();
+    let out = update_cmd(&home, CURRENT, &["--check"])
         .assert()
         .success() // nothing to update → exit 0
         .get_output()
@@ -35,13 +45,7 @@ fn update_check_reports_current_cli_and_missing_wasm_without_network() {
 #[test]
 fn update_check_exits_nonzero_when_a_newer_release_is_pinned() {
     let home = TempDir::new().unwrap();
-    let out = Command::cargo_bin("zj-radar")
-        .unwrap()
-        .args(["update", "--check"])
-        .env("HOME", home.path())
-        .env_remove("XDG_CONFIG_HOME")
-        .env_remove("ZELLIJ_CONFIG_DIR")
-        .env("ZJ_RADAR_VERSION", "99.0.0")
+    let out = update_cmd(&home, "99.0.0", &["--check"])
         .assert()
         .failure() // an update is available → exit 1, scriptable
         .get_output()
@@ -56,13 +60,7 @@ fn update_refuses_a_pin_older_than_the_running_cli() {
     // `update` only moves forward: refreshing the wasm to an older pin while
     // the CLI stays put would split the two halves across versions.
     let home = TempDir::new().unwrap();
-    let out = Command::cargo_bin("zj-radar")
-        .unwrap()
-        .arg("update")
-        .env("HOME", home.path())
-        .env_remove("XDG_CONFIG_HOME")
-        .env_remove("ZELLIJ_CONFIG_DIR")
-        .env("ZJ_RADAR_VERSION", "0.0.1")
+    let out = update_cmd(&home, "0.0.1", &[])
         .assert()
         .failure()
         .get_output()
@@ -75,13 +73,7 @@ fn update_refuses_a_pin_older_than_the_running_cli() {
 #[test]
 fn update_rejects_a_pin_that_is_not_a_plain_version() {
     let home = TempDir::new().unwrap();
-    let out = Command::cargo_bin("zj-radar")
-        .unwrap()
-        .args(["update", "--check"])
-        .env("HOME", home.path())
-        .env_remove("XDG_CONFIG_HOME")
-        .env_remove("ZELLIJ_CONFIG_DIR")
-        .env("ZJ_RADAR_VERSION", "v0.6.0-rc1")
+    let out = update_cmd(&home, "v0.6.0-rc1", &["--check"])
         .assert()
         .failure()
         .get_output()
@@ -106,13 +98,7 @@ fn update_leaves_a_symlinked_wasm_to_its_manager() {
     fs::write(&store_copy, b"\0asm").unwrap();
     std::os::unix::fs::symlink(&store_copy, plugins.join("zj_radar.wasm")).unwrap();
 
-    let out = Command::cargo_bin("zj-radar")
-        .unwrap()
-        .args(["update", "--check"])
-        .env("HOME", home.path())
-        .env_remove("XDG_CONFIG_HOME")
-        .env_remove("ZELLIJ_CONFIG_DIR")
-        .env("ZJ_RADAR_VERSION", CURRENT)
+    let out = update_cmd(&home, CURRENT, &["--check"])
         .assert()
         .success()
         .get_output()
@@ -125,13 +111,7 @@ fn update_leaves_a_symlinked_wasm_to_its_manager() {
 #[test]
 fn update_with_nothing_newer_does_not_reinstall_a_missing_wasm() {
     let home = TempDir::new().unwrap();
-    let out = Command::cargo_bin("zj-radar")
-        .unwrap()
-        .arg("update")
-        .env("HOME", home.path())
-        .env_remove("XDG_CONFIG_HOME")
-        .env_remove("ZELLIJ_CONFIG_DIR")
-        .env("ZJ_RADAR_VERSION", CURRENT)
+    let out = update_cmd(&home, CURRENT, &[])
         .assert()
         .success()
         .get_output()

--- a/crates/core/src/command/tests.rs
+++ b/crates/core/src/command/tests.rs
@@ -451,20 +451,8 @@
         assert!(store.get(1).is_none(), "must never become Running");
     }
 
-    // ── Test 3: starship ignore-set: stays Idle, no pending, no Done
-
-    #[test]
-    fn starship_on_idle_pane_leaves_no_trace() {
-        let mut store = CommandStore::default();
-        let cmd = vec!["starship".to_string()];
-
-        store.on_command_changed(1, &cmd, true, None, 1);
-        assert!(
-            !store.pending.contains_key(&1),
-            "starship must not enter pending"
-        );
-        assert!(store.get(1).is_none(), "no resolved state expected");
-    }
+    // starship's ignore-set behavior (no pending, no Done) is pinned alongside
+    // the other shells in `ignore_set_covers_all_shells` below.
 
     // direnv's per-prompt `direnv export <shell>` hook is back-to-the-prompt
     // machinery (like starship), not a tracked command: it must neither open its

--- a/crates/core/src/payload.rs
+++ b/crates/core/src/payload.rs
@@ -531,6 +531,15 @@ mod tests {
     }
 
     #[test]
+    fn sanitize_strips_osc_st_terminated() {
+        // The OSC's other well-formed terminator is ST (`ESC \`), the third exit
+        // of the scanner alongside BEL and the stray-control bound. The doc
+        // comment promises ST support, so pin it: the sequence is removed and
+        // only the trailing text survives.
+        assert_eq!(sanitize("\x1b]0;evil title\x1b\\ok", 100), "ok");
+    }
+
+    #[test]
     fn sanitize_converts_newline_to_space() {
         assert_eq!(sanitize("a\nb", 100), "a b");
     }

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -23,6 +23,33 @@ fn runtime_with_config(config: config::Config) -> PluginRuntime {
     }
 }
 
+/// A granted runtime with the default test `config()` and NO session name —
+/// the "permission resolved, nameless" shape many render/effect tests hand-roll
+/// inline. `runtime_with_granted_permission` differs by also setting a session
+/// name, which only the presence tests need.
+fn granted_runtime() -> PluginRuntime {
+    PluginRuntime {
+        permission: PermissionState::Resolved { granted: true },
+        config: config(),
+        ..Default::default()
+    }
+}
+
+/// Push the canonical Done ledger entry (tab 1 "work", "cargo test", pane 5) at
+/// `at_epoch_s`. The cadence tests differ only in that timestamp — a fresh
+/// `now` vs a saturated `0` — so a helper makes that the visible payload
+/// instead of burying it in a repeated eight-line literal.
+fn seed_done_ledger(rt: &mut PluginRuntime, at_epoch_s: u64) {
+    rt.radar.ledger_mut().push(crate::ledger::LedgerEntry {
+        at_epoch_s,
+        outcome: crate::ledger::LedgerOutcome::Done,
+        tab_id: TabId::new(1),
+        tab_name: "work".into(),
+        label: "cargo test".into(),
+        pane_id: 5,
+    });
+}
+
 impl PluginRuntime {
     /// Test shorthand: deliver a timer fire "now" (a real wall-clock
     /// capture) with the given elapsed. The sites that still pass an
@@ -760,11 +787,7 @@ fn config_pipe_accepts_json_scalars() {
 fn render_records_targets_and_mouse_click_returns_host_effect() {
     // 3 tracked panes → multi-pane mode (line-per-pane).
     // Line 2 = tab header, line 3 = pane 20, line 4 = pane 21, line 5 = pane 22.
-    let mut runtime = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut runtime = granted_runtime();
     runtime.tabs_changed(vec![tab(0, "team", false), tab(1, "plain", false)]);
     runtime
         .radar
@@ -800,11 +823,7 @@ fn single_pane_detail_line_click_shows_the_pane() {
     // (line 2) + detail line (line 3). The detail line describes that one
     // pane, so it must click-target the pane (ShowPane), not the tab
     // (SwitchTab) — mirroring the multi-pane tree rows.
-    let mut runtime = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut runtime = granted_runtime();
     runtime.tabs_changed(vec![tab(0, "team", false)]);
     runtime
         .radar
@@ -882,11 +901,7 @@ fn no_tabs_with_history_renders_ledger_not_scanning() {
 
 #[test]
 fn command_attention_next_emits_switch_tab() {
-    let mut runtime = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut runtime = granted_runtime();
     // tab 0 active (running), tab 1 pending → attention.
     runtime.tabs_changed(vec![tab(0, "a", true), tab(1, "b", false)]);
     runtime.radar.set_tab_panes_for_position(0, vec![pane(10)]);
@@ -910,22 +925,14 @@ fn command_is_inert_without_permission() {
 
 #[test]
 fn command_no_op_when_no_attention() {
-    let mut runtime = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut runtime = granted_runtime();
     runtime.tabs_changed(vec![tab(0, "a", true)]);
     assert_eq!(runtime.control(Verb::AttentionNext), Outcome::default());
 }
 
 #[test]
 fn control_pipe_unknown_verb_is_no_op() {
-    let mut runtime = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut runtime = granted_runtime();
     assert_eq!(runtime.control_pipe("attention-top"), Outcome::default());
     assert_eq!(runtime.control_pipe(""), Outcome::default());
 }
@@ -936,11 +943,7 @@ fn control_pipe_unknown_verb_is_no_op() {
 /// in production once Zellij's first `ModeUpdate` lands) — needed for the
 /// presence edge in `project` to ever fire.
 fn runtime_with_granted_permission() -> PluginRuntime {
-    let mut rt = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut rt = granted_runtime();
     rt.session_name_changed(Some("work".into()));
     rt
 }
@@ -1091,11 +1094,7 @@ fn presence_withheld_until_own_session_name_is_known() {
     // Same status edge as above, but WITHOUT `session_name_changed` ever landing —
     // an unnamed presence file is useless to peers, so `project` must not
     // emit `PersistPresence` no matter what the own counts do.
-    let mut rt = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut rt = granted_runtime();
     drive_tabs_and_panes(&mut rt);
 
     let out = rt.status_pipe(&payload_json(7, "running"));
@@ -1386,11 +1385,7 @@ fn right_click_without_permission_is_inert_even_on_stale_session_line() {
 ///   6   tab1 header line   → (1, None)
 ///   7   tab1 pane 20 line  → (1, Some(20)) — Pending
 fn runtime_with_pending_panes() -> PluginRuntime {
-    let mut rt = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut rt = granted_runtime();
     rt.tabs_changed(vec![tab(0, "a", false), tab(1, "b", false)]);
     rt.radar.set_tab_panes_for_position(0, vec![pane(10), pane(11), pane(12)]);
     rt.radar.set_tab_panes_for_position(1, vec![pane(20)]);
@@ -1477,11 +1472,7 @@ fn right_click_on_a_running_pane_row_is_a_strict_no_op() {
 
 #[test]
 fn right_click_on_a_tab_row_with_no_tracked_panes_is_a_strict_no_op() {
-    let mut rt = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut rt = granted_runtime();
     rt.tabs_changed(vec![tab(0, "a", false)]);
     let _ = rt.render(100, 80);
     assert_eq!(rt.mouse_right_click(2, 0), Outcome::default(), "no panes at all in this tab");
@@ -1999,11 +1990,7 @@ fn flash_keeps_fast_timer_until_cleared() {
 
 #[test]
 fn command_attention_prev_emits_switch_tab() {
-    let mut runtime = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut runtime = granted_runtime();
     // tab 0 active (running); tabs 1 and 2 pending → attention.
     // From active 0: Next steps forward to 1, Prev wraps backward to 2.
     runtime.tabs_changed(vec![tab(0, "a", true), tab(1, "b", false), tab(2, "c", false)]);
@@ -2020,11 +2007,7 @@ fn command_attention_prev_emits_switch_tab() {
 
 #[test]
 fn control_pipe_dispatches_known_verb() {
-    let mut runtime = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut runtime = granted_runtime();
     // tab 0 active (running), tab 1 pending → attention.
     runtime.tabs_changed(vec![tab(0, "a", true), tab(1, "b", false)]);
     runtime.radar.set_tab_panes_for_position(0, vec![pane(10)]);
@@ -2110,20 +2093,9 @@ fn command_ttl_recede_rearms_slow_not_fast_when_ledgered() {
 
 #[test]
 fn idle_with_fresh_history_arms_slow_and_repaints() {
-    let mut rt = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut rt = granted_runtime();
     let now = crate::clock::now_epoch_s();
-    rt.radar.ledger_mut().push(crate::ledger::LedgerEntry {
-        at_epoch_s: now,
-        outcome: crate::ledger::LedgerOutcome::Done,
-        tab_id: TabId::new(1),
-        tab_name: "work".into(),
-        label: "cargo test".into(),
-        pane_id: 5,
-    });
+    seed_done_ledger(&mut rt, now);
     assert!(rt.timer_chain.armed().is_none(), "setup: nothing has armed a timer yet");
 
     // Any event that runs `project` (here, a no-op topology update) must
@@ -2150,21 +2122,10 @@ fn saturated_history_fully_disarms() {
     // `session_name_changed` ever lands, so `own_session_name` stays at its
     // Default empty). Once a name is known the presence-liveness heartbeat
     // keeps Slow armed instead — see the sibling test below.
-    let mut rt = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut rt = granted_runtime();
     // Any epoch older than SATURATE_S relative to the real wall clock —
     // 0 trivially qualifies.
-    rt.radar.ledger_mut().push(crate::ledger::LedgerEntry {
-        at_epoch_s: 0,
-        outcome: crate::ledger::LedgerOutcome::Done,
-        tab_id: TabId::new(1),
-        tab_name: "work".into(),
-        label: "cargo test".into(),
-        pane_id: 5,
-    });
+    seed_done_ledger(&mut rt, 0);
     assert_eq!(
         rt.desired_cadence(crate::clock::now_epoch_s()),
         None,
@@ -2195,19 +2156,8 @@ fn saturated_history_with_known_name_keeps_slow_armed_for_the_heartbeat() {
     // feature exists for.
     // So: saturation may step the cadence down to Slow, but never to None
     // while the name is known.
-    let mut rt = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
-    rt.radar.ledger_mut().push(crate::ledger::LedgerEntry {
-        at_epoch_s: 0,
-        outcome: crate::ledger::LedgerOutcome::Done,
-        tab_id: TabId::new(1),
-        tab_name: "work".into(),
-        label: "cargo test".into(),
-        pane_id: 5,
-    });
+    let mut rt = granted_runtime();
+    seed_done_ledger(&mut rt, 0);
     // Seed `last_now_epoch_s` with a real wall-clock capture (any entry
     // point that owns an epoch does) BEFORE the name lands, so the arm
     // decision inside `session_name_changed`'s project pass evaluates at
@@ -2249,20 +2199,9 @@ fn saturated_history_with_known_name_keeps_slow_armed_for_the_heartbeat() {
 
 #[test]
 fn fast_work_arriving_during_slow_rearms_fast() {
-    let mut rt = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut rt = granted_runtime();
     let now = crate::clock::now_epoch_s();
-    rt.radar.ledger_mut().push(crate::ledger::LedgerEntry {
-        at_epoch_s: now,
-        outcome: crate::ledger::LedgerOutcome::Done,
-        tab_id: TabId::new(1),
-        tab_name: "work".into(),
-        label: "cargo test".into(),
-        pane_id: 5,
-    });
+    seed_done_ledger(&mut rt, now);
     rt.tabs_changed(vec![]);
     assert_eq!(rt.timer_chain.armed(), Some(Cadence::Slow), "setup: slow-armed on fresh history");
 
@@ -2284,20 +2223,9 @@ fn fast_work_arriving_during_slow_rearms_fast() {
 /// history (one fire in flight), then a Running broadcast tops up Fast
 /// (a second, non-cancellable fire in flight).
 fn slow_armed_then_fast_topup() -> PluginRuntime {
-    let mut rt = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut rt = granted_runtime();
     let now = crate::clock::now_epoch_s();
-    rt.radar.ledger_mut().push(crate::ledger::LedgerEntry {
-        at_epoch_s: now,
-        outcome: crate::ledger::LedgerOutcome::Done,
-        tab_id: TabId::new(1),
-        tab_name: "work".into(),
-        label: "cargo test".into(),
-        pane_id: 5,
-    });
+    seed_done_ledger(&mut rt, now);
     rt.tabs_changed(vec![]); // arms Slow: one fire in flight
     assert_eq!(rt.timer_chain.armed(), Some(Cadence::Slow), "setup: slow-armed on fresh history");
     let raw = payload::to_wire(&payload_for(5, Status::Running));
@@ -2388,20 +2316,9 @@ fn lone_slow_fire_processes_as_the_live_chain() {
     // A slow fire with no other fire in flight IS the live chain — its
     // 60s elapsed must not get it swallowed, or the idle heartbeat (and
     // the ledger-age repaint it exists for) would die.
-    let mut rt = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut rt = granted_runtime();
     let now = crate::clock::now_epoch_s();
-    rt.radar.ledger_mut().push(crate::ledger::LedgerEntry {
-        at_epoch_s: now,
-        outcome: crate::ledger::LedgerOutcome::Done,
-        tab_id: TabId::new(1),
-        tab_name: "work".into(),
-        label: "cargo test".into(),
-        pane_id: 5,
-    });
+    seed_done_ledger(&mut rt, now);
     rt.tabs_changed(vec![]); // arms Slow: the only fire in flight
     assert_eq!(rt.timer_chain.armed(), Some(Cadence::Slow));
 
@@ -2520,11 +2437,7 @@ fn read_presences_is_bound_to_fast_fires_only() {
     // 90s; a per-second directory scan per instance bought nothing). `timer`
     // tells Fast from Slow the same way `TimerChain::on_fire` tells live from
     // stale: by `elapsed_s` against `STALE_FIRE_ELAPSED_S`.
-    let mut rt = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut rt = granted_runtime();
 
     let scans: Vec<bool> = (0..(2 * PRESENCE_READ_TICK_INTERVAL))
         .map(|_| {
@@ -2543,11 +2456,7 @@ fn read_presences_is_bound_to_fast_fires_only() {
     // a stale leftover — see `lone_slow_fire_processes_as_the_live_chain`)
     // must not — even though a scan is overdue (no scan has EVER run, the
     // strongest form of "due" the last-scan gate knows).
-    let mut rt = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut rt = granted_runtime();
     let slow = rt.timer_slow(PermissionProbe::default());
     assert!(!slow.effects.contains(&Effect::ReadPresences), "a Slow fire must not scan peers, got {:?}", slow.effects);
 }
@@ -2628,11 +2537,7 @@ fn slow_heartbeat_survives_a_fast_decay_indefinitely() {
     // ORIGINAL stale Slow arm lands somewhere in the stream. Run it out
     // past 15 minutes of virtual time and assert every live Slow fire
     // still re-arms and still heartbeats.
-    let mut rt = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut rt = granted_runtime();
     let mut sim = FireSim::new();
 
     // name-known: arms Slow immediately (idle from birth so far).
@@ -2794,11 +2699,7 @@ fn sustained_fast_cadence_with_unchanged_content_still_heartbeats_presence() {
     // every peer dims this — the busiest — session as stale. Hold Fast for
     // 4 virtual minutes and assert a `PersistPresence` keeps landing well
     // inside every 90s window.
-    let mut rt = PluginRuntime {
-        permission: PermissionState::Resolved { granted: true },
-        config: config(),
-        ..Default::default()
-    };
+    let mut rt = granted_runtime();
     let mut sim = FireSim::new();
     let named = rt.session_name_changed(Some("work".into()));
     sim.schedule_from(&named.effects);

--- a/crates/plugin/src/tab_namer.rs
+++ b/crates/plugin/src/tab_namer.rs
@@ -497,6 +497,22 @@ mod tests {
     }
 
     #[test]
+    fn force_overrides_a_manual_name_that_stickiness_would_protect() {
+        // The manual name "manual" IS in the candidate space here (a second
+        // pane's repo), so `name_supported` holds — Managed keeps it, and Force
+        // must still re-pick to the top candidate "alpha". This pins the
+        // precedence between the two guards: earlier Force tests used a manual
+        // name outside the candidate space, where the re-pick is trivial.
+        let mut namer = TabNamer::default();
+        let panes = vec![repo_pane("alpha", true), repo_pane("manual", false)];
+        let tabs = vec![tab(1, "manual", panes)];
+        // Managed keeps the supported manual name.
+        assert!(namer.rename(&tabs, NamingMode::Managed).is_empty());
+        // Force re-picks to the focused pane's repo regardless of support.
+        assert_eq!(namer.rename(&tabs, NamingMode::Force), renamed_to("alpha"));
+    }
+
+    #[test]
     fn applied_name_is_sticky_while_any_pane_justifies_it() {
         let mut namer = TabNamer::default();
         // Focused `alpha` names the tab; `beta` also present.

--- a/plugins/zj-radar-claude/tests/parity.bats
+++ b/plugins/zj-radar-claude/tests/parity.bats
@@ -127,6 +127,28 @@ teardown() { teardown_fakes; }
   [ "$(jq -r '.msg' <<<"$BASH_PAYLOAD")" = "building" ]
 }
 
+# The `test` and `install` verbs were pinned only negatively (git-checkout-latest
+# isn't a test, npm-uninstall isn't install). Without a positive case the two
+# producers could diverge on the verb output with the whole suite green.
+@test "parity: test verb activity matches between producers" {
+  parity_case '{"hook_event_name":"PostToolUse","cwd":"/home/u/myrepo","tool_name":"Bash","tool_input":{"command":"cargo test --workspace"}}' running
+}
+
+@test "parity: install verb activity matches between producers" {
+  parity_case '{"hook_event_name":"PostToolUse","cwd":"/home/u/myrepo","tool_name":"Bash","tool_input":{"command":"pip install requests"}}' running
+}
+
+# The bash producer groups Edit|Write|MultiEdit and reads NotebookEdit's
+# `notebook_path` (not `file_path`); the Rust side tests all three. Pin the
+# two untested file-tool branches so the key path difference stays in sync.
+@test "parity: MultiEdit activity" {
+  parity_case '{"hook_event_name":"PostToolUse","cwd":"/home/u/myrepo","tool_name":"MultiEdit","tool_input":{"file_path":"/home/u/myrepo/src/auth.rs"}}' running
+}
+
+@test "parity: NotebookEdit activity" {
+  parity_case '{"hook_event_name":"PostToolUse","cwd":"/home/u/myrepo","tool_name":"NotebookEdit","tool_input":{"notebook_path":"/home/u/myrepo/nb.ipynb"}}' running
+}
+
 @test "parity: leading-newline Bash command still derives its first token" {
   # The first token comes from the WHOLE string (Rust split_whitespace().next());
   # a line-based read would see an empty first line and derive nothing.

--- a/scripts/tests/install.bats
+++ b/scripts/tests/install.bats
@@ -115,6 +115,18 @@ fake_uname() {
   [[ "$output" == *"skipping integrity check"* ]]
 }
 
+@test "verify_sha256: no sha256 tool on PATH downgrades to the TLS floor" {
+  # A readable, VALID sidecar so the read+parse passes and the code reaches the
+  # tool selection — then neither sha256sum nor shasum resolves (empty PATH), so
+  # it must warn and return 0 rather than block, TLS remaining the floor. This
+  # is the security-sensitive "install without an integrity check" branch.
+  echo "payload" > "$TMP/f"
+  printf '%s  f\n' "$(hash_of "$TMP/f")" > "$TMP/f.sha256"
+  run run_installer "PATH= verify_sha256 '$TMP/f' '$TMP/f.sha256'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no sha256 tool"* ]]
+}
+
 # ── main, end to end with stubbed downloads ──────────────────────────────────
 # Everything but the network is real: tar, checksum tooling, install/cp.
 


### PR DESCRIPTION
A pass over the test suite (four parallel reviewers across cli / plugin-state / render+e2e / core+bash) surfaced a cluster of coverage gaps on security and contract boundaries, plus mechanical fixture duplication. The suite is healthy overall; this closes the concrete gaps and tidies the repetition. No production code changes.

## Coverage (all fill gaps in existing correct code)

- **`cli_setup`: checksum-mismatch wasm download is refused, nothing installed.** The security boundary of the `download_verified_asset` generalization (Zellij loads the wasm with permissions) shipped without a test; a fake curl serves good bytes + a wrong digest, and the install is refused with `checksum mismatch` and no staged file.
- **`download`: `compute_sha256` round-trips the NIST `"abc"` vector** — the shell-out+parse composition the checksum guard depends on.
- **`update`: `is_newer` rejects 4-component and too-short version strings.**
- **`payload`: `sanitize` strips an OSC terminated by ST (`ESC \`)** — the third scanner exit the doc promised but nothing pinned.
- **`tab_namer`: Force re-picks over a manual name that IS in the candidate space** — pins force-vs-stickiness precedence (prior Force tests used a name outside the space, where the re-pick is trivial).
- **`parity.bats`: positive `test`/`install` verb cases + `MultiEdit`/`NotebookEdit`** — those branches were pinned only negatively.
- **`install.bats`: the no-sha256-tool-on-PATH TLS-floor branch** — the security-sensitive "install without integrity check" path.

## Simplification (no behavior change)

- `runtime/tests`: `granted_runtime()` replaces 21 inline granted-runtime struct literals; `seed_done_ledger()` collapses 6 identical 8-line `LedgerEntry` pushes that differed only in the timestamp.
- `agents`: six single-assert bash-verb tests → one table-driven test (matches the word-bounded sibling).
- `cli_update`: an `update_cmd(home, version, args)` helper removes the repeated isolated-env block.
- `command/tests`: drop `starship_on_idle_pane_leaves_no_trace`, fully subsumed by `ignore_set_covers_all_shells`.

## Deferred (recorded, not done here)

The reviewers also flagged ~8-10 vestigial/paired tests in `render/tests.rs` (the removed right-slot cluster, a couple of paired single-variant tests subsumed by the width proptests) and two inline "snapshot"-named tests that hand-roll expected strings instead of using insta. Left for a focused render-tests pass to keep this PR's snapshot review surface small.

## Test plan

- [x] `cargo test --workspace` green (cli, core, plugin lib 537, integration, e2e-host).
- [x] `cargo clippy --workspace --all-targets --all-features -D warnings` clean.
- [x] `bats plugins/zj-radar-claude/tests/parity.bats` (36) and `bats scripts/tests/install.bats` (17) green locally.
- [x] Confirmed the checksum-mismatch test fails for the right reason (refusal message is the checksum, not an incidental error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)