### PR TITLE
fix(plugin): scan peer presences on Slow fires so idle rails reap dead sessions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -153,8 +153,9 @@ plugin pane, resolved to a stable `TabId`. The once-per-pane cwd bootstrap
 
 How one session's rail learns another's counts without asking Zellij. Each
 plugin writes `zj-radar.presence.<zellij_pid>.json` into the shared `/cache`
-root (`session_files.rs`); peers read the directory on Fast ticks and feed
-`Sessions` (`sessions.rs`), pure state that derives the badge on demand.
+root (`session_files.rs`); peers read the directory on every Slow tick and on
+decimated Fast ticks, and feed `Sessions` (`sessions.rs`), pure state that
+derives the badge on demand.
 Liveness is the file's mtime, graded fresh (≤ 90 s) → stale (dimmed, skipped
 by cycling) → dead (≥ 300 s, reaped and unlinked). Badge order and cycling
 order come from one `ordered()`. The `✕` glyph is the manual dismiss. Detail:

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -359,8 +359,10 @@ pub(crate) struct PluginRuntime {
     /// reads as "long overdue" the moment a name is known.
     last_presence_write_epoch_s: u64,
     /// The tick of the last peer-presence directory scan (`None` = never) —
-    /// the decimation gate in [`timer`](Self::timer) measures from here, so
-    /// the first Fast fire always scans.
+    /// the Fast decimation gate in [`timer`](Self::timer) measures from
+    /// here, so a fresh instance's first Fast fire always scans. Stamped by
+    /// Slow scans too, so a Fast fire landing right after one waits out the
+    /// interval rather than re-reading a roster graded seconds ago.
     last_presence_scan: Option<u64>,
     /// The `radar.generation()` the own-`Presence` in `last_presence` was
     /// derived at. Presence counts are a pure function of radar state, so an
@@ -503,9 +505,9 @@ impl PluginRuntime {
         // read per instance (N tabs × N sessions of wasi stat+read) bought
         // nothing — except mid-cycle (`wants_fast_cadence`), where the Alt+[/]
         // selection UI wants the freshest roster every tick. Measured from the
-        // LAST scan (`last_presence_scan`), not the absolute tick, so the very
-        // first Fast fire always seeds the badge — a fresh instance must not
-        // sit blank for up to a full interval on an arbitrary tick phase.
+        // LAST scan (`last_presence_scan`), not the absolute tick, so a fresh
+        // instance's very first Fast fire always seeds the badge — it must
+        // not sit blank for up to a full interval on an arbitrary tick phase.
         let scan_due = is_slow_fire
             || self.sessions.wants_fast_cadence()
             || self.last_presence_scan
@@ -530,8 +532,9 @@ impl PluginRuntime {
             || awaiting_permission
             || store_changed
             || self.timer_should_continue()
-            // A Slow fire exists precisely to repaint ledger ages — even
-            // when nothing else changed, `format_age` output may have moved.
+            // A Slow fire exists to repaint ledger ages — even when nothing
+            // else changed, `format_age` output may have moved — and, since
+            // the peer scan rides it, to re-grade the badge.
             // Keyed on the fire that actually landed, not `desired_cadence`:
             // the desire can have moved on (in either direction) between the
             // arm and the fire.
@@ -1109,10 +1112,11 @@ impl PluginRuntime {
             // known.
             || !self.own_session_name.is_empty()
         {
-            // Slow ticks exist to advance minute-granular ages: ledger rows'
-            // relative ages and pending rows' `· Nm` wait tags. Both freeze
-            // at 1h+ (saturation) — which, before the name is learned, is
-            // what lets the timer disarm fully.
+            // Slow ticks advance minute-granular ages (ledger rows' relative
+            // ages, pending rows' `· Nm` wait tags — both freeze at 1h+
+            // saturation, which, before the name is learned, is what lets the
+            // timer disarm fully) and carry the peer-presence scan, an idle
+            // rail's only way to grade a peer stale or dead.
             Some(Cadence::Slow)
         } else {
             None

--- a/crates/plugin/src/runtime.rs
+++ b/crates/plugin/src/runtime.rs
@@ -86,7 +86,8 @@ const STALE_FIRE_ELAPSED_S: f64 = 5.0;
 /// Fast (1 Hz) ticks between peer-presence directory scans — see the gate in
 /// [`PluginRuntime::timer`]. Peers heartbeat every 60s and dim as stale at
 /// 90s, so 5s scan latency is invisible on the badge; only an active Alt+[/]
-/// cycle (`Sessions::wants_fast_cadence`) reads every tick.
+/// cycle (`Sessions::wants_fast_cadence`) reads every tick. Slow (60s) fires
+/// scan unconditionally — they are already rarer than this interval.
 const PRESENCE_READ_TICK_INTERVAL: u64 = 5;
 
 /// Wall-clock seconds between own-presence liveness writes — the level
@@ -153,10 +154,11 @@ pub(crate) enum Effect {
     PersistPresence,
     /// Re-read every peer session's presence file and feed the result back
     /// through `presences_changed` — mirrors `ResolveCwd`'s
-    /// request/read-back pattern, except the read is gated on cadence
-    /// (Fast fires only — see `timer`) rather than on a fresh set of pane
-    /// ids: one directory scan per `PRESENCE_READ_TICK_INTERVAL` Fast ticks
-    /// (every tick mid-cycle), never on the Slow heartbeat.
+    /// request/read-back pattern, except the read is gated on cadence (see
+    /// `timer`) rather than on a fresh set of pane ids: every Slow (60s)
+    /// fire — an idle rail's only event source, and the only way it ever
+    /// notices a peer went stale or dead — plus one scan per
+    /// `PRESENCE_READ_TICK_INTERVAL` Fast ticks (every tick mid-cycle).
     ReadPresences,
     /// Commit a cross-session cycle selection: switch to `name` and, once
     /// there, jump straight to the tab that needs attention (if any).
@@ -486,25 +488,31 @@ impl PluginRuntime {
         // opened in that window would seed a rail missing the change — the same
         // cross-instance convergence pushed statuses get from `status_pipe`.
         let store_changed = self.radar.timer(self.tick, now);
-        // Cross-session peers: re-read the directory bound to Fast fires only
-        // — never on a Slow fire (which exists solely to repaint ledger ages
-        // and has no business paying for a peer scan). Within Fast, the scan
-        // is further decimated to one per `PRESENCE_READ_TICK_INTERVAL`
-        // ticks: peers heartbeat at 60s and dim at 90s, so a once-per-second
-        // directory read per instance (N tabs × N sessions of wasi stat+read)
-        // bought nothing — except mid-cycle (`wants_fast_cadence`), where the
-        // Alt+[/] selection UI wants the freshest roster every tick. Measured
-        // from the LAST scan (`last_presence_scan`), not the absolute tick,
-        // so the very first Fast fire always seeds the badge — a fresh
-        // instance must not sit blank for up to a full interval on an
-        // arbitrary tick phase.
-        if !is_slow_fire {
-            let scan_due = self.last_presence_scan
+        // Cross-session peers: re-read the directory on every Slow fire and
+        // on decimated Fast fires. The Slow fire is an idle rail's ONLY event
+        // source, and this scan is the only thing that ever re-grades a peer
+        // (`Sessions::update_presences` works off the age captured at read
+        // time) — so a rail that never scanned on Slow froze its badge at
+        // the last Fast-era read: killed peers stayed listed, never dimmed,
+        // never reaped, their files never unlinked, until something pinned
+        // the rail Fast again. One scan per minute is also the cheapest
+        // cadence on offer, so the "Slow exists solely to repaint ledger
+        // ages" economy argument never applied. Within Fast, the scan is
+        // decimated to one per `PRESENCE_READ_TICK_INTERVAL` ticks: peers
+        // heartbeat at 60s and dim at 90s, so a once-per-second directory
+        // read per instance (N tabs × N sessions of wasi stat+read) bought
+        // nothing — except mid-cycle (`wants_fast_cadence`), where the Alt+[/]
+        // selection UI wants the freshest roster every tick. Measured from the
+        // LAST scan (`last_presence_scan`), not the absolute tick, so the very
+        // first Fast fire always seeds the badge — a fresh instance must not
+        // sit blank for up to a full interval on an arbitrary tick phase.
+        let scan_due = is_slow_fire
+            || self.sessions.wants_fast_cadence()
+            || self.last_presence_scan
                 .is_none_or(|at| self.tick.saturating_sub(at) >= PRESENCE_READ_TICK_INTERVAL);
-            if self.sessions.wants_fast_cadence() || scan_due {
-                self.last_presence_scan = Some(self.tick);
-                effects.push(Effect::ReadPresences);
-            }
+        if scan_due {
+            self.last_presence_scan = Some(self.tick);
+            effects.push(Effect::ReadPresences);
         }
         // BEFORE re-arming below, commit an idle cycle selection if one is
         // pending. Committing here — not after `project` re-arms — matters:

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -2429,11 +2429,9 @@ fn heartbeat_coincident_with_a_genuine_presence_edge_persists_exactly_once() {
 }
 
 #[test]
-fn read_presences_is_bound_to_fast_fires_only() {
-    // Finding 2 pin, tightened by the decimation pass: `Effect::ReadPresences`
-    // rides Fast fires only — never the Slow (60s) heartbeat, which exists
-    // purely to repaint ledger ages — and within Fast only every
-    // `PRESENCE_READ_TICK_INTERVAL`th tick (peers heartbeat at 60s and dim at
+fn read_presences_rides_every_slow_fire_and_decimated_fast_fires() {
+    // Within Fast, `Effect::ReadPresences` is decimated to one per
+    // `PRESENCE_READ_TICK_INTERVAL` ticks (peers heartbeat at 60s and dim at
     // 90s; a per-second directory scan per instance bought nothing). `timer`
     // tells Fast from Slow the same way `TimerChain::on_fire` tells live from
     // stale: by `elapsed_s` against `STALE_FIRE_ELAPSED_S`.
@@ -2452,13 +2450,51 @@ fn read_presences_is_bound_to_fast_fires_only() {
         "Fast fires must scan peers once per interval, got {scans:?}"
     );
 
-    // A lone Slow fire (nothing else in flight, so it's the live chain, not
-    // a stale leftover — see `lone_slow_fire_processes_as_the_live_chain`)
-    // must not — even though a scan is overdue (no scan has EVER run, the
-    // strongest form of "due" the last-scan gate knows).
+    // Every Slow fire scans, unconditionally. An idle rail runs on nothing
+    // but Slow fires, and the scan is the only thing that ever grades a peer
+    // stale or dead — the field bug this pins: with the scan bound to Fast
+    // fires, an idle session's badge froze at its last Fast-era read, so
+    // killed peers stayed listed (never dimmed, never reaped, their files
+    // never unlinked) until something happened to pin the rail Fast again.
     let mut rt = granted_runtime();
+    for _ in 0..3 {
+        let slow = rt.timer_slow(PermissionProbe::default());
+        assert!(slow.effects.contains(&Effect::ReadPresences), "every Slow fire must scan peers, got {:?}", slow.effects);
+    }
+}
+
+#[test]
+fn idle_rail_reaps_a_dead_peer_from_its_slow_heartbeat_alone() {
+    // The field report end to end: a named, idle session (nothing Running,
+    // no ledger — `desired_cadence` settles on Slow) whose only peer was
+    // killed hard, so its file's mtime just ages. The idle rail's Slow fire
+    // must request the scan, and the scan's read-back must reap the corpse
+    // and ask for its file to be unlinked.
+    let json = r#"{"session_name":"alpha","running":0,"attention":1}"#;
+    let mut rt = runtime_with_granted_permission();
+    rt.tabs_changed(vec![tab(0, "team", false)]);
+    rt.presences_changed(vec![fresh(json)]);
+    assert!(rt.sessions.badge().iter().any(|b| b.name == "alpha"), "setup: peer shows while fresh");
+
     let slow = rt.timer_slow(PermissionProbe::default());
-    assert!(!slow.effects.contains(&Effect::ReadPresences), "a Slow fire must not scan peers, got {:?}", slow.effects);
+    assert!(
+        slow.effects.contains(&Effect::ReadPresences),
+        "an idle rail's Slow fire is its only chance to notice a dead peer, got {:?}",
+        slow.effects
+    );
+    assert!(
+        slow.effects.contains(&Effect::SetTimeout(Cadence::Slow)),
+        "a named idle rail must stay Slow-armed (the heartbeat contract), got {:?}",
+        slow.effects
+    );
+
+    let out = rt.presences_changed(vec![dead(json)]);
+    assert!(
+        out.effects.contains(&Effect::DismissPresence { name: "alpha".into() }),
+        "the read-back must reap the dead peer's file, got {:?}",
+        out.effects
+    );
+    assert!(!rt.sessions.badge().iter().any(|b| b.name == "alpha"), "the corpse must leave the badge");
 }
 
 // ── Fast-decay heartbeat survival (task-13 investigation) ───────────────

--- a/crates/plugin/src/runtime/tests.rs
+++ b/crates/plugin/src/runtime/tests.rs
@@ -2694,6 +2694,68 @@ fn assert_heartbeats_for(rt: &mut PluginRuntime, sim: &mut FireSim, minutes: u64
 }
 
 #[test]
+fn idle_slow_chain_keeps_scanning_peers_for_half_an_hour() {
+    // The read side's companion to `assert_heartbeats_for`'s write side, and
+    // the counterpart to `read_presences_rides_every_slow_fire_and_decimated_fast_fires`:
+    // that test hands `timer` one hand-made Slow `elapsed_s`, which proves
+    // the gate but not that the CHAIN keeps delivering. Here the fires come
+    // only from the runtime's own `SetTimeout` effects through `FireSim`, so
+    // a scan that stops arriving — a starved chain, a decay that loses the
+    // arm, a gate that only fires once — shows up as a gap or a starvation
+    // panic rather than passing unnoticed.
+    //
+    // The bound that matters is the gap, not the count: a corpse is graded
+    // dead off its mtime age, so as long as consecutive scans stay well
+    // inside `DEAD_AFTER_SECS` an idle rail cannot leave one listed past the
+    // horizon (which is the whole field bug).
+    let mut rt = granted_runtime();
+    let mut sim = FireSim::new();
+    let named = rt.session_name_changed(Some("work".into()));
+    sim.schedule_from(&named.effects);
+    drive_tabs_and_panes(&mut rt);
+    drain_to_settled_slow(&mut rt, &mut sim);
+    assert_eq!(rt.timer_chain.armed(), Some(Cadence::Slow), "setup: an idle named rail rides Slow");
+
+    let deadline_ms = sim.now_ms + 30 * 60_000;
+    let mut scans = 0u64;
+    let mut last_scan_ms = sim.now_ms;
+    let mut worst_gap_ms = 0u64;
+    while sim.now_ms < deadline_ms {
+        let Some(elapsed) = sim.pop() else {
+            panic!(
+                "TimerChain starved at virtual t={:.1}s (armed={:?}) — an idle rail with no \
+                 chain never scans again",
+                sim.now_ms as f64 / 1000.0,
+                rt.timer_chain.armed(),
+            );
+        };
+        let out = rt.timer(PermissionProbe::default(), elapsed, sim.now_epoch_s());
+        sim.schedule_from(&out.effects);
+        if out.effects.contains(&Effect::ReadPresences) {
+            scans += 1;
+            worst_gap_ms = worst_gap_ms.max(sim.now_ms - last_scan_ms);
+            last_scan_ms = sim.now_ms;
+        }
+    }
+
+    let horizon_ms = crate::sessions::DEAD_AFTER_SECS * 1000;
+    assert!(
+        worst_gap_ms < horizon_ms,
+        "worst gap between peer scans was {worst_gap_ms}ms, which must stay under the \
+         {horizon_ms}ms dead horizon or an idle rail can leave a corpse listed"
+    );
+    assert!(
+        scans >= 25,
+        "expected ~one scan per Slow fire over 30 virtual minutes, got {scans}"
+    );
+    assert_eq!(
+        rt.timer_chain.armed(),
+        Some(Cadence::Slow),
+        "the rail must ride out the run on Slow, still armed to scan again"
+    );
+}
+
+#[test]
 fn slow_heartbeat_survives_a_long_sustained_busy_period() {
     // Variant where the original stale Slow fire's 60s deadline actually
     // elapses WHILE Fast activity is still ongoing (not right at the

--- a/crates/plugin/tests/e2e/main.rs
+++ b/crates/plugin/tests/e2e/main.rs
@@ -1193,7 +1193,7 @@ fn rail_paints_every_column_of_its_pane() {
 /// separate processes, WITHOUT any session-manager trigger: B's plugin
 /// learns its own name from `Event::ModeUpdate` (push, automatic on load —
 /// no `get_session_list()` call needed) and persists presence to the shared
-/// `/cache` root; A's plugin reads that back directly off disk on a Fast
+/// `/cache` root; A's plugin reads that back directly off disk on a timer
 /// tick and renders a badge line for B; A's `session-next` (+ idle-commit
 /// ~1s later) really calls Zellij's `switch_session`, physically
 /// reattaching A's PTY client onto B.
@@ -1249,15 +1249,15 @@ fn session_next_switches_to_the_session_with_attention() {
     );
     b.pipe_status(&b_payload);
 
-    // `Effect::ReadPresences` (A reading the shared /cache root back) is
-    // gated to Fast timer fires only (runtime.rs `timer`), and A has nothing
-    // of its own yet to arm Fast — it would otherwise idle on the 60s Slow
-    // heartbeat and this test would need up to a minute of real wall time to
-    // stay honest. Piping a `running` status into A's OWN terminal arms A's
-    // Fast cadence indefinitely (an active `Running` row animates every
-    // tick — see `timer_should_continue`/`needs_fast_ticks`) without giving A
-    // any attention of its own, so it doesn't interfere with the ordering
-    // assertion below (B is still the only attention>0 peer).
+    // `Effect::ReadPresences` (A reading the shared /cache root back) rides
+    // every Slow (60s) fire and decimated Fast fires (runtime.rs `timer`),
+    // and A has nothing of its own yet to arm Fast — it would otherwise idle
+    // on the Slow heartbeat and this test would need up to a minute of real
+    // wall time to stay honest. Piping a `running` status into A's OWN
+    // terminal arms A's Fast cadence indefinitely (an active `Running` row
+    // animates every tick — see `timer_should_continue`/`needs_fast_ticks`)
+    // without giving A any attention of its own, so it doesn't interfere with
+    // the ordering assertion below (B is still the only attention>0 peer).
     let pane_a = a.discover_terminal_pane_id();
     eprintln!("[e2e] A terminal pane_id={pane_a}");
     let a_payload = format!(
@@ -1324,4 +1324,159 @@ fn session_next_switches_to_the_session_with_attention() {
          showed B's marker {marker:?} (session-next tapped, ~1 Fast tick should commit it)"
     );
     eprintln!("[e2e] PASS: session-next committed and A's client switched onto B");
+}
+
+/// Recursively find the peer-presence file under `root` whose JSON names
+/// `session_name`. The plugin writes it into Zellij's plugin `/cache` mount,
+/// whose host path is an implementation detail of Zellij (keyed by the plugin
+/// URL, and differently rooted on macOS vs Linux), so the test discovers it by
+/// walking the harness's private HOME rather than reconstructing that path.
+fn find_presence_file(root: &std::path::Path, session_name: &str) -> Option<std::path::PathBuf> {
+    let entries = std::fs::read_dir(root).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if let Some(hit) = find_presence_file(&path, session_name) {
+                return Some(hit);
+            }
+            continue;
+        }
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !name.starts_with("zj-radar.presence.") || !name.ends_with(".json") {
+            continue;
+        }
+        let json = std::fs::read_to_string(&path).unwrap_or_default();
+        if json.contains(&format!(r#""session_name":"{session_name}""#)) {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Liveness grading is mtime arithmetic performed INSIDE the wasm sandbox:
+/// `session_files::read_peer_presences` asks WASI for each peer file's
+/// `modified()` and subtracts it from the plugin's own `SystemTime::now()`.
+/// Every other test of that ladder is host-side — the unit tests inject
+/// `age_secs` directly, and the cross-session test above only ever asserts
+/// that a FRESH peer appears. That leaves the whole fresh→stale→dead ladder
+/// resting on an assumption no test checks: that `modified()` works at all
+/// through Zellij's `/cache` mount. It has one degenerate failure mode that
+/// would look exactly like working code — `age_of`'s `unwrap_or(0)` treats a
+/// metadata or clock failure as "age 0", i.e. eternally fresh — under which
+/// no peer is ever graded stale, nothing is ever reaped, and no amount of
+/// scanning helps.
+///
+/// So: give A a live peer B, kill B, backdate B's presence file past the reap
+/// horizon, and require A to both drop the badge line AND unlink the file.
+/// That is the full production path — WASI `modified()` → `Sessions`' dead
+/// grading → `Effect::DismissPresence` → `remove_presences_matching` — and
+/// nothing short of it proves the ladder runs outside the host tests.
+///
+/// A is pinned Fast (a `running` row of its own) purely for wall-clock
+/// budget: the scan rides every Slow fire too, but waiting one out would add
+/// a minute of real time to the suite. Which cadences carry the scan is
+/// pinned host-side
+/// (`read_presences_rides_every_slow_fire_and_decimated_fast_fires`); what
+/// only Zellij can prove is the mtime arithmetic, and that is
+/// cadence-independent.
+#[test]
+#[ignore = "e2e: requires zellij + built wasm; run via `just test-e2e`"]
+fn dead_peer_presence_file_is_reaped_through_the_real_cache_mount() {
+    use std::time::Duration;
+
+    let wasm = plugin_wasm_path();
+    assert!(
+        wasm.exists(),
+        "Plugin wasm not found at {wasm:?}. Build it:\n  cargo build --release --target wasm32-wasip1 -p zj-radar-plugin"
+    );
+
+    let temp_home = pre_grant_permissions(&wasm);
+    let pid = std::process::id();
+    let layout = sidebar_layout(&wasm);
+
+    let a = ZellijSession::start(&format!("zjr_reap_a_{pid}"), &layout, &wasm, temp_home);
+    let b = a.start_sibling(&format!("zjr_reap_b_{pid}"), &layout);
+    eprintln!("[e2e] A ({}) + sibling B ({}) loaded", a.name, b.name);
+
+    // B publishes a presence file, and A must see it — the same crossing the
+    // test above asserts, here only as the setup that makes the
+    // disappearance below meaningful.
+    let pane_b = b.discover_terminal_pane_id();
+    b.pipe_status(&format!(
+        r#"{{"v":1,"source":"claude","pane":{{"type":"terminal","id":{pane_b}}},"status":"pending","repo":"reap-b-repo","msg":"pick one"}}"#
+    ));
+
+    // A's own `running` row keeps A's cadence Fast, so A rescans the shared
+    // root every `PRESENCE_READ_TICK_INTERVAL` ticks (~5s) instead of once a
+    // minute.
+    let pane_a = a.discover_terminal_pane_id();
+    a.pipe_status(&format!(
+        r#"{{"v":1,"source":"claude","pane":{{"type":"terminal","id":{pane_a}}},"status":"running","repo":"reap-a-repo","msg":"keep-fast"}}"#
+    ));
+
+    let b_name = b.name.clone();
+    let saw_peer = a.wait_until(Duration::from_secs(10), |s| {
+        sidebar_region(&s.screen(), 32).contains(&b_name)
+    });
+    eprintln!("[e2e] A's rail with B alive:\n{}", sidebar_region(&a.screen(), 32));
+    assert!(
+        saw_peer,
+        "setup failed: A's badge never showed peer {b_name:?}, so this test could not go on to \
+         observe its removal. That is the cross-session presence path itself failing — see \
+         `session_next_switches_to_the_session_with_attention` for its diagnosis."
+    );
+
+    let presence = find_presence_file(a.temp_home(), &b_name).unwrap_or_else(|| {
+        panic!(
+            "no presence file naming {b_name:?} found under {:?}, yet A's badge rendered it — \
+             the badge can only come from such a file, so either the search missed it or \
+             Zellij mounted /cache somewhere outside the private HOME.",
+            a.temp_home()
+        )
+    });
+    eprintln!("[e2e] B's presence file: {presence:?}");
+
+    // Kill B so nothing rewrites the file back to fresh. The plugin has no
+    // exit hook (a killed server's file is exactly the corpse the reap exists
+    // for), so the file must outlive the session — assert that, rather than
+    // assume it, or the reap assertion below could pass on a file Zellij
+    // itself deleted.
+    drop(b);
+    assert!(
+        presence.exists(),
+        "B's presence file vanished when B's session was killed ({presence:?}). Then this test \
+         cannot distinguish a reap from Zellij's own cache teardown — and the corpse the reap \
+         is designed for would never exist in the field either."
+    );
+
+    // Backdate past `sessions::DEAD_AFTER_SECS` (300s — a private const, so
+    // spelled out here) with slack for scan latency. This is the one fact
+    // only the real stack can check: the plugin must read this mtime through
+    // WASI and compute a large age from it.
+    let dead_age = Duration::from_secs(300 + 120);
+    let backdated = std::time::SystemTime::now() - dead_age;
+    std::fs::File::options()
+        .write(true)
+        .open(&presence)
+        .expect("failed to open B's presence file to backdate it")
+        .set_times(std::fs::FileTimes::new().set_modified(backdated))
+        .expect("failed to backdate B's presence file mtime");
+
+    let reaped = a.wait_until(Duration::from_secs(20), |s| {
+        !sidebar_region(&s.screen(), 32).contains(&b_name) && !presence.exists()
+    });
+    eprintln!("[e2e] A's rail after backdating B:\n{}", sidebar_region(&a.screen(), 32));
+    assert!(
+        reaped,
+        "A never reaped dead peer {b_name:?} (badge still shows it: {}; file still on disk: \
+         {}). The plugin read this file's mtime through WASI and must have computed an age \
+         past `DEAD_AFTER_SECS`; if the badge line persists, either the age came back ~0 \
+         (`age_of`'s `unwrap_or(0)` swallowing a metadata/clock failure under the /cache \
+         mount, which would disable the whole staleness ladder in production) or the scan \
+         never ran. See the printed rail above.",
+        sidebar_region(&a.screen(), 32).contains(&b_name),
+        presence.exists()
+    );
+    eprintln!("[e2e] PASS: dead peer reaped from the badge and unlinked from the shared /cache");
 }

--- a/docs/design.md
+++ b/docs/design.md
@@ -481,11 +481,10 @@ rows, header badge, and footer stay tab-level summaries.
 **Liveness is the mtime, graded fresh → stale → dead.** A live session
 rewrites its file at least every 60 s (`PRESENCE_HEARTBEAT_S`, a level trigger
 in `project` that bypasses the content gate). Peers read the directory on every
-Slow (60 s) tick, and on every fifth Fast tick except mid-cycle. The Slow read
-is what lets an idle rail notice a peer's death at all; without it the badge
-froze at its last Fast-era read and killed sessions stayed listed until the
-rail went Fast again. `Sessions::update_presences`
-grades each file's age: fresh (≤ 90 s), stale (90–300 s: dimmed, unreachable
+Slow (60 s) tick, and on every fifth Fast tick except mid-cycle; the Slow read
+is what lets an idle rail grade a peer at all, since ages are captured at read
+time. `Sessions::update_presences` grades each file's age: fresh (≤ 90 s),
+stale (90–300 s: dimmed, unreachable
 by cycling since switching onto a dead session would have Zellij resurrect it
 as an empty zombie), dead (≥ 300 s, five missed heartbeats: reaped and the
 file unlinked via `Effect::DismissPresence`). Dimming stays twitchy because it

--- a/docs/design.md
+++ b/docs/design.md
@@ -480,8 +480,11 @@ rows, header badge, and footer stay tab-level summaries.
 
 **Liveness is the mtime, graded fresh → stale → dead.** A live session
 rewrites its file at least every 60 s (`PRESENCE_HEARTBEAT_S`, a level trigger
-in `project` that bypasses the content gate). Peers read the directory only on
-Fast ticks, every fifth tick except mid-cycle. `Sessions::update_presences`
+in `project` that bypasses the content gate). Peers read the directory on every
+Slow (60 s) tick, and on every fifth Fast tick except mid-cycle. The Slow read
+is what lets an idle rail notice a peer's death at all; without it the badge
+froze at its last Fast-era read and killed sessions stayed listed until the
+rail went Fast again. `Sessions::update_presences`
 grades each file's age: fresh (≤ 90 s), stale (90–300 s: dimmed, unreachable
 by cycling since switching onto a dead session would have Zellij resurrect it
 as an empty zombie), dead (≥ 300 s, five missed heartbeats: reaped and the

--- a/docs/smart-tabs-postmortem.md
+++ b/docs/smart-tabs-postmortem.md
@@ -107,11 +107,15 @@ crystallizes *why* — these are constraints to preserve, not just happy acciden
     manifest delta, not a dirty tick) and #3 (cap concurrent in-flight calls). Decision logic
     lives in the pure `RadarState::cwd_bootstrap_targets`; the blocking call itself is isolated
     to `lib.rs::resolve_cwd` (wasm glue). Do not widen this to per-output or uncapped use.
-- **The one-shot timer must stay event-gated.** zj-radar re-arms its timer only while there is
-  *animating* work (a `Running` glyph that spins) or an un-carried completion edge still to
-  settle — a backgrounded `done`/`error`/`pending` row does not keep it awake
-  (`PluginRuntime::timer_should_continue`). Even while armed, a tick does no work proportional to
-  pane count. Keep it that way; never let a timer tick fan out into N host calls.
+- **The one-shot timer must stay event-gated, and its cadence must match the reason.** zj-radar
+  arms the 1 Hz *Fast* cadence only while there is *animating* work (a `Running` glyph that
+  spins) or an un-carried completion edge still to settle — a backgrounded
+  `done`/`error`/`pending` row does not keep it awake (`PluginRuntime::timer_should_continue`).
+  A named session otherwise decays to the 60 s *Slow* cadence, which exists to keep this
+  session's own presence file's mtime fresh, repaint minute-granular ages, and re-read the peer
+  presence directory. Even while armed, a tick does no work proportional to pane count: the peer
+  read is bounded by live session count and, on Fast, decimated. Keep it that way; never let a
+  timer tick fan out into N host calls.
 - **Output volume is irrelevant to us.** Because we key off discrete hook events
   (UserPromptSubmit / Pre/PostToolUse / Notification / Stop), a pane spewing megabytes of
   output costs us nothing. That is the exact dimension that melted smart-tabs.


### PR DESCRIPTION
## Bug

Field report from a NUC: radar's cross-session badge listed eight sessions, the session manager listed two. The other six were dead Zellij servers whose `zj-radar.presence.<pid>.json` files were never unlinked. The report concluded "there is no stale/TTL/reap logic". That's not quite right, and the real cause is narrower.

## Root cause

The reap ladder exists (`sessions.rs`: fresh ≤90s → stale/dimmed → dead >300s → `Effect::DismissPresence` unlinks the file). But it only runs when the directory is **re-read**, and `Effect::ReadPresences` was emitted on **Fast (1 Hz) timer fires only**, never on the Slow (60s) heartbeat (`runtime.rs` `timer`, pinned by `read_presences_is_bound_to_fast_fires_only`).

A rail with nothing Running settles on Slow. `Sessions::update_presences` grades staleness off the age captured at read time, so an idle session's badge froze at its last Fast-era read: killed peers stayed listed — never dimmed, never reaped, files never unlinked — until something happened to pin that rail Fast again. On a mostly-idle box (a NUC you ssh into) that's effectively forever. The 6h debris sweep only runs at plugin load, so it didn't help a long-lived session either.

## Fix

Scan on every Slow fire, unconditionally. The Fast-side decimation (one scan per `PRESENCE_READ_TICK_INTERVAL` ticks, every tick mid-cycle) is unchanged. The original "Slow exists solely to repaint ledger ages" economy argument never applied: once a minute is already cheaper than the Fast decimation.

```rust
let scan_due = is_slow_fire
    || self.sessions.wants_fast_cadence()
    || self.last_presence_scan
        .is_none_or(|at| self.tick.saturating_sub(at) >= PRESENCE_READ_TICK_INTERVAL);
```

Side benefit: an idle-from-birth rail now seeds its badge at its first Slow fire (60s) instead of staying blank until something goes Fast.

## Tests

- `read_presences_rides_every_slow_fire_and_decimated_fast_fires` inverts the old pin: every Slow fire scans; Fast decimation preserved.
- `idle_rail_reaps_a_dead_peer_from_its_slow_heartbeat_alone`: the field report end to end — named idle rail → Slow fire emits `ReadPresences` and stays Slow-armed → dead read-back emits `DismissPresence` and drops the badge line.

`just test`, clippy `-D warnings`, wasm build, and `just test-e2e` all green locally.

## Not in scope

- `kill -0` on the pid in the filename (suggested in the report) isn't possible from the wasm sandbox; mtime-TTL is the right mechanism, it just wasn't running.
- The orphaned Zellij 0.43.1 servers in the report are a Zellij version-mismatch artifact, not a zj-radar issue.


---

## Fresh-eyes review round (second commit)

Two independent reviewers with no session context: one general code review, one adversarial attempt to falsify the diagnosis. Both confirmed it independently, and both verified the new tests fail on the base commit. Neither found a logic defect. What they did find is addressed in `07ccd9f`.

**The substantive gap: nothing proved mtime grading works inside the wasm sandbox.** `read_peer_presences` asks WASI for each peer file's `modified()` and subtracts it from the plugin's own clock. Every existing test of that ladder is host-side — the unit tests inject `age_secs` directly, and the cross-session E2E only asserts that a *fresh* peer appears. So the whole fresh/stale/dead ladder rested on an unchecked assumption, with a silent failure mode: `age_of`'s `unwrap_or(0)` treats a metadata or clock error as age 0, i.e. eternally fresh, under which nothing is ever reaped and no cadence change helps. `dead_peer_presence_file_is_reaped_through_the_real_cache_mount` kills a peer, backdates its presence file past the reap horizon, and requires the badge line to vanish **and** the file to be unlinked. It passes, which also rules that hypothesis out as an explanation of the field report.

**Slow-chain delivery is now pinned through the real arm/fire chain.** `idle_slow_chain_keeps_scanning_peers_for_half_an_hour` drives 30 virtual minutes of idle time through FireSim, where fires come only from the runtime's own `SetTimeout` effects, and bounds the worst gap between consecutive scans under `DEAD_AFTER_SECS`. The earlier test proved the gate; this one proves the chain keeps delivering.

**Doc drift.** `CONTEXT.md`, the cross-session E2E's rationale comment, and two `runtime.rs` comments still described the Fast-only gate or argued that Slow exists solely to repaint ledger ages. The postmortem's timer rule predated the Slow heartbeat entirely, which matters because it is the text a future reader would use to judge whether a once-a-minute directory read counts as forbidden polling; it now states both cadences and why this read is bounded by session count.

**One behavior note.** `last_presence_scan` is now stamped by Slow scans too, so a Fast fire landing right after one waits out the decimation interval instead of scanning immediately. The roster is under 60s old against a 90s stale threshold, and the cycling UI bypasses the gate, so the only effect is up to 5s of latency on a freshly-Fast badge. The doc comment is scoped accordingly.

**Known follow-up, out of scope:** a tab opened in an already-idle session now waits up to 60s for its first badge, where before it waited forever. Emitting one `ReadPresences` when the session name is learned would close it, in the same once-per-instance shape as the cwd bootstrap.

Re-verified after the review round: `just test` (539 plugin tests), clippy `-D warnings`, wasm build, `just test-e2e` 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
