### PR TITLE
chore: bump to v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3332,7 +3332,7 @@ dependencies = [
 
 [[package]]
 name = "zj-radar"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "clap 4.6.1",
@@ -3347,7 +3347,7 @@ dependencies = [
 
 [[package]]
 name = "zj-radar-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proptest",
  "serde",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "zj-radar-plugin"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "insta",
  "portable-pty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/core", "crates/cli", "crates/plugin"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/marktoda/zj-radar"
@@ -22,7 +22,7 @@ rust-version = "1.95"
 # would let an older published CLI resolve a newer, incompatible core and stop
 # compiling. Bump this in lockstep with [workspace.package] version — the
 # release checklist (RELEASING.md) walks through it.
-zj-radar-core = { path = "crates/core", version = "=0.5.0" }
+zj-radar-core = { path = "crates/core", version = "=0.6.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 unicode-width = "0.2"

--- a/plugins/zj-radar-claude/.claude-plugin/plugin.json
+++ b/plugins/zj-radar-claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zj-radar-claude",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Broadcast Claude Code agent status to the zj-radar Zellij sidebar (working/waiting/done), with zero settings.json editing.",
   "author": { "name": "Mark Toda" },
   "homepage": "https://github.com/marktoda/zj-radar"


### PR DESCRIPTION
Release bump for v0.6.0. Version synced across the three places `RELEASING.md` requires: `[workspace.package]`, the exact `zj-radar-core` pin, and `plugin.json`.

## What's in 0.6.0 since v0.5.0

- **`zj-radar update`** (#35): move the CLI and the sidebar wasm to the latest release together; `--check` reports without writing. Hands Nix/cargo installs back to their manager; forward-only pins.
- **setup fix** (#35): re-running `setup zellij --download` now refreshes an already-installed wasm (the "config already up to date" arm previously skipped the copy) — the path `update` relies on.
- **docs** (#36): README/user-doc rewrite, new `docs/using.md`, ownership map.
- **E2E flake fix** (#37) and **test-suite hardening** (#38): coverage on the download checksum boundary, sanitize OSC-ST, version parsing, naming precedence; fixture de-duplication.

After this merges: publish core then cli to crates.io, then the signed `v0.6.0` tag (per `RELEASING.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)